### PR TITLE
standardizing page managers

### DIFF
--- a/src/js/page_managers/abstract_nav_view_mixin.js
+++ b/src/js/page_managers/abstract_nav_view_mixin.js
@@ -28,7 +28,6 @@ define([
 
     model : AbstractNavModel,
 
-
     setActive: function(subPage){
 
       this.each(function(m){

--- a/src/js/page_managers/landing_page_controller.js
+++ b/src/js/page_managers/landing_page_controller.js
@@ -1,59 +1,59 @@
-define(["marionette", "hbs!./templates/landing-page-layout",
-    "js/widgets/base/base_widget"
+define(["marionette",
+    "hbs!./templates/landing-page-layout",
+    "js/widgets/base/base_widget",
+    'js/page_managers/page_manager_mixin'
   ],
-  function (Marionette, fullLengthLayout, BaseWidget) {
+  function (Marionette,
+    fullLengthLayout,
+    BaseWidget,
+    PageManagerMixin) {
 
-    var history;
 
-    var API = {
+    var LandingPageView = Marionette.ItemView.extend({
 
-      insertTemplate: function () {
-        $("#body-template-container").empty()
-          .append(fullLengthLayout())
+      template : fullLengthLayout,
 
-      },
+      className : "s-landing-page-layout",
 
-      displayLandingPage: function () {
-        this.insertTemplate();
+      id : "landing-page-layout",
 
-        $(".search-bar-rows-container").append(this.widgetDict.searchBar.render().el);
+      onShow : function(){
+
+        var searchBar = Marionette.getOption(this, "widgetDict").searchBar
+
+        $(".search-bar-rows-container")
+          .append(searchBar.render().el);
 
       }
+      
+    });
 
-    };
 
     var LandingPageController = BaseWidget.extend({
-
 
       initialize: function (options) {
 
         options = options || {};
 
         this.widgetDict = options.widgetDict;
-        _.extend(this, API);
 
-
-        history = options.history;
-
+        this.controllerView = new LandingPageView({widgetDict : this.widgetDict});
 
       },
 
+      //don't need to activate this widget
       activate: function (beehive) {
 
-
-
       },
 
-      showPage: function (options) {
-
-        if (!options.inDom){
-          this.displayLandingPage()
-        }
+      //error unless this is overridden
+      processResponse : function(){
 
       }
 
     });
 
+    _.extend(LandingPageController.prototype, PageManagerMixin);
 
     return LandingPageController
 

--- a/src/js/page_managers/master_page_manager.js
+++ b/src/js/page_managers/master_page_manager.js
@@ -41,6 +41,7 @@ define([
 
         if (c.controllerView && c.controllerView.render){
           c.controllerView.render();
+
         }
       });
 
@@ -65,10 +66,11 @@ define([
 
       options.inDom = (this.currentPage === pageName) ? true : false;
 
-      if (!options.inDom){
+//      if (!options.inDom){
         //scroll up automatically
         window.scrollTo(0,0);
-      }
+//      }
+
         this.currentPage = pageName;
 
         this.pageControllers[pageName].showPage(options);

--- a/src/js/page_managers/page_manager_mixin.js
+++ b/src/js/page_managers/page_manager_mixin.js
@@ -1,0 +1,49 @@
+define([
+  "jquery"
+], function(
+  $
+  ){
+
+
+  /*
+  * all general functionality for the page managers
+  * */
+
+
+  var m = {}
+
+  m.insertControllerView  = function(){
+
+    var $b = $("#body-template-container");
+
+    var $former =  $b.children();
+
+    $former.detach();
+
+    $b.append(this.controllerView.el);
+
+    this.triggerMethod("show");
+
+    this.controllerView.triggerMethod("show");
+
+  };
+
+  /*
+  * the most basic showPage function called by master page manager;
+  * this can be overridden if necessary
+  * */
+
+  m.showPage = function (options) {
+
+    var inDom = options.inDom;
+
+    if (!inDom){
+      this.insertControllerView();
+    }
+
+  }
+
+  return m
+
+
+})

--- a/src/js/page_managers/results_page_controller.js
+++ b/src/js/page_managers/results_page_controller.js
@@ -16,13 +16,17 @@ define([
     "hbs!./templates/results-page-layout",
     'js/widgets/base/base_widget',
     'js/widgets/loading/widget',
-    'hbs!./templates/results-control-row'],
+    'hbs!./templates/results-control-row',
+    'js/page_managers/page_manager_mixin'
+  ],
   function (
     Marionette,
     threeColumnTemplate,
     BaseWidget,
     LoadingWidget,
-    resultsControlRowTemplate) {
+    resultsControlRowTemplate,
+    PageManagerMixin
+    ) {
 
 
 
@@ -34,6 +38,10 @@ define([
         this.widgetDict = options.widgetDict;
 
       },
+
+      className : "s-results-page-layout",
+
+      id : "results-page-layout",
 
       template : threeColumnTemplate,
 
@@ -221,34 +229,12 @@ define([
         this.controllerView = new ResultsControllerView({widgetDict : this.widgetDict, debug : beehive.getDebug()});
 
 
-      },
-
-      insertResultsControllerView : function(){
-
-          var $b = $("#body-template-container");
-
-          $b.children().detach();
-
-          //don't call render each time or else we
-          //would have to re-delegate widget events
-
-          $b.append(this.controllerView.el);
-
-          this.controllerView.triggerMethod("show");
-
-      },
-
-      showPage: function (options) {
-
-        var inDom = options.inDom;
-
-        if (!inDom){
-          this.insertResultsControllerView();
-        }
-
       }
 
+
     });
+
+    _.extend(ResultsController.prototype, PageManagerMixin)
 
     return ResultsController
 

--- a/src/js/page_managers/templates/abstract-page-layout.html
+++ b/src/js/page_managers/templates/abstract-page-layout.html
@@ -1,4 +1,3 @@
-<div id="abstract-page-layout" class="s-abstract-page-layout">
 
 <div class="row s-stable-search-bar-height">
     <div class="s-search-bar-full-width-container">
@@ -25,4 +24,3 @@
             </div>
         </div>
     </div>
-</div>

--- a/src/js/page_managers/templates/landing-page-layout.html
+++ b/src/js/page_managers/templates/landing-page-layout.html
@@ -1,5 +1,4 @@
 
-    <div id="landing-page-layout" class="s-landing-page-layout">
 
     <div class="s-greeting-row">
             <div class="col-sm-12">
@@ -86,5 +85,3 @@
 
 
         </div>
-
-    </div>

--- a/src/js/page_managers/templates/results-page-layout.html
+++ b/src/js/page_managers/templates/results-page-layout.html
@@ -1,4 +1,3 @@
-<div id="results-page-layout" class="s-results-page-layout">
     <div class="row s-stable-search-bar-height">
         <div class="s-search-bar-full-width-container">
             <div class="col-sm-7 col-sm-offset-2 s-search-bar-row" id="search-bar-row"></div>
@@ -23,4 +22,3 @@
             </div>
         </div>
     </div>
-</div>


### PR DESCRIPTION
I wanted to add a fade transition in between pages, but I realized that it gave the impression that performance was slightly slower. So there is no transition added here; I just extracted the common functionality into the page_manager_mixin and brought the landing page controller in line with the other two.
