### PR TITLE
Jshint watch

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -170,26 +170,7 @@ module.exports = function(grunt) {
         interrupt: true,// necessary for windows
       },
 
-      server: {
-        files: ['./Gruntfile', './src/**/*.js', './src/**/*.html', './server.js', './src/**/*.css'],
-        tasks: ['server']
-      },
-//
-//      local_testing: {
-//        files: ['./Gruntfile', './src/js/**/*.js', './test/mocha/**/*.js', './src/*.js', './src/*.html'],
-//        tasks: ['mocha_phantomjs:local_testing', 'watch:local_testing']
-//      },
-//
-//      web_testing: {
-//        files: ['./Gruntfile', './src/js/**/*.js', './test/mocha/**/*.js', './src/*.js', './src/*.html'],
-//        tasks: ['express:dev', 'mocha_phantomjs:web_testing', 'watch:web_testing']
-//      },
-//
-//      sandbox_testing: {
-//        files: ['./Gruntfile', './src/js/**/*.js', './test/mocha/**/*.js', './src/*.js', './src/*.html'],
-//        tasks: ['express:dev', 'mocha_phantomjs:sandbox_testing', 'watch:sandbox_testing']
-//      },
-//
+
       styles: {
         files: ['./src/**/*.less'], // which files to watch
         tasks: ['less'], //should trigger server restart
@@ -201,7 +182,28 @@ module.exports = function(grunt) {
       scripts: {
         files: ['./src/js/**/*.js'],
         tasks: ['jshint:new']
+      },
+
+      server: {
+        files: ['./Gruntfile', './src/js/**/*.js', './src/*.js', './src/*.html', './server.js', './src/styles/css/*.css'],
+        tasks: ['env:dev', 'express:dev']
+      },
+
+      local_testing: {
+        files: ['./Gruntfile', './src/js/**/*.js', './test/mocha/**/*.js', './src/*.js', './src/*.html'],
+        tasks: ['mocha_phantomjs:local_testing', 'watch:local_testing']
+      },
+
+      web_testing: {
+        files: ['./Gruntfile', './src/js/**/*.js', './test/mocha/**/*.js', './src/*.js', './src/*.html'],
+        tasks: ['express:dev', 'mocha_phantomjs:web_testing', 'watch:web_testing']
+      },
+
+      sandbox_testing: {
+        files: ['./Gruntfile', './src/js/**/*.js', './test/mocha/**/*.js', './src/*.js', './src/*.html'],
+        tasks: ['express:dev', 'mocha_phantomjs:sandbox_testing', 'watch:sandbox_testing']
       }
+
     },
 
     //**


### PR DESCRIPTION
Hi Roman,
I thought it would help me to format my code correctly if we could have a grunt watch task that linted the code while you work on it, but it was overwhelming to see all issues with all files. So now if you do grunt:watch it will show you what is wrong with the current file every time you save it. I had to comment out the testing watch tasks, which were raising an error that said "too many open files".

 I also made it so that saving less will automatically compile the css and load the page again in the browser. It requires the [livereload browser plugin](https://chrome.google.com/webstore/detail/livereload/jnihajbhpnppcggbcgedagnkighmdlei?hl=en).
