### PR TITLE
router uses replace=true

### DIFF
--- a/src/js/apps/discovery/router.js
+++ b/src/js/apps/discovery/router.js
@@ -43,6 +43,21 @@ define([
         }
       },
 
+      /*
+      * if you don't want the navigator to duplicate the route in history,
+      * use this function instead of pubsub.publish(pubsub.NAVIGATE ...)
+      * */
+
+      routerNavigate: function (route, options) {
+
+        var options = options || {};
+        //this tells navigator not to create 2 history entries, which causes
+        //problems with the back button
+        _.extend(options, {replace : true});
+       this.pubsub.publish(this.pubsub.NAVIGATE, route, options);
+
+      },
+
       routes: {
         "": "index",
         'index/(:query)': 'index',
@@ -63,7 +78,7 @@ define([
       },
 
       index: function (query) {
-        this.pubsub.publish(this.pubsub.NAVIGATE, 'index-page');
+        this.routerNavigate('index-page');
       },
 
       search: function (query) {
@@ -110,7 +125,7 @@ define([
               navigateString = "Show"+ subPage[0].toUpperCase() + subPage.slice(1);
               href =  "#abs/" + bibcode + "/" + subPage;
             }
-            self.pubsub.publish(self.pubsub.NAVIGATE, navigateString, {href : href});
+            self.routerNavigate(navigateString, {href : href});
           },
           fail: function() {
             console.log('Cannot identify page to load, bibcode: ' + bibcode);
@@ -214,17 +229,17 @@ define([
         if (subView && !_.contains(["login", "register", "reset-password-1", "reset-password-2"], subView)){
           throw new Error("that isn't a subview that the authentication page knows about")
         }
-        this.pubsub.publish(this.pubsub.NAVIGATE, 'authentication-page', {subView: subView});
+        this.routerNavigate('authentication-page', {subView: subView});
       },
 
       settingsPage : function(subView){
         //possible subViews: "token", "password", "email", "preferences"
         if (_.contains(["token", "password", "email", "delete"], subView)){
-          this.pubsub.publish(this.pubsub.NAVIGATE, 'UserSettings', {subView: subView});
+          this.routerNavigate('UserSettings', {subView: subView});
         }
         else if ("preferences" == subView || !subView){
           //show preferences if no subview provided
-          this.pubsub.publish(this.pubsub.NAVIGATE, 'UserPreferences');
+          this.routerNavigate('UserPreferences');
         }
         else {
           throw new Error("did not recognize user page");
@@ -238,17 +253,17 @@ define([
           var subView = subView || "library";
           if (_.contains(["library", "admin"], subView )){
 
-            this.pubsub.publish(this.pubsub.NAVIGATE, 'IndividualLibraryWidget', {sub : subView, id : id});
+            this.routerNavigate('IndividualLibraryWidget', {sub : subView, id : id});
           }
           else if(_.contains(["export", "metrics", "visualization"], subView)) {
 
             subView = "library-" + subView;
 
             if (subView == "library-export"){
-              this.pubsub.publish(this.pubsub.NAVIGATE, subView, {sub : subData || "bibtex", id : id});
+              this.routerNavigate(subView, {sub : subData || "bibtex", id : id});
             }
             else if (subView == "library-metrics"){
-              this.pubsub.publish(this.pubsub.NAVIGATE, subView, { id : id});
+              this.routerNavigate(subView, { id : id});
 
             }
             else if (subView == "library-visualization"){
@@ -262,12 +277,12 @@ define([
         }
         else {
           //main libraries view
-          this.pubsub.publish(this.pubsub.NAVIGATE, "AllLibrariesWidget", "libraries");
+          this.routerNavigate("AllLibrariesWidget", "libraries");
         }
       },
 
       homePage : function(subView){
-        this.pubsub.publish(this.pubsub.NAVIGATE, 'home-page', {subView: subView});
+        this.routerNavigate('home-page', {subView: subView});
       },
 
       noPageFound : function() {

--- a/src/js/components/navigator.js
+++ b/src/js/components/navigator.js
@@ -60,6 +60,7 @@ define(['underscore',
        * Responds to PubSubEvents.NAVIGATE signal
        */
       navigate: function(ev, arg1, arg2) {
+
         if (!this.router || ! (this.router instanceof Backbone.Router)) {
           throw new Error('Navigator must be given \'router\' instance');
         }
@@ -84,11 +85,14 @@ define(['underscore',
           this.handleTransitionError(transition, e, arguments);
         }
 
+        //router can communicate directly with navigator to replace url
+        var replace = arg1 && arg1.replace ? true : false;
+
         if (transition.route) {
           // update the History object
           this.router.navigate(
             transition.route,
-            {trigger: transition.trigger || false, replace: transition.replace || false}
+            {trigger: transition.trigger || false, replace: replace || transition.replace || false}
           );
         }
       },

--- a/src/js/components/query_mediator.js
+++ b/src/js/components/query_mediator.js
@@ -98,7 +98,7 @@ define(['underscore',
         if ((JSON.stringify(apiQuery.toJSON()) == JSON.stringify(this.mostRecentQuery.toJSON())) &&
           (this.app.getPluginOrWidgetName(senderKey.getId()) != "widget:SearchWidget")){
           //simply navigate to search results page, widgets are already stocked with data
-           this.app.getService('Navigator').navigate('results-page');
+           this.app.getService('Navigator').navigate('results-page', {replace : true});
            return
         }
 

--- a/src/js/widgets/list_of_things/templates/results-container-template.html
+++ b/src/js/widgets/list_of_things/templates/results-container-template.html
@@ -38,8 +38,7 @@
 
     {{#if operator}}
         <div class="s-operator">
-            view this list in a search results page:<br/>
-            <a href="#search/q={{queryOperator}}(bibcode:{{bibcode}})" class="btn btn-sm btn-primary-faded"><i class="fa fa-search"></i> {{queryOperator}}(bibcode:{{bibcode}})</a>
+            <a href="#search/q={{queryOperator}}(bibcode:{{bibcode}})" class="btn btn-sm btn-primary-faded"><i class="fa fa-search"></i> view this list in a search results page</a>
          </div>
     {{/if}}
 

--- a/test/mocha/js/widgets/list_of_things_widget.spec.js
+++ b/test/mocha/js/widgets/list_of_things_widget.spec.js
@@ -269,7 +269,7 @@ define(['marionette',
         var $w = $(view.render().el);
         $('#test').append($w);
 
-        expect($("#test .s-operator").html().trim()).to.eql('view this list in a search results page:<br>\n            <a href="#search/q=citations(bibcode:foo)" class="btn btn-sm btn-primary-faded"><i class="fa fa-search"></i> citations(bibcode:foo)</a>');
+        expect($("#test .s-operator").html().trim()).to.eql('<a href="#search/q=citations(bibcode:foo)" class="btn btn-sm btn-primary-faded"><i class="fa fa-search"></i> view this list in a search results page</a>');
 
       });
 


### PR DESCRIPTION
Hi Roman,

This fixes the back button problem.
I'm not totally sure if the change in src/js/components/query_mediator.js is right for all situations, can you take a look and tell me what you think? 

Basically you need to use {replace: true} for all cases when the call to navigate is coming from the router, so you don't put 2 entries in history when there should be only 1.