### PR TITLE
added json response option if data doesnt have a response header

### DIFF
--- a/src/js/components/query_mediator.js
+++ b/src/js/components/query_mediator.js
@@ -14,7 +14,8 @@ define(['underscore',
     'js/components/api_request',
     'js/components/api_response',
     'js/components/api_query_updater',
-    'js/components/api_feedback'],
+    'js/components/api_feedback',
+    'js/components/json_response'],
   function(
     _,
     $,
@@ -24,7 +25,8 @@ define(['underscore',
     ApiRequest,
     ApiResponse,
     ApiQueryUpdater,
-    ApiFeedback) {
+    ApiFeedback,
+    JsonResponse) {
 
 
   var QueryMediator = GenericModule.extend({
@@ -178,7 +180,9 @@ define(['underscore',
         console.log('[QM]: received response:', JSON.stringify(data).substring(0, 1000));
 
       // TODO: check the status responses
-      var response = new ApiResponse(data);
+
+     var response = (data.responseHeader && data.responseHeader.QTime) ? new ApiResponse(data) : new JsonResponse(data);
+
       response.setApiQuery(this.request.get('query'));
 
       if (qm.debug)


### PR DESCRIPTION
Hi Roman,

This works for the network widget -- was it what you wanted?

I am using data.responseHeader && data.responseHeader.QTime to check if it is a solr response, I don't know if that is always going to be correct or if responseHeader is enough.
