### PR TITLE
updated getPageVal function

### DIFF
--- a/src/js/mixins/add_stable_index_to_collection.js
+++ b/src/js/mixins/add_stable_index_to_collection.js
@@ -31,13 +31,14 @@ define(['underscore'], function (_) {
      * Returns the page number (on which the position falls)
      * It is zero-based count
      *
-     * @param position
+     * @param start (zero indexed start value of record, returned by solr)
      * @param perPage
      * @returns {number}
      */
-    getPageVal: function (position, perPage) {
-      return Math.max(0, Math.ceil(position/perPage)-1);
+    getPageVal: function (start, perPage) {
+      return Math.floor(start/perPage);
     },
+
 
     /**
      * Add 'resultsIndex' attribute into the model.

--- a/src/js/widgets/list_of_things/paginated_view.js
+++ b/src/js/widgets/list_of_things/paginated_view.js
@@ -197,6 +197,8 @@ define([
         var d = $(e.target).data("paginate");
         this.trigger('pagination:select', d);
         e.preventDefault();
+        //scroll to top in preparation for loading of new records
+        document.body.scrollTop = document.documentElement.scrollTop = 0;
       },
 
       changePerPage: _.debounce(function (e) {

--- a/src/js/widgets/list_of_things/widget.js
+++ b/src/js/widgets/list_of_things/widget.js
@@ -149,7 +149,7 @@ define([
         // this information is important for calcullation of pages
         var numFound = apiResponse.get("response.numFound");
         var perPage =  this.model.get('perPage') || (q.has("rows") ? q.get('rows')[0] : 10);
-        var start = q.has("start") ? q.get('start')[0] : 0;
+        var start = this.model.get("start");
 
         // compute the page number of this request
         var page = PaginationMixin.getPageVal(start, perPage);
@@ -223,9 +223,11 @@ define([
       updatePagination: function(options) {
         var perPage = options.perPage || this.model.get('perPage');
         var page = _.isNumber(options.page) ? options.page : null;
+        var start = this.getPageStart(page, perPage, numFound);
         var numFound = options.numFound || this.model.get('numFound');
         var numAround = options.numAround || this.model.get('numAround') || 2;
         var currentQuery = options.currentQuery || this.model.get('currentQuery') || new ApiQuery();
+
 
         // click to go to another 'page' will skip this
         if (page === null && this.collection.length) {
@@ -241,6 +243,7 @@ define([
         var showFirst = (_.pluck(pageData, "p").indexOf(1) !== -1) ? false : true;
 
         this.model.set({
+          start: start,
           perPage: perPage,
           page: page,
           numFound: numFound,
@@ -250,7 +253,6 @@ define([
           showRange: showRange,
           showFirst: showFirst
         });
-
 
         this.hiddenCollection.showRange(showRange[0], showRange[1]);
         this.collection.reset(this.hiddenCollection.getVisibleModels());

--- a/test/mocha/js/mixins/add_stable_index_to_collection.spec.js
+++ b/test/mocha/js/mixins/add_stable_index_to_collection.spec.js
@@ -74,7 +74,7 @@ define([
     it("should have a getPageVal method that returns the page number given a starting index and number of records per Page", function(){
 
       expect(PaginationMixin.getPageVal(10, 20)).to.eql(0);
-      expect(PaginationMixin.getPageVal(10, 5)).to.eql(1);
+      expect(PaginationMixin.getPageVal(10, 5)).to.eql(2);
       expect(PaginationMixin.getPageVal(11, 5)).to.eql(2);
       expect(PaginationMixin.getPageVal(11, 2)).to.eql(5);
     });

--- a/test/mocha/js/modules/orcid/orcid_extension.spec.js
+++ b/test/mocha/js/modules/orcid/orcid_extension.spec.js
@@ -19,11 +19,9 @@ define([
       beforeEach(function (done) {
         minsub = new (MinimalPubsub.extend({
           request: function (apiRequest) {
-            if (this.requestCounter % 2 === 0) {
-              return Test2();
-            } else {
-              return Test1();
-            }
+             var fakeSolrResponse = this.requestCounter % 2 == 0 ? Test2() : Test1();
+             fakeSolrResponse.response.start = apiRequest.get("query").get("start")[0];
+            return fakeSolrResponse;
           }
         }))({verbose: false});
 

--- a/test/mocha/js/widgets/list_of_things_widget.spec.js
+++ b/test/mocha/js/widgets/list_of_things_widget.spec.js
@@ -181,13 +181,15 @@ define(['marionette',
             counter++;
             var q = apiRequest.get('query');
             var ret = test1();
-            if (counter % 2 == 0)
-              ret = test2();
+            if (counter % 2 == 0){
+
+            }
 
             _.each(q.keys(), function(k) {
               ret.responseHeader.params[k] = q.get(k)[0];
             });
-            //_.extend(ret.responseHeader.params, q.toJSON());
+            //but widget is currently checking in the response.start not the responseheader
+            ret.response.start = q.get("start")[0];
             return ret;
           }
         }))({verbose: false});
@@ -202,7 +204,6 @@ define(['marionette',
         // give command to display first 20 docs; since responses are coming in
         // batches of 10; the collection will automatically ask twice
         minsub.publish(minsub.DISPLAY_DOCUMENTS, new ApiQuery({'q': 'foo:bar'}));
-
         expect($w.find("label").length).to.equal(20);
 
         // click on next page // this should trigger new request

--- a/test/mocha/js/widgets/lot_derivates.spec.js
+++ b/test/mocha/js/widgets/lot_derivates.spec.js
@@ -42,6 +42,8 @@ define([
           _.each(q.keys(), function(k) {
             ret.responseHeader.params[k] = q.get(k)[0];
           });
+          //but widget is currently checking in the response.start not the responseheader
+          ret.response.start = q.get("start")[0];
           //_.extend(ret.responseHeader.params, q.toJSON());
           return ret;
         }


### PR DESCRIPTION
and added scroll top when paging through results
updated tests

Hi Roman,
I think the two problems were: the getPageVal function was not returning the right number in all cases, and the start value was being updated based on solr responses rather than what it actually was (so if you needed to request data 2x from solr to go from records 0-20, for instance, it would update your start value to "10" when it got the second batch of results back, which caused a never ending loop).

Can you take a look and tell me if this makes sense?
I wonder if it wouldn't be more simple to forget about keeping a hidden collection and all the extra functions that come with that, and just re-request the data each time, since we are now caching solr requests? 