### PR TITLE
Issue #324

### DIFF
--- a/src/js/bugutils/minimal_pubsub.js
+++ b/src/js/bugutils/minimal_pubsub.js
@@ -81,13 +81,7 @@ define(['underscore', 'backbone',
           }
           var defer = $.Deferred();
           defer.done(function() {
-            if (response && response.state() == 'rejected' && context.fail) {
-              context.fail.call(context.context, response);
-            }
-            else {
               context.done.call(context.context, response);
-            }
-
           });
           defer.resolve(response);
           return defer.promise();

--- a/src/js/bugutils/minimal_pubsub.js
+++ b/src/js/bugutils/minimal_pubsub.js
@@ -81,7 +81,13 @@ define(['underscore', 'backbone',
           }
           var defer = $.Deferred();
           defer.done(function() {
-            context.done.call(context.context, response);
+            if (response && response.state() == 'rejected' && context.fail) {
+              context.fail.call(context.context, response);
+            }
+            else {
+              context.done.call(context.context, response);
+            }
+
           });
           defer.resolve(response);
           return defer.promise();

--- a/src/js/modules/orcid/orcid_api.js
+++ b/src/js/modules/orcid/orcid_api.js
@@ -118,7 +118,7 @@ define([
           null,
           {
             fail: function() {
-              ret.reject();
+              ret.reject(arguments);
             },
             done: function(res) {
               ret.resolve(res);

--- a/test/mocha/js/components/user.spec.js
+++ b/test/mocha/js/components/user.spec.js
@@ -7,8 +7,8 @@ define([
   'js/components/json_response',
   'js/components/api_query',
   'js/services/api',
-  'js/components/app_storage'
-
+  'js/components/app_storage',
+  'js/modules/orcid/module'
 ], function(
   _,
   User,
@@ -18,7 +18,8 @@ define([
   JsonResponse,
   ApiQuery,
   Api,
-  AppStorage
+  AppStorage,
+  OrcidModule
   ){
 
  describe("User Object", function(){
@@ -110,6 +111,116 @@ define([
        "__facade__",
        "mixIn"
      ]);
+
+   });
+
+   it('orcid settings reset if the contact with the OrcidApi gives a 401', function() {
+
+     var api = new Api();
+     var minsub = new MinSub({verbose: true, Api: api});
+
+     this.server = sinon.fakeServer.create();
+     this.server.autoRespond = false;
+     this.server.respondWith(/.*/,
+         [401, { "Content-Type": "application/json" }, JSON.stringify({"you suck": "YOU FAILED"})]);
+
+     //var minsub = new (MinSub.extend({
+     //  request: function(apiRequest) {}
+     //}))({verbose: false});
+
+     // Activate the OrcidApi so that the User object can retrieve it from the BeeHive
+     minsub.beehive.addObject('DynamicConfig', {
+            orcidClientId: 'APP-P5ANJTQRRTMA6GXZ',
+            orcidApiEndpoint: 'https://api.orcid.org',
+            orcidRedirectUrlBase: 'http://localhost:8000',
+            orcidLoginEndpoint: 'https://api.orcid.org/oauth/authorize'
+     });
+     var oModule = new OrcidModule();
+     oModule.activate(minsub.beehive);
+     var orcidApi = minsub.beehive.getService('OrcidApi');
+
+     // Lets watch the signOut method and see if it is called
+     sinon.spy(orcidApi, 'signOut');
+
+     // Add the user to the beehive, and activate stuff
+     var user = new User();
+     minsub.beehive.addObject("User", user);
+     user.activate(minsub.beehive);
+
+     // Set some defaults that mimicks that the user is logged in to Orcid
+     user.setOrcidMode(1);
+     orcidApi.authData = {};
+
+     // Lets watch the setOrcidMode method and see if it is called
+     sinon.spy(user, 'setOrcidMode');
+
+     // Publish the event "Application Starting" or "APP_STARTING" to PubSub
+     minsub.publish(minsub.APP_STARTING);
+     this.server.respond();
+
+     // The user object should reset everything
+     expect(orcidApi.signOut.called).to.eql(true);
+     expect(user.setOrcidMode.called).to.eql(true);
+     expect(orcidApi.authData).to.eql(null);
+     expect(user.isOrcidModeOn()).to.eql(0);
+
+     minsub.destroy();
+     this.server.restore();
+
+   });
+
+   it('orcid settings do not reset if the contact with the OrcidApi gives anything but a 401', function() {
+
+     var api = new Api();
+     var minsub = new MinSub({verbose: true, Api: api});
+
+     this.server = sinon.fakeServer.create();
+     this.server.autoRespond = false;
+     this.server.respondWith(/.*/,
+         [500, { "Content-Type": "application/json" }, JSON.stringify({"you suck": "YOU FAILED"})]);
+
+     //var minsub = new (MinSub.extend({
+     //  request: function(apiRequest) {}
+     //}))({verbose: false});
+
+     // Activate the OrcidApi so that the User object can retrieve it from the BeeHive
+     minsub.beehive.addObject('DynamicConfig', {
+       orcidClientId: 'APP-P5ANJTQRRTMA6GXZ',
+       orcidApiEndpoint: 'https://api.orcid.org',
+       orcidRedirectUrlBase: 'http://localhost:8000',
+       orcidLoginEndpoint: 'https://api.orcid.org/oauth/authorize'
+     });
+     var oModule = new OrcidModule();
+     oModule.activate(minsub.beehive);
+     var orcidApi = minsub.beehive.getService('OrcidApi');
+
+     // Lets watch the signOut method and see if it is called
+     sinon.spy(orcidApi, 'signOut');
+
+     // Add the user to the beehive, and activate stuff
+     var user = new User();
+     minsub.beehive.addObject("User", user);
+     user.activate(minsub.beehive);
+
+     // Set some defaults that mimicks that the user is logged in to Orcid
+     user.setOrcidMode(1);
+     orcidApi.authData = {};
+
+     // Lets watch the setOrcidMode method and see if it is called
+     sinon.spy(user, 'setOrcidMode');
+
+     // Publish the event "Application Starting" or "APP_STARTING" to PubSub
+     minsub.publish(minsub.APP_STARTING);
+     this.server.respond();
+
+     // The user object should reset everything
+     expect(orcidApi.signOut.called).to.eql(false);
+     expect(user.setOrcidMode.called).to.eql(false);
+     expect(orcidApi.authData).to.eql({});
+     expect(user.isOrcidModeOn()).to.eql(1);
+
+     minsub.destroy();
+     this.server.restore();
 
    });
 


### PR DESCRIPTION
This handles the scenario in which a user's Orcid token is revoked, and
they revisit the ADS before the application has forgotten the token.

It will only revoke the token if the response from the Orcid API contains
an 'Unauthorized'/401 error.

I have left modifications inside src/js/bugutils/minimal_pubsub.js made
by @romanchyla that allows failed promises to be forwarded correctly
within the unit tests.