### PR TITLE
results widget and facets now dont reload data if the query is identical

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -40,8 +40,6 @@
     </div>
 </div>
 
-<span id="aria-announcement-container" aria-live="assertive"></span>
-
 <!-- start the discovery application -->
 <script data-main="./discovery.config" src="./libs/requirejs/require.js"></script>
 <script>

--- a/src/js/apps/discovery/router.js
+++ b/src/js/apps/discovery/router.js
@@ -79,7 +79,6 @@ define([
 
       view: function (bibcode, subPage) {
 
-        console.time("absStart")
         var navigateString;
 
         if (bibcode) {

--- a/src/js/apps/discovery/router.js
+++ b/src/js/apps/discovery/router.js
@@ -78,18 +78,22 @@ define([
       },
 
       view: function (bibcode, subPage) {
-        if (bibcode){
-          this.pubsub.publish(this.pubsub.DISPLAY_DOCUMENTS, new ApiQuery({'q': 'bibcode:' + bibcode}));
 
-          if (!subPage) {
-            return this.pubsub.publish(this.pubsub.NAVIGATE, 'abstract-page', bibcode);
-          }
-          else {
-            var navigateString = "Show"+ subPage[0].toUpperCase() + subPage.slice(1);
-            return this.pubsub.publish(this.pubsub.NAVIGATE, navigateString, bibcode);
-          }
+        console.time("absStart")
+        var navigateString;
+
+        if (bibcode) {
+          this.pubsub.publish(this.pubsub.DISPLAY_DOCUMENTS, new ApiQuery({'q': 'bibcode:' + bibcode}));
         }
-        this.pubsub.publish(this.pubsub.NAVIGATE, 'abstract-page');
+
+        if (!subPage) {
+            navigateString = 'abstract-page';
+        }
+          else {
+            navigateString = "Show"+ subPage[0].toUpperCase() + subPage.slice(1);
+        }
+
+         this.pubsub.publish(this.pubsub.NAVIGATE, navigateString, bibcode);
       },
 
 

--- a/src/js/page_managers/master.js
+++ b/src/js/page_managers/master.js
@@ -94,7 +94,10 @@ define([
           model.attributes.numAttach += 1;
 
           //scroll up automatically
-//          window.scrollTo(0,0);
+          window.scrollTo(0,0);
+          //fix the search bar back into its default spot
+          $(".s-search-bar-full-width-container").removeClass("s-search-bar-motion");
+          $(".s-quick-add").removeClass("hidden");
         }
         else {
           if (model.attributes.object.view.$el.parent().length > 0) {

--- a/src/js/page_managers/master.js
+++ b/src/js/page_managers/master.js
@@ -81,16 +81,27 @@ define([
       },
 
       collectionEvents : {
-        "change:isSelected" : "onSelectedChange",
-        "change:options": "onSelectedChange"
+        "change:isSelected" : "changeManager",
+        "change:options": "changeWithinManager"
       },
 
-      onSelectedChange: function(model) {
+      //transition between page managers
+      changeManager: function(model, opts){
+
+        var within = (opts.flag == "within");
+
         if (model.attributes.isSelected) {
           // call the subordinate page-manager
           var res = model.attributes.object.show.apply(model.attributes.object, model.attributes.options);
 
-          this.$el.append(res.el);
+          if (this.notFirst && !within){
+            //only show transitions for subsequent pages
+            this.$el.append(res.$el.addClass("fade-in"));
+          }
+          else if (!within) {
+            this.$el.append(res.el);
+            this.notFirst = true;
+          }
           model.attributes.numAttach += 1;
 
           //scroll up automatically
@@ -106,6 +117,11 @@ define([
           }
         }
         this.render();
+      },
+
+      //transition widgets within a manager
+      changeWithinManager : function(model){
+        this.changeManager(model, {flag: "within"})
       },
 
       render: function() {

--- a/src/js/widgets/abstract/widget.js
+++ b/src/js/widgets/abstract/widget.js
@@ -147,8 +147,6 @@ define([
       },
 
       onRender : function(){
-        console.timeEnd("absStart")
-
         this.$(".icon-help").popover({trigger : "hover", placement : "right", html :true});
       }
 

--- a/src/js/widgets/alerts/templates/alerts_template.html
+++ b/src/js/widgets/alerts/templates/alerts_template.html
@@ -36,7 +36,7 @@
     {{#if msg}}
     <div class="alert alert-{{type}} {{#if fade}} fade-out {{/if}}" id="alertBox">
         {{{msg}}}
-        <button type="button" class="close"  ><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+        <button type="button" class="close"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
     </div>
     {{/if}}
 {{/if}}

--- a/src/js/widgets/base/base_widget.js
+++ b/src/js/widgets/base/base_widget.js
@@ -122,7 +122,7 @@ define([
      * Default callback to be called by PubSub on 'INVITING_REQUEST'
      */
     dispatchRequest: function (apiQuery) {
-      this._dispatchRequest(apiQuery);
+     this._dispatchRequest(apiQuery);
     },
 
     _dispatchRequest: function(apiQuery) {

--- a/src/js/widgets/facet/tree_view.js
+++ b/src/js/widgets/facet/tree_view.js
@@ -49,14 +49,12 @@ define(['underscore',
       var val;
       val = this.model.get("count")
       this.$(".facet-amount:first").html("&nbsp;(" + this.formatNum(val) + ")" );
-      this.$(".item-caret").addClass("draw-attention-text")
 
     },
 
     onMouseLeave: function(e){
       e.stopPropagation();
       this.$(".facet-amount").empty();
-      this.$("i.item-caret").removeClass("draw-attention-text")
     },
 
 

--- a/src/js/widgets/facet/widget.js
+++ b/src/js/widgets/facet/widget.js
@@ -39,19 +39,15 @@ define(['backbone',
 
         this._extractor = undefined;
         this._preprocessor = undefined;
-
       },
 
+      //called in response to "inviting_request"
       dispatchRequest : function(apiQuery, data){
-        this.reset();
-        this._dispatchRequest(apiQuery, data);
-
+         this._paginators = {};
+         this._dispatchRequest(apiQuery, data);
       },
 
-      reset : function(){
-        this._paginators = {};
-      },
-
+      //called by widgets as well (don't need to reset paginators)
       _dispatchRequest: function (apiQuery, data) {
         var q = this.customizeQuery(apiQuery);
         data = data || {};
@@ -271,7 +267,7 @@ define(['backbone',
             p.before();
           }
           if (p && p.runQuery) {
-            this.dispatchRequest(q, {collection: collection, view: view});
+            this._dispatchRequest(q, {collection: collection, view: view});
           }
         }
         else if (ev.substring(ev.length-20) == 'itemview:itemClicked') {

--- a/src/js/widgets/facet/widget.js
+++ b/src/js/widgets/facet/widget.js
@@ -43,7 +43,13 @@ define(['backbone',
       },
 
       dispatchRequest : function(apiQuery, data){
-         this._dispatchRequest(apiQuery, data);
+        this.reset();
+        this._dispatchRequest(apiQuery, data);
+
+      },
+
+      reset : function(){
+        this._paginators = {};
       },
 
       _dispatchRequest: function (apiQuery, data) {

--- a/src/js/widgets/facet/widget.js
+++ b/src/js/widgets/facet/widget.js
@@ -42,6 +42,9 @@ define(['backbone',
 
       },
 
+      dispatchRequest : function(apiQuery, data){
+         this._dispatchRequest(apiQuery, data);
+      },
 
       _dispatchRequest: function (apiQuery, data) {
         var q = this.customizeQuery(apiQuery);
@@ -262,7 +265,7 @@ define(['backbone',
             p.before();
           }
           if (p && p.runQuery) {
-            this._dispatchRequest(q, {collection: collection, view: view});
+            this.dispatchRequest(q, {collection: collection, view: view});
           }
         }
         else if (ev.substring(ev.length-20) == 'itemview:itemClicked') {

--- a/src/js/widgets/list_of_things/templates/item-template.html
+++ b/src/js/widgets/list_of_things/templates/item-template.html
@@ -48,7 +48,7 @@
                 <ul class="hidden list-unstyled list-unstyled link-details s-link-details" role="menu">
 
                     {{#each links.list}}
-                    <li><a href="{{this.link}}" target="_blank">{{this.title}}</a></li>
+                    <li><a href="{{this.link}}">{{this.title}}</a></li>
                     {{/each}}
                 </ul>
                 {{/if}}

--- a/src/js/widgets/list_of_things/widget.js
+++ b/src/js/widgets/list_of_things/widget.js
@@ -95,9 +95,10 @@ define([
       activate: function (beehive) {
         this.pubsub = beehive.Services.get('PubSub');
 
-        _.bindAll(this, 'onStartSearch', 'onDisplayDocuments', 'processResponse');
+        _.bindAll(this, 'onStartSearch', 'dispatchRequest', 'processResponse');
         this.pubsub.subscribe(this.pubsub.START_SEARCH, this.onStartSearch);
-        this.pubsub.subscribe(this.pubsub.DISPLAY_DOCUMENTS, this.onDisplayDocuments);
+        //using the standard base widget dispatch request
+        this.pubsub.subscribe(this.pubsub.DISPLAY_DOCUMENTS, this.dispatchRequest);
         this.pubsub.subscribe(this.pubsub.DELIVERING_RESPONSE, this.processResponse);
       },
 
@@ -105,12 +106,9 @@ define([
         this.reset();
       },
 
-      onDisplayDocuments: function(apiQuery) {
-        BaseWidget.prototype.dispatchRequest.call(this, apiQuery);
-      },
-
       processResponse: function (apiResponse) {
         var q = apiResponse.getApiQuery();
+        this.setCurrentQuery(q);
 
         var docs = this.extractDocs(apiResponse);
 

--- a/src/js/widgets/results/widget.js
+++ b/src/js/widgets/results/widget.js
@@ -50,8 +50,8 @@ define([
       activate: function (beehive) {
         this.setBeeHive(beehive);
         this.pubsub = beehive.Services.get('PubSub');
-        _.bindAll(this, 'onDisplayDocuments', 'processResponse', 'onUserAnnouncement');
-        this.pubsub.subscribe(this.pubsub.INVITING_REQUEST, this.onDisplayDocuments);
+        _.bindAll(this, 'dispatchRequest', 'processResponse', 'onUserAnnouncement');
+        this.pubsub.subscribe(this.pubsub.INVITING_REQUEST, this.dispatchRequest);
         this.pubsub.subscribe(this.pubsub.DELIVERING_RESPONSE, this.processResponse);
 
         this.pubsub.subscribe(this.pubsub.USER_ANNOUNCEMENT, this.onUserAnnouncement);
@@ -70,9 +70,9 @@ define([
         }
       },
 
-      onDisplayDocuments: function(apiQuery) {
-        this.reset();
-        ListOfThingsWidget.prototype.dispatchRequest.call(this, apiQuery);
+      dispatchRequest: function(apiQuery) {
+          this.reset();
+          ListOfThingsWidget.prototype.dispatchRequest.call(this, apiQuery);
       },
 
       checkDetails: function(){

--- a/src/styles/less/ads-less/animations.less
+++ b/src/styles/less/ads-less/animations.less
@@ -19,3 +19,10 @@
   .lh-animation(fadeOut 2s 5s linear forwards);
 
 }
+
+.lh-keyframes(~'fadeIn, 0% {opacity: 0} 100% {opacity: 1 }');
+
+
+.fade-in{
+  .lh-animation(fadeIn .2s 0s linear forwards);
+}

--- a/src/styles/less/ads-less/facets.less
+++ b/src/styles/less/ads-less/facets.less
@@ -5,31 +5,6 @@
 }
 
 
-.s-child-facet-item-closed {
-  display:inline-block;
-  width: 8px;
-  color: @brand-warning;
-  margin-left: 2px;
-  cursor: pointer;
-  z-index:1;
-  margin-top: -10px;
-  margin-bottom: -10px;
-  .icon-item-closed;
-}
-
-
-.s-child-facet-item-open {
-  display: inline-block;
-  width: 12px;
-  left: -13%;
-  color: darken(@brand-warning, 25%);
-  margin-top: -10px;
-  margin-bottom: -10px;
-  cursor: pointer;
-  z-index:1;
-  .icon-item-open;
-
-}
 
 .item-open {
   .s-item-open
@@ -42,10 +17,26 @@
 //rules for item open and closed styling
 .s-tree {
   .item-open {
-    .s-child-facet-item-open;
+    display: inline-block;
+    width: 12px;
+    color: @brand-warning;
+    left: -13%;
+    margin-top: -10px;
+    margin-bottom: -10px;
+    cursor: pointer;
+    z-index:1;
+    .icon-item-open;
   }
   .item-closed {
-    .s-child-facet-item-closed;
+    display:inline-block;
+    width: 8px;
+    color: @brand-warning;
+    margin-left: 2px;
+    cursor: pointer;
+    z-index:1;
+    margin-top: -10px;
+    margin-bottom: -10px;
+    .icon-item-closed;
   }
 
   position: relative;
@@ -101,7 +92,7 @@
 
 .s-widget .item-caret:hover {
 
-  color: darken(@brand-warning, 5%);
+  color: darken(@brand-warning, 20%);
   cursor: pointer;
 }
 

--- a/test/mocha/js/components/query_mediator.spec.js
+++ b/test/mocha/js/components/query_mediator.spec.js
@@ -257,7 +257,7 @@ define([
         qm.startSearchCycle(new ApiQuery({'q': 'foo'}), key);
 
         expect(qm._cache.size).to.be.eql(0);
-        expect(qm.reset.called).to.be.true;
+        expect(qm.reset.callCount).to.eql(1);
         expect(qm.__searchCycle.initiator).to.be.eql(key.getId());
         expect(qm.__searchCycle.waiting[key.getId()]).to.be.defined;
         expect(pubSpy.lastCall.args[0]).to.be.eql(PubSubEvents.INVITING_REQUEST);
@@ -269,7 +269,26 @@ define([
           done();
         }, 5);
 
+
+        //if the queries match, the mediator checks to see if the query came from the search widget
+        qm.app = {getPluginOrWidgetName : function(){return false}, getService : sinon.spy(function(){return {navigate: sinon.spy()}})}
+        qm.startSearchCycle(new ApiQuery({'q': 'foo'}), key);
+
+        //same query, shouldn't have an effect other than navigation
+        expect(qm.reset.callCount).to.eql(1);
+        expect(qm.app.getService.callCount).to.eql(1);
+
+
+
+
+
+
+
+
+
       });
+
+
 
       it("responds to EXECUTE_REQUEST signal", function(done) {
         var x = createTestQM();


### PR DESCRIPTION
Hi Roman,
This fixes the child facet problem as well as making the "back to search page" process much faster. Basically the results and facets widgets check against their _currentQuery to see if a new dispatchRequest call is really necessary. I know early on you said you didn't want to do this, but the speed improvement is really noticeable. Can you take a look when you get a chance?