### PR TITLE
f

### DIFF
--- a/src/js/apps/discovery/navigator.js
+++ b/src/js/apps/discovery/navigator.js
@@ -472,6 +472,8 @@ define([
           this.route = data.href;
         });
         this.set('ShowPaperMetrics', function() {
+
+          app.getWidget("ShowPaperMetrics").renderGraphs();
           //set left hand nav panel correctly
           app.getWidget("DetailsPage").setActive("ShowPaperMetrics");
           app.getObject('MasterPageManager').show('DetailsPage',

--- a/src/js/bugutils/minimal_pubsub.js
+++ b/src/js/bugutils/minimal_pubsub.js
@@ -69,8 +69,8 @@ define(['underscore', 'backbone',
       this.pubsub.debug = true;
       this.beehive.addService('PubSub', this.pubsub);
       var self = this;
-      this.beehive.addService('Api', options.Api || {
-        request: function(req, context) {
+      var Api = {
+        request: function (req, context) {
           self.requestCounter += 1;
           if (!context) {
             context = req.get('options');
@@ -80,12 +80,15 @@ define(['underscore', 'backbone',
             console.log('[MinSub]', 'request', self.requestCounter, response);
           }
           var defer = $.Deferred();
-          defer.done(function() {
-              context.done.call(context.context, response);
+          defer.done(function () {
+            context.done.call(context.context, response);
           });
           defer.resolve(response);
           return defer.promise();
-        }});
+        }
+      };
+      this.beehive.addService("Api", options.Api || Api);
+
       this.beehive.addObject('QueryMediator', new QueryMediator({
         recoveryDelayInMs: 0,
         shortDelayInMs: 0,

--- a/src/js/page_managers/toc_controller.js
+++ b/src/js/page_managers/toc_controller.js
@@ -73,11 +73,9 @@ define([
         else if (event == 'broadcast-payload'){
           this.broadcast('page-manager-message', event, data);
         }
-
         else if (event == "navigate"){
           this.pubsub.publish(this.pubsub.NAVIGATE, data.navCommand, data.sub);
         }
-
         else if (event == "apply-function"){
           data.func.apply(this);
         }

--- a/src/js/widgets/metrics/templates/citations_table.html
+++ b/src/js/widgets/metrics/templates/citations_table.html
@@ -8,11 +8,11 @@
     <th>
 
     </th>
-    <th>
+    <th class="hidden-abstract-page">
         Totals
 
     </th>
-    <th>
+    <th class="hidden-abstract-page">
         Refereed
 
     </th>
@@ -20,7 +20,7 @@
 </tr>
 </thead>
 
-<tr>
+<tr class="hidden-abstract-page">
 
     <td>
         Number of citing papers
@@ -32,7 +32,7 @@
     <td>
         {{ numberOfCitingPapers.[0] }}
     </td>
-    <td>
+    <td class="hidden-abstract-page">
         {{ numberOfCitingPapers.[1] }}
     </td>
 
@@ -45,7 +45,7 @@
     <td>
         {{ totalCitations.[0]}}
     </td>
-    <td>
+    <td class="hidden-abstract-page">
         {{ totalCitations.[1] }}
     </td>
 
@@ -58,13 +58,13 @@
     <td>
         {{ numberOfSelfCitations.[0] }}
     </td>
-    <td>
+    <td class="hidden-abstract-page">
         {{  numberOfSelfCitations.[1] }}
     </td>
 
 </tr>
 
-<tr>
+<tr class="hidden-abstract-page">
     <td> Average citations </td>
     <td>
         <i class="icon-help" data-toggle="popover" title="<b>Average Citations</b>" data-content="The total number of citations divided by the number of papers."></i>
@@ -77,7 +77,7 @@
     </td>
 
 </tr>
-<tr>
+<tr class="hidden-abstract-page">
     <td> Median citations </td>
     <td>
         <i class="icon-help" data-toggle="popover" title="<b>Median Citations</b>" data-content="The median of the citation distribution."></i>
@@ -99,7 +99,7 @@
     <td>
         {{ normalizedCitations.[0] }}
     </td>
-    <td>
+    <td class="hidden-abstract-page">
         {{ normalizedCitations.[1] }}
     </td>
 
@@ -113,12 +113,12 @@
     <td>
         {{ refereedCitations.[0] }}
     </td>
-    <td>
+    <td class="hidden-abstract-page">
         {{  refereedCitations.[1] }}
     </td>
 
 </tr>
-<tr>
+<tr class="hidden-abstract-page">
     <td> Average refereed citations  </td>
     <td>
         <i class="icon-help" data-toggle="popover" title="<b>Average Refereed Citations</b>" data-content="The average number of citations from refereed publications to all/refereed publications in the list."></i>
@@ -132,7 +132,7 @@
 
 </tr>
 
-<tr>
+<tr class="hidden-abstract-page">
     <td> Median refereed citations  </td>
     <td>
         <i class="icon-help" data-toggle="popover" title="<b>Median Refereed Citations</b>" data-content="The average median of citations from refereed publications to all refereed publications in the list."></i>
@@ -153,7 +153,7 @@
     <td>
         {{ normalizedRefereedCitations.[0] }}
     </td>
-    <td>
+    <td class="hidden-abstract-page">
         {{ normalizedRefereedCitations.[1]  }}
     </td>
 

--- a/src/js/widgets/metrics/templates/metrics_container.html
+++ b/src/js/widgets/metrics/templates/metrics_container.html
@@ -1,6 +1,14 @@
 <span class="s-large-close close-widget">x</span>
 <div class="metrics-metadata s-metrics-metadata">
 </div>
+
+     <!--used by widget when it is on the abstract page-->
+    {{#if title}}
+        <div style="padding-left:4%">
+            <h4 class="s-list-description">Metrics for</h4>
+            <h2 class="s-article-title">{{title}}</h2>
+        </div>
+    {{/if}}
 <div class="s-metrics-section" id="papers">
     <div class="s-metrics-title">
         <h3>Papers</h3>

--- a/src/js/widgets/metrics/templates/paper_table.html
+++ b/src/js/widgets/metrics/templates/paper_table.html
@@ -24,7 +24,6 @@
         <td>Number of papers</td>
         <td>
             <i class="icon-help" data-toggle="popover" title="<b>Number of Papers</b>" data-content="The total number of papers."></i>
-
         </td>
         <td>
             {{ totalNumberOfPapers.[0] }}

--- a/src/js/widgets/metrics/templates/reads_table.html
+++ b/src/js/widgets/metrics/templates/reads_table.html
@@ -6,11 +6,11 @@
         <th>
 
         </th>
-        <th>
+        <th class="hidden-abstract-page">
             Totals
 
         </th>
-        <th>
+        <th class="hidden-abstract-page">
             Refereed
 
         </th>
@@ -30,12 +30,12 @@
         <td>
             {{ totalNumberOfReads.[0] }}
         </td>
-        <td>
+        <td class="hidden-abstract-page">
             {{ totalNumberOfReads.[1]  }}
         </td>
 
     </tr>
-    <tr>
+    <tr class="hidden-abstract-page">
         <td> Average number of reads </td>
         <td>
             <i class="icon-help" data-toggle="popover" title="<b>Average Number of Reads</b>" data-content="The total number of reads divided by the number of papers."></i>
@@ -43,12 +43,12 @@
         <td>
             {{ averageNumberOfReads.[0] }}
         </td>
-        <td>
+        <td class="hidden-abstract-page">
             {{ averageNumberOfReads.[1] }}
         </td>
 
     </tr>
-<tr>
+ <tr class="hidden-abstract-page">
     <td> Median number of reads </td>
     <td>
         <i class="icon-help" data-toggle="popover" title="<b>Median Number of Reads</b>" data-content="The median of the reads distribution."></i>
@@ -56,7 +56,7 @@
     <td>
         {{ medianNumberOfReads.[0] }}
     </td>
-    <td>
+    <td class="hidden-abstract-page">
         {{ medianNumberOfReads.[1] }}
     </td>
 
@@ -70,12 +70,12 @@
     <td>
         {{ totalNumberOfDownloads.[0] }}
     </td>
-    <td>
+    <td class="hidden-abstract-page">
         {{ totalNumberOfDownloads.[1] }}
     </td>
 
 </tr>
-<tr>
+<tr class="hidden-abstract-page">
     <td> Average number of downloads </td>
     <td>
         <i class="icon-help" data-toggle="popover" title="<b>Average Number of Downloads</b>" data-content="The total number of downloads divided by the number of papers."></i>
@@ -83,13 +83,13 @@
     <td>
         {{ averageNumberOfDownloads.[0] }}
     </td>
-    <td>
+    <td class="hidden-abstract-page">
         {{ averageNumberOfDownloads.[1]  }}
     </td>
 
 </tr>
 
-<tr>
+<tr class="hidden-abstract-page">
     <td> Median number of downloads </td>
     <td>
         <i class="icon-help" data-toggle="popover" title="<b>Median Number of Downloads</b>" data-content="The median of the downloads distribution."></i>
@@ -97,7 +97,7 @@
     <td>
         {{ medianNumberOfDownloads.[0] }}
     </td>
-    <td>
+    <td class="hidden-abstract-page">
         {{ medianNumberOfDownloads.[1] }}
     </td>
 

--- a/src/js/widgets/recommender/templates/recommender_template.html
+++ b/src/js/widgets/recommender/templates/recommender_template.html
@@ -1,8 +1,7 @@
 {{#if items}}
 <div>
-    <h4 class="s-right-col-widget-title">Suggested Articles <br/><i>(experimental feature)</i></h4>
-
     <i class="icon-help pull-right" style="margin-top:7px" data-toggle="popover" data-placement="left" data-content="These recommendations are based on a number of factors, including text similarity, citations, and co-readership information." data-container=".recommender-widget"></i>
+    <h4 class="s-right-col-widget-title">Suggested Articles <br/><i>(experimental feature)</i></h4>
 </div>
 
 

--- a/src/js/wraps/abstract_page_manager/abstract-nav.html
+++ b/src/js/wraps/abstract_page_manager/abstract-nav.html
@@ -6,6 +6,7 @@
      data-ShowTableOfContents='{"title": "Volume Content", "path":"tableofcontents", "category":"view", "showCount": false}'
      data-ShowSimilar='{"title": "Similar Papers", "path":"similar", "category":"view"}'
      data-ShowGraphics='{"title": "Graphics", "path":"graphics", "showCount": false, "category":"view"}'
+     data-ShowPaperMetrics='{"title": "Metrics", "path":"metrics", "showCount": false, "category":"view"}'
      data-ShowPaperExport__bibtex='{"title": "in BibTEX", "path":"export/bibtex", "category":"export", "alwaysThere":"true"}'
      data-ShowPaperExport__aastex='{"title": "in AASTex", "path":"export/aastex", "category":"export", "alwaysThere":"true"}'
      data-ShowPaperExport__endnote='{"title": "in Endnote", "path":"export/endnote", "category":"export", "alwaysThere":"true"}'

--- a/src/js/wraps/abstract_page_manager/abstract-page-layout.html
+++ b/src/js/wraps/abstract_page_manager/abstract-page-layout.html
@@ -34,6 +34,8 @@
                         <div data-widget="ShowSimilar" data-debug="true"/>
                         <div data-widget="ShowGraphics"/>
                         <div data-widget="ShowPaperExport"></div>
+                        <div data-widget="ShowPaperMetrics"></div>
+
                     </div>
                 </div>
             </div>

--- a/src/js/wraps/paper_metrics.js
+++ b/src/js/wraps/paper_metrics.js
@@ -1,78 +1,105 @@
 
 define([
-    'underscore',
-    'jquery',
+
     'js/widgets/metrics/widget',
-    'js/widgets/base/base_widget',
     'js/components/api_query',
-    'js/components/json_response'
+
   ],
 
   function (
-    _,
-    $,
     MetricsWidget,
-    BaseWidget,
-    ApiQuery,
-    JsonResponse
+    ApiQuery
     ) {
 
-    var Widget = BaseWidget.extend({
-      initialize : function(options) {
-        // other widgets can send us data through page manager
+    var Widget = MetricsWidget.extend({
+
+
+      initialize : function(options){
+
         this.on('page-manager-message', function(event, data){
           if (event === "broadcast-payload"){
             this.ingestBroadcastedPayload(data);
           }
         });
-        BaseWidget.prototype.initialize.call(this, options);
-        this.innerWidget = new MetricsWidget();
-        this.view = this.innerWidget.view;
-      },
+        MetricsWidget.prototype.initialize.apply(this, arguments);
 
-      activate: function(beehive) {
-        _.bindAll(this, "setCurrentQuery", "processResponse");
-        this.pubsub = beehive.Services.get('PubSub');
-        this.pubsub.subscribe(this.pubsub.DELIVERING_RESPONSE, this.processResponse);
-        this.innerWidget.pubsub = this.pubsub;
       },
 
       ingestBroadcastedPayload: function(data) {
-        if (data.bibcode) {
-          var q = new ApiQuery({'q': 'bibcode:' + data.bibcode});
-          this.innerWidget.setCurrentQuery(q);
-          this.innerWidget.onShow();
-        }
+        var bibcode = data.bibcode;
+        var self = this;
+        this.containerModel.set("title", data.title);
+        this.getMetrics([bibcode]).done(function(data) {
+          //check to see that there is at least 1 read/citation
+          if (self.hasReads(data) || self.hasCitations(data)){
+            self.trigger('page-manager-event', 'widget-ready', {isActive: true, widget : self});
+          }
+          });
       },
 
-      render: function() {
-        var ret = this.innerWidget.render();
-        this.el = ret.el;
-        return ret;
+      hasCitations : function(data){
+        return data["citation stats"]["total number of citations"] > 0;
       },
 
-      processResponse: function(apiResponse) {
+      hasReads : function(data){
+         return  data["basic stats"]["total number of reads"] > 0;
+      },
 
-        if (apiResponse instanceof JsonResponse) {
-          // decide if it is worth showing it
-          var stats = _.values(apiResponse.attributes["all stats"]);
-          var reads = _.values(apiResponse.attributes["all reads"]);
-          if (!(stats && reads)) return;
-          var f = function(x) {return x > 2};
-          if (!(_.filter(_.values(stats), f).length || _.filter(_.values(reads), f).length)) return;
-          this._response = apiResponse;
-          this.trigger('page-manager-event', 'widget-ready',
-            {numFound: 1});
+      activate : function(beehive){
+        _.bindAll(this, "setCurrentQuery", "processResponse");
+        var pubsub = beehive.getService("PubSub");
+        //this will have to be changed later
+        this.pubsub = pubsub;
+        pubsub.subscribe(pubsub.DELIVERING_RESPONSE, this.processResponse);
+      },
+
+      insertViews: function (data) {
+        //render the container view
+        this.view.render({title : this.containerModel.get("title")});
+        this.view.$("#indices").hide();
+        this.view.$("#papers").hide();
+        this.view.$(".metrics-metadata").hide();
+
+        //attach table views
+        if (this.hasReads(data)){
+          this.view.readsTable.show(this.childViews.readsTableView);
+          this.view.readsGraph.show(this.childViews.readsGraphView);
         }
         else {
-          this.innerWidget.processResponse(apiResponse);
+          this.view.$(this.view.readsTable.el).html("No reads found for this article.");
         }
+        if (this.hasCitations(data)){
+          this.view.citationsTable.show(this.childViews.citationsTableView);
+          this.view.citationsGraph.show(this.childViews.citationsGraphView);
+        }
+        else {
+          this.view.$(this.view.citationsTable.el).html("No citations found for this article.");
+        }
+        //some table rows need to be hidden
+        this.view.$(".hidden-abstract-page").hide();
       },
 
-      onShow: function() {
-        this.innerWidget.resetWidget();
-        this.innerWidget.processResponse(this._response);
-        this.innerWidget.childViews.papersGraphView.destroy();
+      processMetrics : function (response){
+        //how is the json response formed? need to figure out why attributes is there
+        response = response.attributes ? response.attributes : response;
+        // for now, metrics api returns errors as 200 messages, so we have to detect it
+        if ((response.msg && response.msg.indexOf('Unable to get results') > -1) || (response.status == 500)) {
+          this.closeWidget();
+          this.pubsub.publish(this.pubsub.ALERT, new ApiFeedback({
+            code: ApiFeedback.CODES.ALERT,
+            msg: 'Unfortunately, the metrics service returned error (it affects only some queries). Please try with different search parameters.',
+            modal: true
+          }));
+          return;
+        }
+        this.containerModel.set("data", response);
+      },
+
+      renderGraphs : function(){
+        var data = this.containerModel.get("data");
+        this.createTableViews(data);
+        this.createGraphViews(data);
+        this.insertViews(data);
       }
 
     });

--- a/src/styles/less/ads-less/abstract-page-widgets.less
+++ b/src/styles/less/ads-less/abstract-page-widgets.less
@@ -128,6 +128,11 @@
 
 .s-abstract-content {
   padding: 1% 0;
+
+  .s-large-close {
+    //to prevent widgets from navigating back to main page
+    display: none;
+  }
 }
 
 .s-abstract-page-layout {

--- a/src/styles/less/ads-less/general-components.less
+++ b/src/styles/less/ads-less/general-components.less
@@ -84,10 +84,10 @@ body {
   color: @brand-primary-faded;
   font-weight: 400;
   &:hover {
-    background-color:lighten(@brand-primary, 63%);
+    background-color:lighten(@brand-primary, 60%);
     border-left: 5px solid @brand-primary-faded;
   }
-  background-color: lighten(@brand-primary, 63%);
+  background-color: lighten(@brand-primary, 60%);
 }
 
 .s-nav-inactive {

--- a/src/styles/less/ads-less/metrics.less
+++ b/src/styles/less/ads-less/metrics.less
@@ -4,13 +4,10 @@
 }
 
 .s-metrics-title {
-
   .s-title-format;
-}
+  margin: 6px 2%;
 
-  .s-metrics-section {
-    min-height: 460px;
-  }
+}
 
 .s-metrics-table, .s-metrics-graph {
 
@@ -23,6 +20,7 @@
   }
 
 }
+
 
 .s-metrics-table {
   font-size : 14px;
@@ -37,9 +35,7 @@
   }
 
   @media(min-width: @screen-sm-min){
-
     width: 33%;
-
   }
 
   th {
@@ -53,19 +49,21 @@
   }
 
   tr td:nth-of-type(3), tr td:nth-of-type(4) {
-
       text-align: right;
-
   }
 
+}
+
+.s-abstract-content {
+  .s-metrics-table, .s-metrics-graph {
+    width: 100%;
+  }
 }
 
 .s-metrics-graph {
 
   @media(min-width: @screen-sm-min){
-
     width: 66%;
-
   }
 }
 
@@ -114,6 +112,10 @@
     width: 60px;
 
   }
+}
+
+.s-metrics-metadata:empty {
+  padding:0;
 }
 
 

--- a/test/mocha/js/widgets/metrics_widget.spec.js
+++ b/test/mocha/js/widgets/metrics_widget.spec.js
@@ -851,7 +851,7 @@ define([
     it("should have a function that empties the main view", function(){
 
       metricsWidget = new MetricsWidget();
-      metricsWidget.processResponse(new JsonResponse(testData));
+      metricsWidget.processMetrics(testData);
       $("#test").append(metricsWidget.view.el);
       metricsWidget.resetWidget();
 
@@ -916,7 +916,7 @@ define([
 
       var metricsWidget = new MetricsWidget();
 
-      metricsWidget.processResponse(new JsonResponse(testData));
+      metricsWidget.processMetrics(testData);
       //checking a single row from each template
       //would there be a way to check the entire rendered html in a non-messy way?
       expect(metricsWidget.childViews.papersTableView.render().$("td:contains(Number of papers)~td").eq(1).text().trim()).to.eql("30");
@@ -955,7 +955,7 @@ define([
 
       var metricsWidget = new MetricsWidget();
 
-      metricsWidget.processResponse(new JsonResponse(testData));
+      metricsWidget.processMetrics(testData);
 
       //check to see that the rendered views are inserted
 
@@ -966,41 +966,38 @@ define([
 
       done();
 
+    });
 
-    })
 
-
-    it("should request data from pubsub, then send that data to the metrics endpoint, then render the graph", function(done){
-
+    it("should request data from pubsub, then send that data to the metrics endpoint using the Api, then render the graph", function(done){
 
       var metricsWidget = new MetricsWidget();
 
       var minsub = new (MinimalPubSub.extend({
         request: function(apiRequest) {
-          if (apiRequest.toJSON().target === ApiTargets.SEARCH){
+          if (apiRequest.toJSON().target === ApiTargets.SEARCH) {
             return {
-              "responseHeader":{
-                "status":0,
-                "QTime":1,
-                "params":{
-                  "fl":"bibcode",
-                  "indent":"true",
+              "responseHeader": {
+                "status": 0,
+                "QTime": 1,
+                "params": {
+                  "fl": "bibcode",
+                  "indent": "true",
                   "rows": 200,
-                  "wt":"json",
-                  "q":"bibcode:(\"1980ApJS...44..137K\" OR \"1980ApJS...44..489B\")\n"}},
-              "response":{"numFound":2,"start":0,"docs":[
+                  "wt": "json",
+                  "q": "bibcode:(\"1980ApJS...44..137K\" OR \"1980ApJS...44..489B\")\n"}},
+              "response": {"numFound": 2, "start": 0, "docs": [
                 {
-                  "bibcode":"1980ApJS...44..489B"},
+                  "bibcode": "1980ApJS...44..489B"},
                 {
-                  "bibcode":"1980ApJS...44..137K"}]
+                  "bibcode": "1980ApJS...44..137K"}
+              ]
               }};
           }
-          //just to be explicit
-          else if (apiRequest.toJSON().target === ApiTargets.SERVICE_METRICS){
+          else if (apiRequest.toJSON().target == ApiTargets.SERVICE_METRICS) {
             return testData;
           }
-        }
-      }))({verbose: false});
+        }}))({verbose: false, hardenedApi : true});
 
       metricsWidget.activate(minsub.beehive.getHardenedInstance());
 
@@ -1070,7 +1067,7 @@ define([
             return testData;
           }
         }
-      }))({verbose: false});
+      }))({verbose: false, hardenedApi : true});
 
       var metricsWidget = new MetricsWidget();
 
@@ -1084,8 +1081,7 @@ define([
       metricsWidget.showMetricsForCurrentQuery();
       expect($("#test").find(".metrics-metadata").text().trim()).to.eql('Currently viewing metrics for 2\n    \n     papers.\n    \n \nChange to first  paper(s) (max is 2).\n Submit');
 
-
-        sinon.spy(metricsWidget.pubsub, "publish");
+      sinon.spy(metricsWidget.pubsub, "publish");
 
         $("#test").find(".metrics-metadata input").val("1");
         $("#test").find(".metrics-metadata button.submit-rows").trigger("click");
@@ -1095,7 +1091,7 @@ define([
           expect(metricsWidget.pubsub.publish.args[0][1].get("query").toJSON().rows).to.eql([1]);
           expect($("#test").find(".metrics-metadata").text().trim()).to.eql("Loading data...");
           done();
-        }, 1000)
+        }, 1000);
 
 
     });


### PR DESCRIPTION
Hi Roman,

This is adding the abstract widget to the abstract page.

It took a while because I was confused about tests -- the minsub's Api object is not accessible to widgets because it doesn't have a getHardenedInstance function, so I added an option to have that (in case the widget both uses pubsub and uses Api.request directly).

This is what it should look like, with non-relevant information removed:
![screen shot 2015-07-21 at 12 26 45 pm](https://cloud.githubusercontent.com/assets/3680488/8806272/d7e9200a-2fa3-11e5-95d8-35edb557c5ea.png)
