### PR TITLE
Issue #451 'undefined' values popping up for baseURL and ISBN

### DIFF
--- a/src/js/mixins/link_generator_mixin.js
+++ b/src/js/mixins/link_generator_mixin.js
@@ -99,7 +99,7 @@ var linkGenerator = {
           //   - the user HAS a library link server
 
           if (!l.access && !scan_available && link_server){
-            var openURL = new OpenURLGenerator(data);
+            var openURL = new OpenURLGenerator(data, link_server);
             openURL.createOpenURL();
             electr_link = openURL.openURL;
             openUrl = true;

--- a/src/js/mixins/openurl_generator.js
+++ b/src/js/mixins/openurl_generator.js
@@ -171,7 +171,7 @@ define([], function() {
                 'issn': this.rft_issn,
                 'id': this.id,
                 'genre': this.genre,
-                'isbn': this.isbn
+                'isbn': this.rft_isbn
             };
         };
 

--- a/test/mocha/js/mixins/link_generator_mixin.spec.js
+++ b/test/mocha/js/mixins/link_generator_mixin.spec.js
@@ -173,7 +173,7 @@ define(['js/mixins/link_generator_mixin'],
           "doi": ["10.1093/mnras/stv960"],
           "issue": 1,
           "issn": ["0035-8711"],
-          "link_server": "test"
+          "link_server": "MyBaseURL"
         };
 
         var stub_links_data = [
@@ -185,6 +185,7 @@ define(['js/mixins/link_generator_mixin'],
         // Check that an openURL is created
         var output = mixin.getTextAndDataLinks(stub_links_data, stub_meta_data.bibcode, stub_meta_data);
         expect(_.where(output.text, {title : "Publisher Article"})[0]["link"]).to.contain("doi:10.1093/mnras/stv960");
+        expect(_.where(output.text, {title : "Publisher Article"})[0]["link"]).to.contain("MyBaseURL");
         expect(_.where(output.text, {title : "Publisher Article"})[0]["openUrl"]).to.eql(true);
 
       });

--- a/test/mocha/js/mixins/openurl_generator.spec.js
+++ b/test/mocha/js/mixins/openurl_generator.spec.js
@@ -226,11 +226,12 @@ define(
                     "pub": "Monthly Notices of the Royal Astronomical Society",
                 };
 
-                var openURL = new OpenURLGenerator(false_meta_data);
+                var openURL = new OpenURLGenerator(false_meta_data, 'test');
 
                 // Create the open URL
                 openURL.createOpenURL();
                 expect(openURL.openURL).to.not.contain('false');
+                expect(openURL.openURL).to.not.contain('undefined');
 
                 // Hackish comparison
                 // Split both urls based on the &


### PR DESCRIPTION
This closes issue #451.

baseURL was not passed to the OpenURLGenerator in the LinkGeneratorMixin, meaning
all baseURLs would be of the form 'undefined'. I have added the paramter to be
passed in the LinkGeneratorMixin, and added a check in the test for the Mixin to
ensure the baseURL is set correctly this way.

ISBN was being set by a non-existent object attribute 'this.isbn' and should have
been 'this.rft_isbn'. This has been updated. The tests have been modified to check
that no 'undefined' values are found in the object, which would highlight any behaviour
like that of the ISBN.