### PR TITLE
fixed grant facet; reducted redundant calls to refreshLogicTooltip

### DIFF
--- a/src/js/widgets/facet/container_view.js
+++ b/src/js/widgets/facet/container_view.js
@@ -36,21 +36,14 @@ define(['backbone', 'marionette',
             throw new Error('logicOptions should be null or an object with single/multiple keys and arrays of strings inside');
           }
 
-          this.on('all', function(ev, info) {
+          this.on('all', function (ev, info) {
             if (ev.indexOf('itemClicked') > -1
-              || ev.indexOf('render') > -1
-              || ev.indexOf('treeClicked') > -1) {
+              || ev.indexOf('treeClicked') > -1
+              || ev == "render:collection" )  {
               this.refreshLogicTooltip();
             }
           });
 
-          //this.on("childview:itemClicked", this.refreshLogicTooltip);
-
-          //clear out logic template when collection is reset
-          //this.on("render:collection", this.refreshLogicTooltip);
-
-          // for debugging
-          //this.on('all', function(ev) {console.log(ev, arguments)});
         }
 
         //show only tiny loading indicators, the widget_state_handling mixin will use this flag
@@ -70,7 +63,6 @@ define(['backbone', 'marionette',
         "click .widget-options.top": "onClickOptions",
         "click .widget-options.bottom": "onClickOptions",
         "click .widget-name" : "toggleWidget",
-        "click .dropdown-toggle": "enableLogic",
         "click .dropdown-menu .close": "closeLogic",
         "click .logic-container label": "onLogic"
 
@@ -105,10 +97,6 @@ define(['backbone', 'marionette',
         }
         else {
           this.disableShowMore();
-        }
-        if (this.logicOptions) {
-          this.refreshLogicTooltip();
-          this.closeLogic();
         }
       },
 
@@ -160,7 +148,7 @@ define(['backbone', 'marionette',
         if (e){
           e.stopPropagation();
         }
-        this.$(".logic-dropdown").addClass("hide").removeClass("open");
+        this.$(".logic-dropdown").addClass("hidden");
       },
 
       onLogic: function(ev) {
@@ -172,37 +160,26 @@ define(['backbone', 'marionette',
         this.trigger("containerLogicSelected", val);
       },
 
-      refreshLogicTooltip: function(){
+      refreshLogicTooltip: function(arg1){
 
         var selected = this.$(".widget-item:checked");
-        var numSelected = selected.length;
 
-        if (numSelected >= 1) {
-          //highlight filter
-          this.$(".logic-dropdown").removeClass("hide");
-          //highlight caret
-          this.$("i.main-caret").addClass("active-style");
-
-        }
-        else {
-          //unhighlight filter
-          this.$(".logic-dropdown").removeClass("open").addClass("hide");
-
-          //unhighlight caret
-          this.$("i.main-caret").removeClass("active-style");
+        if (selected.length == 0) {
+          this.$(".logic-dropdown").addClass("hidden");
+          return;
         }
 
-        //open the dropdown
-        if (numSelected === 1) {
+        //open the tooltip for single or multi logic
+        this.$(".logic-dropdown").removeClass("hidden");
+
+        if  (selected.length == 1) {
           this.$(".dropdown-menu").html(FacetTooltipTemplate({
             single: true,
             logic: this.logicOptions.single
           }));
 
-          this.$(".dropdown").addClass("open");
-
         }
-        else if (numSelected > 1) {
+        else if (selected.length > 1) {
           var multiLogic = this.logicOptions.multiple;
           if (multiLogic === "fullSet") {
             /*any multiple selection automatically grabs the full set */
@@ -217,17 +194,8 @@ define(['backbone', 'marionette',
             }))
 
           }
-          this.$(".dropdown").addClass("open");
-        }
-        else {
-
-          this.$(".dropdown-menu").html(FacetTooltipTemplate({
-            noneSelected: true
-          }));
-          this.$(".dropdown").removeClass("open");
         }
       }
-
 
     });
 

--- a/src/js/widgets/facet/templates/logic-container.html
+++ b/src/js/widgets/facet/templates/logic-container.html
@@ -2,7 +2,7 @@
 <div class="widget-name s-widget-meta widget-meta">
     <i class="main-caret item-closed"/><h3>{{title}}</h3>
     {{#unless noOptions}}  <div class="widget-options s-widget-options top hide"> {{/unless}}
-        <span class="btn-group dropdown logic-dropdown s-logic-dropdown">
+        <span class="btn-group dropdown logic-dropdown s-logic-dropdown hidden open">
             <button type="button" class="btn btn-link dropdown-toggle">
                 <span class="s-filter-image inactive-style"> <span class="caret"/>
                 </span>

--- a/src/js/widgets/facet/templates/tooltip.html
+++ b/src/js/widgets/facet/templates/tooltip.html
@@ -1,34 +1,35 @@
 {{# if noneSelected}}
-<div class="logic-container">
-	<i>To filter your search, select one or more items.</i>
+    <div class="logic-container">
+	    <i>To filter your search, select one or more items.</i>
+    </div>
 
 {{else}}
-{{#if single}}
-<div class="logic-container">
-		{{#each logic }}
-		<label>
-			<input name="operator" value="{{this}}" type="radio"> {{this}}
-		</label>
-	{{/each}}
-</div>
-{{/if}}
+        {{#if single}}
+            <div class="logic-container">
+                    {{#each logic }}
+                        <label>
+                            <input name="operator" value="{{this}}" type="radio"> {{this}}
+                        </label>
+                {{/each}}
+            </div>
+        {{/if}}
 
 
-{{#if fullSet}}
-<div class="logic-container">
-	<i>You have selected all results. Try selecting only one entry.</i>
-</div>
+        {{#if fullSet}}
+            <div class="logic-container">
+                <i>You have selected all results. Try selecting only one entry.</i>
+            </div>
 
-{{/if}}
+        {{/if}}
 
-{{#if multiLogic}}
-<div class="logic-container">
-	{{#each logic }}
-		<label>
-			<input name="operator" value="{{this}}" type="radio"> {{this}}
-		</label>
-	{{/each}}
-</div>	               
-{{/if}}
+        {{#if multiLogic}}
+            <div class="logic-container">
+                {{#each logic }}
+                    <label>
+                        <input name="operator" value="{{this}}" type="radio"> {{this}}
+                    </label>
+                {{/each}}
+            </div>
+        {{/if}}
 
 {{/if}}

--- a/src/js/widgets/facet/widget.js
+++ b/src/js/widgets/facet/widget.js
@@ -172,7 +172,6 @@ define(['backbone',
         var view = info.view;
         var paginator = info.paginator;
 
-
         if (paginator.getCycle() <= 1) {
           collection.reset(facetCollection.slice(0, view.maxDisplayNum));
         }

--- a/src/js/wraps/grants_facet.js
+++ b/src/js/wraps/grants_facet.js
@@ -23,8 +23,6 @@ define(['js/widgets/facet/factory' ], function ( FacetFactory) {
       //XXX:rca - hack ; this logic is triggerd multiple times
       // we need to prevent that
 
-      var self = this;
-
       if (conditions && _.keys(conditions).length > 0) {
 
 
@@ -43,8 +41,15 @@ define(['js/widgets/facet/factory' ], function ( FacetFactory) {
         else if (operator == 'or') {
           this.queryUpdater.updateQuery(q, fieldName, 'expand', conditions);
         }
-        else if (operator == 'exclude' || operator == 'not') {
-          this.queryUpdater.updateQuery(q, fieldName, 'exclude', conditions);
+
+        else if (operator == 'exclude' ) {
+          if (q.get(fieldName)) {
+            this.queryUpdater.updateQuery(q, fieldName, 'exclude', conditions);
+          }
+          else {
+            conditions.unshift('*:*');
+            this.queryUpdater.updateQuery(q, fieldName, 'exclude', conditions);
+          }
         }
 
         var fq = '{!type=aqp cache=false cost=150 v=$' + fieldName + '}';

--- a/src/styles/less/ads-less/search-bar.less
+++ b/src/styles/less/ads-less/search-bar.less
@@ -32,10 +32,6 @@
   color: @gray-light
 }
 
-.active-style {
-  color: @component-active-bg
-}
-
 .search-dropdown {
   position: relative;
   left: 88%;

--- a/test/mocha/js/widgets/facet_container_view.spec.js
+++ b/test/mocha/js/widgets/facet_container_view.spec.js
@@ -118,17 +118,19 @@ define([
           view.collection.add(new Backbone.Model({title: 'foo2', value: 'bar2'}));
           view.collection.add(new Backbone.Model({title: 'foo3', value: 'bar3'}));
 
-          expect(view.refreshLogicTooltip.callCount).to.be.equal(24);
+          expect(view.refreshLogicTooltip.callCount).to.be.equal(0);
+
+          view.trigger("render:collection");
+
+          expect(view.refreshLogicTooltip.callCount).to.be.equal(1);
+
+
 
           //logic menu is shown only after a selection is made
 
-          expect(view.$(".logic-dropdown").hasClass("hide")).to.be.true;
+          expect(view.$(".logic-dropdown").hasClass("hidden")).to.be.true;
           $v.find(".widget-item:first").click();
-          expect(view.$(".logic-dropdown").hasClass("hide")).to.be.false;
-
-
-
-
+          expect(view.$(".logic-dropdown").hasClass("hidden")).to.be.false;
 
           expect($v.find('.logic-container').is(':visible')).to.be.true;
           expect($v.find('.logic-container > label:eq(0) > input').val()).to.eql('limit to');
@@ -150,9 +152,7 @@ define([
           expect($v.find('.logic-container > label:eq(1) > input').val()).to.eql('or');
           expect($v.find('.logic-container > label:eq(2) > input').val()).to.eql('exclude');
 
-          // resetting the collection should close the tooltip
-          view.collection.reset();
-          expect($v.find('.logic-container').is(':visible')).to.be.false;
+
           done();
         });
 


### PR DESCRIPTION
The timeline showed that we were calling the facet method "refreshLogicTooltip" ~1200x per search! It was listening to way too many events. Now it only happens 1x per widget collection refresh, and the timeline view says that it increases the frame rate, it seems slight but noticeable (but maybe that's just because I want it to be noticeable).

I also added a condition to the grant facet function that I copied from the main "handleLogicalSelection" function
