### PR TITLE
Implement Vagrant (virtualbox+puppet) workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ test/reports
 test/mocha/sandbox.spec.js
 
 .idea
+
+.vagrant

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ are wonderful gifts to humanity, IT IS OK TO MAKE MISTAKES. Please let no
 Things may change dramatically, be prepared.
 
 
+dev setup - vagrant (virtualbox)
+=================
+
+Port 8000 is forwarded directly to the host (8000:8000). This directory is synced to /vagrant/ on the guest.
+
+1. `vagrant up`
+1. `vagrant ssh`
+1. `cd /vagrant && grunt server`
+
 
 dev setup - linux
 =================

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,50 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "precise64-bumblbee"
+
+  # The url from where the 'config.vm.box' box will be fetched if it
+  # doesn't already exist on the user's system.
+   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 2048
+    v.cpus = 2
+  end
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+      config.vm.network :forwarded_port, guest: 8000, host: 8000
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network :private_network, ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network :public_network
+
+  # If true, then any SSH connections made will enable agent forwarding.
+  # Default value: false
+  # config.ssh.forward_agent = true
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+    config.vm.synced_folder ".", "/vagrant/"
+
+  config.vm.provision :puppet do |puppet|
+    puppet.manifests_path = "manifests"
+    puppet.manifest_file  = "site.pp"
+  end
+end

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -1,0 +1,59 @@
+#Set global path for exec calls
+Exec { path => [ "/bin/", "/sbin/" , "/usr/bin/", "/usr/sbin/", "/usr/local/bin" ] }
+
+class initial_apt_update {
+  exec {
+    'add_node_repo':
+      command   => 'add-apt-repository ppa:chris-lea/node.js && touch /etc/.chris-lea-added-by-puppet',
+      creates   => '/etc/.chris-lea-added-by-puppet',
+      require   => Exec['apt-update1'],
+  }
+
+
+  exec{
+    'apt-update2':
+      command   => 'apt-get update && touch /etc/apt-updated-by-puppet2',
+      creates   => '/etc/.apt-updated-by-puppet2',
+      require   => Exec['add_node_repo'],
+  }
+
+  exec{
+    'apt-update1':
+      command   => 'apt-get update && apt-get install -y python-software-properties software-properties-common && touch /etc/apt-updated-by-puppet1',
+      creates   => '/etc/.apt-updated-by-puppet1',
+  }
+}
+
+include initial_apt_update
+package {
+  ['nodejs',git]:
+    ensure => installed,
+    require => Class['initial_apt_update'];
+}
+
+exec {
+  'npm_install_grunt':
+    command => 'npm install -g grunt-cli',
+    require => Package['nodejs'];
+}
+
+exec {
+  'npm_install':
+    command => 'npm install',
+    cwd     => '/vagrant/',
+    require => [Exec['npm_install_grunt'],Package['git']];
+}
+
+exec {
+  'grunt_cli':
+    command => 'grunt setup',
+    cwd     => '/vagrant/',
+    require => Exec['npm_install_grunt'];
+}
+
+#exec {
+#  'run_naive_webserver':
+#    command => 'grunt server &',
+#    cwd     => '/vagrant/',
+#    require => Exec['grunt_cli'],
+#}


### PR DESCRIPTION
Nothing fancy; spins up precise64 VM using vagrant (virtualbox) and provisions with puppet. Starting devel server is still up to the end user.
