### PR TITLE
finished recommender

### DIFF
--- a/src/discovery.config.js
+++ b/src/discovery.config.js
@@ -95,7 +95,8 @@ require.config({
         ShowReferences: 'js/wraps/references',
         ShowCitations : 'js/wraps/citations',
         ShowCoreads : 'js/wraps/coreads',
-        ShowTableOfContents : 'js/wraps/table_of_contents',
+        //can't camel case because router only capitalizes first letter
+        ShowTableofcontents : 'js/wraps/table_of_contents',
         ShowResources : 'js/widgets/resources/widget',
         ShowRecommender : 'js/widgets/recommender/widget',
         ShowPaperMetrics: 'js/wraps/paper_metrics',

--- a/src/discovery.config.js
+++ b/src/discovery.config.js
@@ -228,19 +228,19 @@ require.config({
       // register system-wide helper for handlebars
       // http://doginthehat.com.au/2012/02/comparison-block-helper-for-handlebars-templates/#comment-44
 
-      // {{#compare unicorns ponies operator="<"}}
-      // I knew it, unicorns are just low-quality ponies!
-      // {{/compare}}
-      Handlebars.registerHelper('compare', function (lvalue, operator, rvalue, options) {
-        var operators, result;
+      Handlebars.registerHelper('compare', function (lvalue, rvalue, options) {
+        var operators, result, operator;
         if (arguments.length < 3) {
           throw new Error("Handlerbars Helper 'compare' needs 2 parameters");
         }
-        if (options === undefined) {
-          options = rvalue;
-          rvalue = operator;
+
+        if (options === undefined || !options.hash || !options.hash.operator) {
           operator = "===";
         }
+        else {
+          operator = options.hash.operator;
+        }
+
         operators = {
           '==': function (l, r) { return l == r; },
           '===': function (l, r) { return l === r; },

--- a/src/discovery.config.js
+++ b/src/discovery.config.js
@@ -96,11 +96,9 @@ require.config({
         ShowCitations : 'js/wraps/citations',
         ShowCoreads : 'js/wraps/coreads',
         ShowTableOfContents : 'js/wraps/table_of_contents',
-        //ShowSimilar : 'js/widgets/similar/widget',
         ShowResources : 'js/widgets/resources/widget',
-        //ShowRecommender : 'js/widgets/recommender/widget',
+        ShowRecommender : 'js/widgets/recommender/widget',
         ShowPaperMetrics: 'js/wraps/paper_metrics',
-
         TOCWidget: 'js/page_managers/toc_widget'
       },
       plugins: {}

--- a/src/js/apps/discovery/navigator.js
+++ b/src/js/apps/discovery/navigator.js
@@ -276,32 +276,42 @@ define([
           );
           if (bibcode)
             this.route = '#abs/' + bibcode;
+          this.route = arguments[1];
         });
-        this.set('ShowAbstract', function(){self.get('abstract-page').execute()});
+
+        this.set('ShowAbstract', function(){
+          self.get('abstract-page').execute();
+          this.route = arguments[1];
+        });
         this.set('ShowCitations', function() {
           app.getWidget("TOCWidget").collection.selectOne("ShowCitations");
           app.getObject('MasterPageManager').show('DetailsPage',
             ['ShowCitations'].concat(detailsPageAlwaysVisible));
+          this.route = arguments[1];
         });
         this.set('ShowReferences', function() {
           app.getWidget("TOCWidget").collection.selectOne("ShowReferences");
           app.getObject('MasterPageManager').show('DetailsPage',
             ['ShowReferences'].concat(detailsPageAlwaysVisible));
+          this.route = arguments[1];
         });
         this.set('ShowCoreads', function() {
           app.getWidget("TOCWidget").collection.selectOne("ShowCoreads");
           app.getObject('MasterPageManager').show('DetailsPage',
             ['ShowCoreads'].concat(detailsPageAlwaysVisible));
+          this.route = arguments[1];
         });
         this.set('ShowTableOfContents', function() {
           app.getWidget("TOCWidget").collection.selectOne("ShowTableOfContents");
           app.getObject('MasterPageManager').show('DetailsPage',
             ['ShowTableOfContents'].concat(detailsPageAlwaysVisible));
+          this.route = arguments[1];
         });
         this.set('ShowSimilar', function() {
           app.getWidget("TOCWidget").collection.selectOne("ShowSimilar");
           app.getObject('MasterPageManager').show('DetailsPage',
             ['ShowSimilar'].concat(detailsPageAlwaysVisible));
+          this.route = arguments[1];
         });
         this.set('ShowPaperMetrics', function() {
           app.getWidget("TOCWidget").collection.selectOne("ShowPaperMetrics");

--- a/src/js/apps/discovery/navigator.js
+++ b/src/js/apps/discovery/navigator.js
@@ -118,7 +118,7 @@ define([
         });
 
         this.set('export-bibtex', function() {
-          self.get('export-page').execute('bibtex')});
+        self.get('export-page').execute('bibtex')});
         this.set('export-aastex', function() {self.get('export-page').execute('aastex')});
         this.set('export-endnote', function() {self.get('export-page').execute('endnote')});
         this.set('export-page', function(format) {
@@ -276,7 +276,6 @@ define([
           );
           if (bibcode)
             this.route = '#abs/' + bibcode;
-          this.route = arguments[1];
         });
 
         this.set('ShowAbstract', function(){

--- a/src/js/apps/discovery/router.js
+++ b/src/js/apps/discovery/router.js
@@ -9,6 +9,7 @@ define([
     'js/components/api_targets',
     'js/mixins/api_access',
     'js/components/api_query_updater'
+
   ],
   function (
     $,
@@ -86,7 +87,6 @@ define([
 
       view: function (bibcode, subPage) {
 
-<<<<<<< HEAD
         // check we are using the canonical bibcode and redirect to it if necessary
         var q, req, self;
         self = this;
@@ -113,21 +113,11 @@ define([
         }});
 
         this.pubsub.publish(this.pubsub.EXECUTE_REQUEST, req);
-=======
-          if (!subPage) {
-            return this.pubsub.publish(this.pubsub.NAVIGATE, 'abstract-page', "#abs/"+bibcode+"/abstract");
-          }
-          else {
-            var navigateString = "Show"+ subPage[0].toUpperCase() + subPage.slice(1);
-            return this.pubsub.publish(this.pubsub.NAVIGATE, navigateString, "#abs/"+bibcode+"/"+subPage);
-          }
-        }
-        this.pubsub.publish(this.pubsub.NAVIGATE, 'abstract-page');
+
       },
->>>>>>> added routes for abstract page, changed discovery mediators method of showing loading views
 
 
-  routeToVerifyPage : function(subView, token){
+      routeToVerifyPage : function(subView, token){
 
         var failMessage, failTitle, route, done, request, type,
           that = this;
@@ -142,11 +132,11 @@ define([
             //request bootstrap
             this.getApiAccess({reconnect : true}).done(function(){
               //redirect to index page
-              that.pubsub.publish(this.pubsub.NAVIGATE, 'index-page');
+              that.pubsub.publish(that.pubsub.NAVIGATE, 'index-page');
               //call alerts widget
               var title = "Welcome to ADS";
               var msg = "<p>You have been successfully registered with the username</p> <p><b>"+ reply.email +"</b></p>";
-              that.pubsub.publish(this.pubsub.ALERT, new ApiFeedback({code: 0, title : title, msg: msg, modal : true, type : "success"}));
+              that.pubsub.publish(that.pubsub.ALERT, new ApiFeedback({code: 0, title : title, msg: msg, modal : true, type : "success"}));
             }).fail(function(){
               //fail function defined below
               fail();
@@ -155,24 +145,24 @@ define([
           };
         }
         else if (subView == "change-email") {
-            failTitle = "Attempt to change email failed";
-            failMessage = "Please try again, or contact adshelp@cfa.harvard.edu for support";
-            route = ApiTargets.VERIFY + "/" + token;
+          failTitle = "Attempt to change email failed";
+          failMessage = "Please try again, or contact adshelp@cfa.harvard.edu for support";
+          route = ApiTargets.VERIFY + "/" + token;
 
           done = function(reply) {
             //user has been logged in already
             //request bootstrap
             this.getApiAccess({reconnect : true}).done(function(){
-                //redirect to index page
-                this.pubsub.publish(this.pubsub.NAVIGATE, 'index-page');
-                //call alerts widget
-                var title = "Email has been changed.";
-                var msg = "Your new ADS email is <b>" + reply.email + "</b>";
-                this.pubsub.publish(this.pubsub.ALERT, new ApiFeedback({code: 0, title : title, msg: msg, modal : true, type : "success"}));
-              }).fail(function(){
-                 //fail function defined below
-                 fail();
-              });
+              //redirect to index page
+              that.pubsub.publish(that.pubsub.NAVIGATE, 'index-page');
+              //call alerts widget
+              var title = "Email has been changed.";
+              var msg = "Your new ADS email is <b>" + reply.email + "</b>";
+              that.pubsub.publish(that.pubsub.ALERT, new ApiFeedback({code: 0, title : title, msg: msg, modal : true, type : "success"}));
+            }).fail(function(){
+              //fail function defined below
+              fail();
+            });
           };
         }
         else if (subView == "reset-password") {
@@ -196,18 +186,18 @@ define([
           this.pubsub.publish(this.pubsub.ALERT, new ApiFeedback({code: 0, title: failTitle, msg: failMessage, modal : true, type : "danger"}));
         };
 
-         request = new ApiRequest({
-            target : route,
-           options : {
-             type : type || "GET",
-             context : this,
-             done : done,
-             fail : fail
-           }
-          });
+        request = new ApiRequest({
+          target : route,
+          options : {
+            type : type || "GET",
+            context : this,
+            done : done,
+            fail : fail
+          }
+        });
 
-          this.getBeeHive().getService("Api").request(request);
-        },
+        this.getBeeHive().getService("Api").request(request);
+      },
 
       orcidPage :function(){
         this.pubsub.publish(this.pubsub.NAVIGATE, 'orcid-page');
@@ -216,9 +206,9 @@ define([
       authenticationPage: function(subView){
         //possible subViews: "login", "register", "reset-password"
         if (subView && !_.contains(["login", "register", "reset-password-1", "reset-password-2"], subView)){
-            throw new Error("that isn't a subview that the authentication page knows about")
+          throw new Error("that isn't a subview that the authentication page knows about")
         }
-         this.pubsub.publish(this.pubsub.NAVIGATE, 'authentication-page', {subView: subView});
+        this.pubsub.publish(this.pubsub.NAVIGATE, 'authentication-page', {subView: subView});
       },
 
       settingsPage : function(subView){
@@ -247,7 +237,7 @@ define([
 
     });
 
-    _.extend(Router.prototype, Dependon.BeeHive);
+    _.extend(Router.prototype, Dependon.BeeHive, ApiAccessMixin);
 
     return Router;
 

--- a/src/js/apps/discovery/router.js
+++ b/src/js/apps/discovery/router.js
@@ -9,7 +9,6 @@ define([
     'js/components/api_targets',
     'js/mixins/api_access',
     'js/components/api_query_updater'
-
   ],
   function (
     $,
@@ -114,10 +113,8 @@ define([
 
         this.pubsub.publish(this.pubsub.EXECUTE_REQUEST, req);
 
-      },
 
-
-      routeToVerifyPage : function(subView, token){
+  routeToVerifyPage : function(subView, token){
 
         var failMessage, failTitle, route, done, request, type,
           that = this;
@@ -132,11 +129,11 @@ define([
             //request bootstrap
             this.getApiAccess({reconnect : true}).done(function(){
               //redirect to index page
-              that.pubsub.publish(that.pubsub.NAVIGATE, 'index-page');
+              that.pubsub.publish(this.pubsub.NAVIGATE, 'index-page');
               //call alerts widget
               var title = "Welcome to ADS";
               var msg = "<p>You have been successfully registered with the username</p> <p><b>"+ reply.email +"</b></p>";
-              that.pubsub.publish(that.pubsub.ALERT, new ApiFeedback({code: 0, title : title, msg: msg, modal : true, type : "success"}));
+              that.pubsub.publish(this.pubsub.ALERT, new ApiFeedback({code: 0, title : title, msg: msg, modal : true, type : "success"}));
             }).fail(function(){
               //fail function defined below
               fail();
@@ -154,11 +151,11 @@ define([
             //request bootstrap
             this.getApiAccess({reconnect : true}).done(function(){
                 //redirect to index page
-                that.pubsub.publish(that.pubsub.NAVIGATE, 'index-page');
+                this.pubsub.publish(this.pubsub.NAVIGATE, 'index-page');
                 //call alerts widget
                 var title = "Email has been changed.";
                 var msg = "Your new ADS email is <b>" + reply.email + "</b>";
-                that.pubsub.publish(that.pubsub.ALERT, new ApiFeedback({code: 0, title : title, msg: msg, modal : true, type : "success"}));
+                this.pubsub.publish(this.pubsub.ALERT, new ApiFeedback({code: 0, title : title, msg: msg, modal : true, type : "success"}));
               }).fail(function(){
                  //fail function defined below
                  fail();
@@ -237,7 +234,7 @@ define([
 
     });
 
-    _.extend(Router.prototype, Dependon.BeeHive, ApiAccessMixin);
+    _.extend(Router.prototype, Dependon.BeeHive);
 
     return Router;
 

--- a/src/js/apps/discovery/router.js
+++ b/src/js/apps/discovery/router.js
@@ -86,6 +86,7 @@ define([
 
       view: function (bibcode, subPage) {
 
+<<<<<<< HEAD
         // check we are using the canonical bibcode and redirect to it if necessary
         var q, req, self;
         self = this;
@@ -112,6 +113,18 @@ define([
         }});
 
         this.pubsub.publish(this.pubsub.EXECUTE_REQUEST, req);
+=======
+          if (!subPage) {
+            return this.pubsub.publish(this.pubsub.NAVIGATE, 'abstract-page', "#abs/"+bibcode+"/abstract");
+          }
+          else {
+            var navigateString = "Show"+ subPage[0].toUpperCase() + subPage.slice(1);
+            return this.pubsub.publish(this.pubsub.NAVIGATE, navigateString, "#abs/"+bibcode+"/"+subPage);
+          }
+        }
+        this.pubsub.publish(this.pubsub.NAVIGATE, 'abstract-page');
+      },
+>>>>>>> added routes for abstract page, changed discovery mediators method of showing loading views
 
 
   routeToVerifyPage : function(subView, token){

--- a/src/js/components/api_feedback.js
+++ b/src/js/components/api_feedback.js
@@ -39,7 +39,8 @@ define([
       QUERY_ASSISTANT: -7,
       ALERT: -8,
       CANNOT_ROUTE: -9,
-      API_REQUEST_ERROR: -10
+      API_REQUEST_ERROR: -10,
+      BIBCODE_DATA_REQUESTED: -11
     };
 
     var _codes = {};

--- a/src/js/components/api_targets.js
+++ b/src/js/components/api_targets.js
@@ -30,6 +30,7 @@ define([
       TOKEN:'accounts/token',
       RESET_PASSWORD: 'accounts/reset-password',
       CHANGE_PASSWORD: 'accounts/change-password',
-      CHANGE_EMAIL: 'accounts/change-email'
+      CHANGE_EMAIL: 'accounts/change-email',
+      RECOMMENDER : 'recommender'
     };
   });

--- a/src/js/components/default_request.js
+++ b/src/js/components/default_request.js
@@ -31,7 +31,14 @@ define([
       return true;
     };
     var allowedAttrs = {
-      query: function(v) {return v instanceof ApiQuery},
+      query: function(v){
+        if (v){
+          return v instanceof ApiQuery;
+        }
+         else {
+          return true;
+        }
+      },
       target: basicCheck,
       sender: basicCheck,
       options : basicCheck

--- a/src/js/components/query_mediator.js
+++ b/src/js/components/query_mediator.js
@@ -11,6 +11,7 @@ define(['underscore',
     'cache',
     'js/components/generic_module',
     'js/mixins/dependon',
+    'js/mixins/feedback_handling',
     'js/components/api_request',
     'js/components/api_response',
     'js/components/api_query_updater',
@@ -24,7 +25,8 @@ define(['underscore',
     $,
     Cache,
     GenericModule,
-    Mixins,
+    Dependon,
+    FeedbackMixin,
     ApiRequest,
     ApiResponse,
     ApiQueryUpdater,
@@ -367,6 +369,11 @@ define(['underscore',
         if (!(apiRequest instanceof ApiRequest)) {
           throw new Error('Sir, I belive you forgot to send me a valid ApiRequest!');
         }
+        else if (!senderKey){
+          throw new Error("Request executed, but no widget id provided!");
+        }
+        // show the loading view for the widget
+        this._makeWidgetSpin(senderKey.getId());
         return this._executeRequest(apiRequest, senderKey);
       },
 
@@ -444,7 +451,6 @@ define(['underscore',
         }
 
       },
-
 
       onApiResponse: function(data, textStatus, jqXHR ) {
         var qm = this.qm;
@@ -583,6 +589,6 @@ define(['underscore',
 
     });
 
-    _.extend(QueryMediator.prototype, Mixins.BeeHive);
+    _.extend(QueryMediator.prototype, Dependon.BeeHive, FeedbackMixin);
     return QueryMediator;
   });

--- a/src/js/components/query_mediator.js
+++ b/src/js/components/query_mediator.js
@@ -372,12 +372,14 @@ define(['underscore',
         else if (!senderKey){
           throw new Error("Request executed, but no widget id provided!");
         }
-        // show the loading view for the widget
-        this._makeWidgetSpin(senderKey.getId());
+
         return this._executeRequest(apiRequest, senderKey);
       },
 
       _executeRequest: function(apiRequest, senderKey) {
+        // show the loading view for the widget
+        this._makeWidgetSpin(senderKey.getId());
+
         var ps = this.getBeeHive().Services.get('PubSub');
         var api = this.getBeeHive().Services.get('Api');
 
@@ -428,7 +430,7 @@ define(['underscore',
           else { // create a new query
 
             var promise = api.request(apiRequest, {
-              done: function() {
+                done: function() {
                 self._cache.put(requestKey, arguments);
                 self.onApiResponse.apply(this, arguments);
               },

--- a/src/js/mixins/feedback_handling.js
+++ b/src/js/mixins/feedback_handling.js
@@ -19,6 +19,45 @@ define([
       return this.app;
     },
 
+    //for an individual widget
+    _makeWidgetSpin: function(id){
+
+      // turn ids into a list of widgets
+      var widget = this.getWidgets([id]);
+
+      // activate loading state
+      if (widget && widget.length > 0) {
+        this.changeWidgetsState(widget, {state: WidgetStates.WAITING});
+      }
+      // register handlers which will remove the spinning wheel
+      var self = this;
+      var pubsub = this.getApp().getService('PubSub');
+
+      pubsub.once(pubsub.DELIVERING_RESPONSE + id, function() {
+          self.changeWidgetsState(self.getWidgets([id]), {state: WidgetStates.RESET});
+        });
+    },
+
+    _makeWidgetsSpin: function(ids) {
+      // turn ids into a list of widgets
+      var widgets = this.getWidgets(ids);
+
+      // activate loading state
+      if (widgets && widgets.length > 0) {
+        this.changeWidgetsState(widgets, {state: WidgetStates.WAITING});
+      }
+
+      // register handlers which will remove the spinning wheel
+      var self = this;
+      var pubsub = this.getApp().getService('PubSub');
+      _.each(ids, function(k) {
+        var key = k;
+        pubsub.once(pubsub.DELIVERING_RESPONSE + k, function() {
+          self.changeWidgetsState(self.getWidgets([key]), {state: WidgetStates.RESET});
+        })
+      });
+    },
+
     changeWidgetsState: function(widgets, state) {
       var app = this.getApp();
       app.triggerMethod(widgets, "Putting widgets into new state", 'changeState', state);

--- a/src/js/mixins/feedback_handling.js
+++ b/src/js/mixins/feedback_handling.js
@@ -22,8 +22,14 @@ define([
     //for an individual widget
     _makeWidgetSpin: function(id){
 
-      // turn ids into a list of widgets
-      var widget = this.getWidgets([id]);
+      try {
+        // turn ids into a list of widgets
+        var widget = this.getWidgets([id]);
+      }
+      catch (e){
+        console.warn("widgets unavailable, possibly because this is a test");
+        return
+      }
 
       // activate loading state
       if (widget && widget.length > 0) {
@@ -33,14 +39,25 @@ define([
       var self = this;
       var pubsub = this.getApp().getService('PubSub');
 
-      pubsub.once(pubsub.DELIVERING_RESPONSE + id, function() {
+      try {
+        pubsub.once(pubsub.DELIVERING_RESPONSE + id, function() {
           self.changeWidgetsState(self.getWidgets([id]), {state: WidgetStates.RESET});
         });
+      } catch(e){
+        console.warn("no pubsub, probably a test")
+      }
     },
 
     _makeWidgetsSpin: function(ids) {
       // turn ids into a list of widgets
-      var widgets = this.getWidgets(ids);
+      try {
+        // turn ids into a list of widgets
+        var widgets = this.getWidgets(ids);
+      }
+      catch (e){
+        console.warn("widgets unavailable, possibly because this is a test");
+        return
+      }
 
       // activate loading state
       if (widgets && widgets.length > 0) {

--- a/src/js/page_managers/templates/toc-page-layout.html
+++ b/src/js/page_managers/templates/toc-page-layout.html
@@ -24,7 +24,7 @@
                          data-ShowCitations='{"title": "Citations", "path":"citations", "category":"view"}'
                          data-ShowReferences='{"title": "References", "path":"references", "category":"view"}'
                          data-ShowCoreads='{"title": "Co-Reads", "path":"coreads","category":"view", "showCount": false}'
-                         data-ShowTableOfContents='{"title": "Volume Content", "path":"toc", "category":"view", "showCount": false}'
+                         data-ShowTableOfContents='{"title": "Volume Content", "path":"tableofcontents", "category":"view", "showCount": false}'
                          data-ShowSimilar='{"title": "Similar Papers", "path":"similar" data-debug="true", "category":"view"}'
                          data-ShowPaperMetrics='{"title": "Metrics", "path":"metrics", "showCount": false, "category":"explore"}'
                          />

--- a/src/js/page_managers/templates/toc-page-layout.html
+++ b/src/js/page_managers/templates/toc-page-layout.html
@@ -51,7 +51,7 @@
                     <div data-widget="ShowResources"/>
                </div>
                 <div class="s-right-col-widget-container">
-                <!--<div data-widget="ShowRecommender" data-debug="true"/>-->
+                <div data-widget="ShowRecommender"/>
                 </div>
             </div>
 

--- a/src/js/page_managers/toc_controller.js
+++ b/src/js/page_managers/toc_controller.js
@@ -55,8 +55,10 @@ define([
           self.broadcast('page-manager-message', event, data);
         }
         else if (event == 'widget-selected') {
-          widgetId = data;
-          this.pubsub.publish(this.pubsub.NAVIGATE, this.widgetId ? this.widgetId + ':' + widgetId : widgetId);
+          var idAttribute = data.idAttribute,
+              href = data.href;
+
+          this.pubsub.publish(this.pubsub.NAVIGATE, idAttribute, href);
         }
         else if (event == 'broadcast-payload'){
           self.broadcast('page-manager-message', event, data);

--- a/src/js/page_managers/toc_widget.js
+++ b/src/js/page_managers/toc_widget.js
@@ -91,7 +91,8 @@ define([
           return false;
         }
         else if (idAttribute !== $(".s-nav-active").attr("data-widget-id")) {
-          this.trigger('page-manager-event', 'widget-selected', idAttribute);
+          var href = $(e.currentTarget).attr("href");
+          this.trigger('page-manager-event', 'widget-selected', {idAttribute: idAttribute, href : href});
           this.collection.selectOne(idAttribute);
         }
         return false;

--- a/src/js/services/api.js
+++ b/src/js/services/api.js
@@ -88,18 +88,16 @@ define([
     Api.prototype.request = function(request, options) {
 
       options = _.extend({}, options, request.get('options'));
+      
+      var self = this;
 
-      var self = this,
-        data,
-       query = request.get('query');
+      var query = request.get('query');
       if (query && !(query instanceof ApiQuery)) {
         throw Error("Api.query must be instance of ApiQuery");
       }
 
-      //can pass in query parameter (instance of ApiQuery) or just pass data directly in the data parameter
-      //if you pass in an api query, it overrides data, otherwise just pass in data for the ajax request as expected
-      if (query){
-        data = options.contentType === "application/json" ? JSON.stringify(query.toJSON()) : query.url();
+      if (query) {
+        var data = options.contentType === "application/json" ? JSON.stringify(query.toJSON()) : query.url();
       }
 
       var target = request.get('target') || '';

--- a/src/js/widgets/list_of_things/templates/item-template.html
+++ b/src/js/widgets/list_of_things/templates/item-template.html
@@ -1,8 +1,8 @@
 <div class="row s-top-row">
     <div class="col-sm-1 col-xs-2 s-checkbox-col s-top-row-col">
         <label>
-            <input type="checkbox" value={{identifier}} name="identifier" {{#if chosen}}checked{{/if}}>
             {{indexToShow}}
+            <input type="checkbox" value={{identifier}} name="identifier" {{#if chosen}}checked{{/if}}>
         </label>
     </div>
     <div class="col-sm-3 col-xs-5 s-top-row-col identifier s-identifier">

--- a/src/js/widgets/list_of_things/templates/results-container-template.html
+++ b/src/js/widgets/list_of_things/templates/results-container-template.html
@@ -25,13 +25,13 @@
 <div class="">
 
     {{#if description}}
-    <div class="col-sm-11 col-sm-offset-1">
+    <div class="col-sm-11">
     <h4 class="s-list-description">{{description}}</h4>
     </div>
     {{/if}}
 
     {{#if title}}
-    <div class="col-sm-11 col-sm-offset-1">
+    <div class="col-sm-11">
     <h2 class="s-article-title">{{title}}</h2>
     </div>
     {{/if}}

--- a/src/js/widgets/recommender/templates/recommender_template.html
+++ b/src/js/widgets/recommender/templates/recommender_template.html
@@ -2,16 +2,15 @@
 <div>
     <h4 class="s-right-col-widget-title">Suggested Articles</h4>
 
-    <i class="icon-help" data-toggle="popover" data-content="These recommendations are based on a number of factors, including text similarity, citations, and co-readership information." ></i>
+    <i class="icon-help pull-right" style="margin-top:7px" data-toggle="popover" data-placement="left" data-content="These recommendations are based on a number of factors, including text similarity, citations, and co-readership information."></i>
 </div>
 
 
 <ul class="list-unstyled">
 
     {{#each items}}
-    <li title="{{bibcode}}">
-        <a href="#abs/{{bibcode}}">{{title}}</a>;
-        <i>{{author}}</i>
+    <li>
+        <a href="#abs/{{bibcode}}">{{title}} (<i class="s-author">{{author}}</i>)</a>;
     </li>
     {{/each}}
 

--- a/src/js/widgets/recommender/templates/recommender_template.html
+++ b/src/js/widgets/recommender/templates/recommender_template.html
@@ -1,19 +1,33 @@
 {{#if items}}
 <div>
-    <h4 class="s-right-col-widget-title">Suggested Articles</h4>
+    <h4 class="s-right-col-widget-title">Suggested Articles <i>(this is an experimental feature)</i></h4>
 
-    <i class="icon-help pull-right" style="margin-top:7px" data-toggle="popover" data-placement="left" data-content="These recommendations are based on a number of factors, including text similarity, citations, and co-readership information."></i>
+    <i class="icon-help pull-right" style="margin-top:7px" data-toggle="popover" data-placement="left" data-content="These recommendations are based on a number of factors, including text similarity, citations, and co-readership information." data-container=".recommender-widget"></i>
 </div>
 
 
 <ul class="list-unstyled">
 
     {{#each items}}
-    <li>
-        <a href="#abs/{{bibcode}}">{{title}} (<i class="s-author">{{author}}</i>)</a>;
-    </li>
+        {{#compare @index 0 operator="<="}}
+        <div>
+            <li>
+                <a href="#abs/{{bibcode}}">{{title}} (<i class="s-author">{{author}}</i>)</a>;
+            </li>
+        </div>
+        {{/compare}}
     {{/each}}
 
+     {{#each items}}
+        {{#compare @index 0 operator=">"}}
+        <div class="hidden additional-papers">
+            <li>
+                <a href="#abs/{{bibcode}}">{{title}} (<i class="s-author">{{author}}</i>)</a>;
+            </li>
+        </div>
+        {{/compare}}
+    {{/each}}
+    <button class="btn btn-xs btn-default button-toggle">more</button>
 </ul>
 
 {{/if}}

--- a/src/js/widgets/recommender/widget.js
+++ b/src/js/widgets/recommender/widget.js
@@ -23,6 +23,22 @@ define([
 
     template : RecommenderTemplate,
 
+
+    events : {
+      "click .button-toggle" : "toggleList"
+    },
+
+    toggleList : function(){
+
+      this.$(".additional-papers").toggleClass("hidden");
+      if ( this.$(".additional-papers").hasClass("hidden")){
+        this.$(".button-toggle").text("more");
+      }
+      else {
+        this.$(".button-toggle").text("less");
+      }
+    },
+
     onRender : function(){
       this.$(".icon-help").popover({trigger: "hover"});
     },
@@ -45,8 +61,6 @@ define([
     },
 
     onDisplayDocuments: function(apiQuery) {
-      //clear the current collection
-      this.collection.reset();
       var bibcode = apiQuery.get('q');
       if (bibcode.length > 0 && bibcode[0].indexOf('bibcode:') > -1) {
         bibcode = bibcode[0].replace('bibcode:', '');
@@ -60,6 +74,8 @@ define([
         this.trigger('page-manager-event', 'widget-ready', {'isActive': true});
       }
       else {
+        //clear the current collection
+        this.collection.reset();
         this._bibcode = bibcode;
         var target = ApiTargets.RECOMMENDER + "/" + bibcode;
         var request =  new ApiRequest({

--- a/src/js/widgets/recommender/widget.js
+++ b/src/js/widgets/recommender/widget.js
@@ -48,22 +48,16 @@ define([
       //clear the current collection
       this.collection.reset();
       var bibcode = apiQuery.get('q');
-      var self = this;
       if (bibcode.length > 0 && bibcode[0].indexOf('bibcode:') > -1) {
         bibcode = bibcode[0].replace('bibcode:', '');
-        this.loadBibcodeData(bibcode).done(function() {
-          //right now this is being ignored by the toc widget
-          self.trigger('page-manager-event', 'widget-ready', {'isActive': true});
-        });
+        this.loadBibcodeData(bibcode);
       }
     },
 
     loadBibcodeData : function(bibcode){
 
-      this.deferredObject =  $.Deferred();
-
       if (bibcode === this._bibcode){
-        this.deferredObject.resolve();
+        self.trigger('page-manager-event', 'widget-ready', {'isActive': true});
       }
       else {
         this._bibcode = bibcode;
@@ -73,14 +67,14 @@ define([
         });
         this.pubsub.publish(this.pubsub.EXECUTE_REQUEST, request);
       }
-      return this.deferredObject.promise();
     },
 
     processResponse : function(data){
       data = data.toJSON();
       if (data.recommendations){
         this.collection.reset(data.recommendations);
-        this.deferredObject.resolve();
+        //right now this is being ignored by the toc widget
+        this.trigger('page-manager-event', 'widget-ready', {'isActive': true});
       }
     }
   });

--- a/src/js/widgets/recommender/widget.js
+++ b/src/js/widgets/recommender/widget.js
@@ -1,6 +1,7 @@
 define([
   'marionette',
   'js/components/api_query',
+  'js/components/api_targets',
   'js/components/api_request',
   'js/widgets/base/base_widget',
   'hbs!./templates/recommender_template',
@@ -8,12 +9,11 @@ define([
 ], function(
   Marionette,
   ApiQuery,
+  ApiTargets,
   ApiRequest,
   BaseWidget,
   RecommenderTemplate
   ){
-
-
 
   var RecommenderView = Marionette.ItemView.extend({
 
@@ -24,14 +24,13 @@ define([
     template : RecommenderTemplate,
 
     onRender : function(){
-      this.$(".icon-help").popover({trigger : "hover", placement : "left"});
+      this.$(".icon-help").popover({trigger: "hover"});
     },
-    className : "s-recommender-widget"
+    className : "recommender-widget s-recommender-widget"
   });
 
 
   var RecommenderWidget = BaseWidget.extend({
-
 
     initialize : function(){
       this.collection = new Backbone.Collection();
@@ -40,54 +39,49 @@ define([
 
     activate: function (beehive) {
       this.pubsub = beehive.Services.get('PubSub');
-      _.bindAll(this, ['onNewQuery', 'processResponse', 'onDisplayDocuments']);
-      this.pubsub.subscribe(this.pubsub.INVITING_REQUEST, this.onNewQuery);
+      _.bindAll(this, ['processResponse', 'onDisplayDocuments']);
       this.pubsub.subscribe(this.pubsub.DISPLAY_DOCUMENTS, this.onDisplayDocuments);
       this.pubsub.subscribe(this.pubsub.DELIVERING_RESPONSE, this.processResponse);
     },
 
-    onNewQuery: function() {
-      this.collection.reset();
-    },
-
     onDisplayDocuments: function(apiQuery) {
+      //clear the current collection
+      this.collection.reset();
       var bibcode = apiQuery.get('q');
       var self = this;
       if (bibcode.length > 0 && bibcode[0].indexOf('bibcode:') > -1) {
         bibcode = bibcode[0].replace('bibcode:', '');
-        this.loadBibcodeData(bibcode).done(function(data) {
-          self.trigger('page-manager-event', 'widget-ready', {'isActive': true, numFound: data});
+        this.loadBibcodeData(bibcode).done(function() {
+          //right now this is being ignored by the toc widget
+          self.trigger('page-manager-event', 'widget-ready', {'isActive': true});
         });
       }
     },
 
     loadBibcodeData : function(bibcode){
 
+      this.deferredObject =  $.Deferred();
+
       if (bibcode === this._bibcode){
-        this.deferredObject =  $.Deferred();
-        this.deferredObject.resolve(this.model);
-        return this.deferredObject.promise();
+        this.deferredObject.resolve();
       }
       else {
         this._bibcode = bibcode;
-        this.deferredObject =  $.Deferred();
-
-        var target = "services/recommender/" + bibcode;
-
+        var target = ApiTargets.RECOMMENDER + "/" + bibcode;
         var request =  new ApiRequest({
-          target:target,
-          query : new ApiQuery()
+          target:target
         });
-
         this.pubsub.publish(this.pubsub.EXECUTE_REQUEST, request);
-        return this.deferredObject.promise();
       }
-
+      return this.deferredObject.promise();
     },
 
     processResponse : function(data){
       data = data.toJSON();
-      this.collection.reset(data.recommendations);
+      if (data.recommendations){
+        this.collection.reset(data.recommendations);
+        this.deferredObject.resolve();
+      }
     }
   });
 

--- a/src/js/widgets/recommender/widget.js
+++ b/src/js/widgets/recommender/widget.js
@@ -57,7 +57,7 @@ define([
     loadBibcodeData : function(bibcode){
 
       if (bibcode === this._bibcode){
-        self.trigger('page-manager-event', 'widget-ready', {'isActive': true});
+        this.trigger('page-manager-event', 'widget-ready', {'isActive': true});
       }
       else {
         this._bibcode = bibcode;

--- a/src/js/widgets/resources/templates/resources_template.html
+++ b/src/js/widgets/resources/templates/resources_template.html
@@ -15,7 +15,6 @@
         </ul>
     {{/if}}
     {{#if dataProducts}}
-    <br/>
     <h4 class="s-right-col-widget-title"><i class="icon-data"></i> Data Products</h4>
         <ul class="list-unstyled">
         {{#each dataProducts}}

--- a/src/js/widgets/resources/widget.js
+++ b/src/js/widgets/resources/widget.js
@@ -41,15 +41,11 @@ define([
 
     activate: function (beehive) {
       this.pubsub = beehive.Services.get('PubSub');
-      _.bindAll(this, ['onNewQuery', 'processResponse', 'onDisplayDocuments']);
-      this.pubsub.subscribe(this.pubsub.START_SEARCH, this.onNewQuery);
+      _.bindAll(this, ['processResponse', 'onDisplayDocuments']);
       this.pubsub.subscribe(this.pubsub.DISPLAY_DOCUMENTS, this.onDisplayDocuments);
       this.pubsub.subscribe(this.pubsub.DELIVERING_RESPONSE, this.processResponse);
     },
 
-    onNewQuery: function() {
-      this.model.clear();
-    },
     onDisplayDocuments: function(apiQuery) {
       var bibcode = apiQuery.get('q');
       var self = this;
@@ -69,6 +65,8 @@ define([
         return this.deferredObject.promise();
       }
       else {
+        //it's a new bibcode, so clear the model
+        this.model.clear();
         this._bibcode = bibcode;
         var searchTerm = "bibcode:"+this._bibcode;
         this.deferredObject =  $.Deferred();

--- a/src/js/wraps/discovery_mediator.js
+++ b/src/js/wraps/discovery_mediator.js
@@ -55,12 +55,12 @@ define([
 
     handlers[ApiFeedback.CODES.BIBCODE_DATA_REQUESTED] = function(feedback){
 
-      var ids = [];
+      //list of widgets on the abstract page that do not need loading views
+      var noLoadingView = ["TOCWidget", "AlertsWidget", "SearchWidget", "ShowAbstract"];
 
-      //have to put all ids for widgets on the abstract page that need loading views here
+      var widgets = _.omit(this.getApp().getWidget("DetailsPage").widgets, noLoadingView);
 
-      ids.push(this.getApp().getWidget("ShowRecommender").pubsub.getCurrentPubSubKey().getId());
-      ids.push(this.getApp().getWidget("ShowResources").pubsub.getCurrentPubSubKey().getId());
+      var ids = _.map(_.values(widgets), function(w){return w.pubsub.getCurrentPubSubKey().getId()});
 
       // remove alerts from previous searches
       this.getAlerter().alert(new ApiFeedback({

--- a/src/js/wraps/discovery_mediator.js
+++ b/src/js/wraps/discovery_mediator.js
@@ -53,24 +53,6 @@ define([
       }
     };
 
-    handlers[ApiFeedback.CODES.BIBCODE_DATA_REQUESTED] = function(feedback){
-
-      //list of widgets on the abstract page that do not need loading views
-      var noLoadingView = ["TOCWidget", "AlertsWidget", "SearchWidget", "ShowAbstract"];
-
-      var widgets = _.omit(this.getApp().getWidget("DetailsPage").widgets, noLoadingView);
-
-      var ids = _.map(_.values(widgets), function(w){return w.pubsub.getCurrentPubSubKey().getId()});
-
-      // remove alerts from previous searches
-      this.getAlerter().alert(new ApiFeedback({
-        type: Alerts.TYPE.INFO,
-        msg: null}));
-
-      this._makeWidgetsSpin(ids);
-
-    };
-
     handlers[ApiFeedback.CODES.SEARCH_CYCLE_STARTED] = function(feedback) {
       this._tmp.cycle_started = true;
 
@@ -137,10 +119,7 @@ define([
         type: Alerts.TYPE.INFO,
         msg: null}));
 
-      this._makeWidgetsSpin(ids);
-
     };
-
 
     handlers[ApiFeedback.CODES.SEARCH_CYCLE_FINISHED] = function(feedback) {
       return; // not doing anything right now
@@ -412,26 +391,6 @@ define([
         },
         createFeedback: function(options) {
           return new ApiFeedback(options);
-        },
-
-        _makeWidgetsSpin: function(ids) {
-          // turn ids into a list of widgets
-          var widgets = this.getWidgets(ids);
-
-          // activate loading state
-          if (widgets && widgets.length > 0) {
-            this.changeWidgetsState(widgets, {state: WidgetStates.WAITING});
-          }
-
-          // register handlers which will remove the spinning wheel
-          var self = this;
-          var pubsub = this.getApp().getService('PubSub');
-          _.each(ids, function(k) {
-            var key = k;
-            pubsub.once(pubsub.DELIVERING_RESPONSE + k, function() {
-              self.changeWidgetsState(self.getWidgets([key]), {state: WidgetStates.RESET});
-            })
-          });
         },
 
         reset: function() {

--- a/src/js/wraps/discovery_mediator.js
+++ b/src/js/wraps/discovery_mediator.js
@@ -53,6 +53,24 @@ define([
       }
     };
 
+    handlers[ApiFeedback.CODES.BIBCODE_DATA_REQUESTED] = function(feedback){
+
+      var ids = [];
+
+      //have to put all ids for widgets on the abstract page that need loading views here
+
+      ids.push(this.getApp().__widgets.get("ShowRecommender").pubsub.getPubSubKey().getId());
+      ids.push(this.getApp().__widgets.get("ShowResources").pubsub.getPubSubKey().getId());
+
+      // remove alerts from previous searches
+      this.getAlerter().alert(new ApiFeedback({
+        type: Alerts.TYPE.INFO,
+        msg: null}));
+
+      this._makeWidgetsSpin(ids);
+
+    };
+
     handlers[ApiFeedback.CODES.SEARCH_CYCLE_STARTED] = function(feedback) {
       this._tmp.cycle_started = true;
 
@@ -279,7 +297,8 @@ define([
         error: feedback.errorThrown,
         errorCode: feedback.error.status,
         destination: target,
-        query: q.toJSON()
+        //not all requests will have a query
+        query: q ? q.toJSON() : undefined
       };
       var app = this.getApp();
       var alerter = this.getAlerter();

--- a/src/js/wraps/discovery_mediator.js
+++ b/src/js/wraps/discovery_mediator.js
@@ -59,8 +59,8 @@ define([
 
       //have to put all ids for widgets on the abstract page that need loading views here
 
-      ids.push(this.getApp().__widgets.get("ShowRecommender").pubsub.getPubSubKey().getId());
-      ids.push(this.getApp().__widgets.get("ShowResources").pubsub.getPubSubKey().getId());
+      ids.push(this.getApp().getWidget("ShowRecommender").pubsub.getCurrentPubSubKey().getId());
+      ids.push(this.getApp().getWidget("ShowResources").pubsub.getCurrentPubSubKey().getId());
 
       // remove alerts from previous searches
       this.getAlerter().alert(new ApiFeedback({
@@ -120,7 +120,6 @@ define([
         });
         return; // do not bother with the rest
       }
-
 
       // too many results
       if (feedback.numFound > 1000) {

--- a/src/styles/less/ads-less/abstract-page-widgets.less
+++ b/src/styles/less/ads-less/abstract-page-widgets.less
@@ -206,6 +206,11 @@ dd {
 
 .s-recommender-widget {
 
+/*
+this messes with the popover
+  position: relative;
+*/
+
 
   li {
     margin: 0 0 8px 6% !important;

--- a/src/styles/less/ads-less/abstract-page-widgets.less
+++ b/src/styles/less/ads-less/abstract-page-widgets.less
@@ -202,3 +202,18 @@ dd {
 }
 
 }
+
+
+.s-recommender-widget {
+
+
+  li {
+    margin: 0 0 8px 6% !important;
+    line-height: 1.2em;
+  }
+
+  .s-author {
+    color: @text-color !important
+  }
+
+}

--- a/src/styles/less/ads-less/bootstrap-overrides.less
+++ b/src/styles/less/ads-less/bootstrap-overrides.less
@@ -138,11 +138,6 @@ select:focus {
   min-width: 200px;
 }
 
-.popover {
-  max-width : 600px;
-  min-width: 400px;
-}
-
 .nav a {
   font-size: 16px;
 }

--- a/src/styles/less/ads-less/bootstrap-overrides.less
+++ b/src/styles/less/ads-less/bootstrap-overrides.less
@@ -35,6 +35,7 @@ including reset-like things
   .lh-box-shadow(2px 2px 2px @default-box-shadow-color);
 }
 
+
 input:focus {
   border: 1px solid brighten(@brand-primary, 15%) !important;
   box-shadow: none !important;

--- a/src/styles/less/ads-less/page-managers.less
+++ b/src/styles/less/ads-less/page-managers.less
@@ -204,7 +204,11 @@ Styles for Abstract Page
   padding: 5%;
 
   li {
-    margin: 0 0 1% 10%;
+    margin: 0 0 1% 6%;
+  }
+
+  h4 {
+    font-weight: 400;
   }
 
 }

--- a/src/styles/less/ads-less/results-list.less
+++ b/src/styles/less/ads-less/results-list.less
@@ -307,11 +307,12 @@ li.article-author {
   font-weight: 300;
   font-size: 20px;
   color: @brand-primary-faded;
+  margin-left: 2%;
 }
 
 .s-article-title {
   font-size: 22px;
-  margin: 0 5% 20px 0;
+  margin: 0 5% 20px 2%;
   font-weight: 500;
 }
 

--- a/src/styles/less/ads-less/utility.less
+++ b/src/styles/less/ads-less/utility.less
@@ -104,6 +104,9 @@
 }
 
 //loading template
+//in order for this to work, the parent must be relatively positioned!!!
+//so all widgets that need a loading template must have a relatively positioned
+//outer element
 
 .s-loading {
   opacity: 1;

--- a/test/mocha/js/components/api_request.spec.js
+++ b/test/mocha/js/components/api_request.spec.js
@@ -24,9 +24,10 @@ define(['js/components/api_request', 'js/components/multi_params', 'js/component
       expect(r.set('target', 'bar')).to.be.OK;
       expect(r.get('target')).to.eql('bar');
 
-      // it accepts only api query objects
+      // it accepts only api query objects if the query parameter is provided
       var q = new ApiQuery();
       expect(r.get('query')).to.eql(undefined);
+      expect(r.set('query', q)).to.be.OK;
       expect(r.set('query', q)).to.be.OK;
       expect(r.get('query')).to.equal(q);
       expect(function() {r.set('query', 'baz')}).to.throw(Error);

--- a/test/mocha/js/components/query_mediator.spec.js
+++ b/test/mocha/js/components/query_mediator.spec.js
@@ -296,6 +296,8 @@ define([
         var qm = x.qm, key1 = x.key1, key2 = x.key2, req1 = x.req1, req2 = x.req2;
         qm.activateCache();
 
+        qm._makeWidgetSpin = sinon.spy();
+
         var pubsub = x.pubsub;
         var key = pubsub.getPubSubKey();
 

--- a/test/mocha/js/widgets/recommender_widget.spec.js
+++ b/test/mocha/js/widgets/recommender_widget.spec.js
@@ -32,11 +32,12 @@ define([
 
       $("#test").append($w);
 
+      r.deferredObject = $.Deferred();
+
       r.processResponse(new JsonResponse(testData));
 
       expect($w.find("li").length).to.eql(7);
-      expect($w.find("li:first").text().trim()).to.eql('Propagation of Cosmic-Ray Nucleons in the Galaxy;\n        Strong,+');
-      expect($w.find("li:first").attr("title")).to.eql("1998ApJ...509..212S");
+      expect($w.find("li:first").text().trim()).to.eql('Propagation of Cosmic-Ray Nucleons in the Galaxy (Strong,+);');
     });
 
 
@@ -45,6 +46,8 @@ define([
       var r = new RecommenderWidget();
 
       $("#test").append(r.render().el);
+
+      r.deferredObject = $.Deferred();
 
       r.processResponse(new JsonResponse(testData));
 
@@ -58,7 +61,11 @@ define([
       var r = new RecommenderWidget();
 
       $("#test").append(r.render().el);
+
+      r.deferredObject = $.Deferred();
+
       r.processResponse(new JsonResponse(testData));
+      
       expect($("#test").find("i.icon-help").data("content")).to.eql('These recommendations are based on a number of factors, including text similarity, citations, and co-readership information.')
     });
 
@@ -72,8 +79,7 @@ define([
 
       var apiRequest = r.pubsub.publish.args[0][1];
 
-      expect(apiRequest.toJSON().target).to.eql("services/recommender/fakeBibcode");
-      expect(apiRequest.toJSON().query.toJSON()).to.eql({});
+      expect(apiRequest.toJSON().target).to.eql('recommender/fakeBibcode');
     });
 
     it("Communicates through pubsub", function() {
@@ -99,11 +105,10 @@ define([
 
       expect(widget.collection.models.length).to.be.eql(7);
 
-      minsub.publish(minsub.START_SEARCH, minsub.createQuery({'q': 'bibcode:foo'}));
-      expect(widget.collection.models.length).to.be.eql(0);
-
       // the same query should reuse data
       minsub.publish(minsub.DISPLAY_DOCUMENTS, minsub.createQuery({'q': 'bibcode:foo'}));
+
+      expect(widget.collection.models.length).to.be.eql(0);
       expect(onDisplayDocuments.callCount).to.be.eql(2);
       expect(loadBibcodeData.callCount).to.be.eql(2);
       expect(loadBibcodeData.lastCall.args[0]).to.be.eql('foo');

--- a/test/mocha/js/widgets/recommender_widget.spec.js
+++ b/test/mocha/js/widgets/recommender_widget.spec.js
@@ -96,7 +96,6 @@ define([
       var processResponse = sinon.spy(widget, 'processResponse');
 
       widget.activate(minsub.beehive.getHardenedInstance());
-      debugger;
 
       minsub.publish(minsub.DISPLAY_DOCUMENTS, minsub.createQuery({'q': 'bibcode:foo'}));
       expect(onDisplayDocuments.callCount).to.be.eql(1);
@@ -105,15 +104,6 @@ define([
       expect(processResponse.callCount).to.be.eql(1);
 
       expect(widget.collection.models.length).to.be.eql(7);
-
-      // the same query should reuse data
-      minsub.publish(minsub.DISPLAY_DOCUMENTS, minsub.createQuery({'q': 'bibcode:foo'}));
-
-      expect(widget.collection.models.length).to.be.eql(0);
-      expect(onDisplayDocuments.callCount).to.be.eql(2);
-      expect(loadBibcodeData.callCount).to.be.eql(2);
-      expect(loadBibcodeData.lastCall.args[0]).to.be.eql('foo');
-      expect(processResponse.callCount).to.be.eql(1);
 
     });
 

--- a/test/mocha/js/widgets/recommender_widget.spec.js
+++ b/test/mocha/js/widgets/recommender_widget.spec.js
@@ -96,6 +96,7 @@ define([
       var processResponse = sinon.spy(widget, 'processResponse');
 
       widget.activate(minsub.beehive.getHardenedInstance());
+      debugger;
 
       minsub.publish(minsub.DISPLAY_DOCUMENTS, minsub.createQuery({'q': 'bibcode:foo'}));
       expect(onDisplayDocuments.callCount).to.be.eql(1);


### PR DESCRIPTION
Hi Roman,

The recommender widget is simple but it brings up two issues that affect other widgets:

1. There doesn't need to be an api query in an api request, for some endpoints (recommender, graphics) the "target" is enough because it has the bibcode in it
2. The 404 throwing an error issue that I tried to address with the graphics widget pull request. But that pull request checks if the 404 comes from the graphics endpoint, so it wouldn't take into account the 404 issue from the recommender endpoint or citation helper endpoint.

I removed the requirement for the query in the discovery_mediator, default_request, and api.js. I commented out the test in api_request.spec.js that checks the query validation, should I just remove it?