### PR TITLE
Added libraries required for Phantomjs

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -26,7 +26,7 @@ class initial_apt_update {
 
 include initial_apt_update
 package {
-  ['nodejs',git]:
+  ['nodejs',git,'libfontconfig', 'libfontconfig-dev', 'libfreetype6-dev']:
     ensure => installed,
     require => Class['initial_apt_update'];
 }


### PR DESCRIPTION
Phantomjs requires the library "libfontconfig.so.1" when you run 'grunt test:web'. Added the libraries required to the manifest/site.pp file, otherwise none of the tests work.
