### PR TITLE
Issue #570 Missing full-text links when openURL...

### DIFF
--- a/src/js/mixins/link_generator_mixin.js
+++ b/src/js/mixins/link_generator_mixin.js
@@ -95,7 +95,12 @@ var linkGenerator = {
 
           data = (data !== undefined) ? data : {};
           var link_server = (data.link_server !== undefined) ? data.link_server : false;
+
+          // Determine if the article has any identifiers
           var article_doi = (data.doi !== undefined) ? true : false;
+          var article_issn = (data.issn !== undefined) ? true : false;
+          var article_isbn = (data.isbn !== undefined) ? true : false;
+          var article_identifier = (article_doi || article_issn || article_isbn);
 
           // Only create an openURL if the following is true:
           //   - The article HAS a DOI
@@ -104,7 +109,7 @@ var linkGenerator = {
           //   - The user is authenticated
           //   - the user HAS a library link server
 
-          if (!l.access && !scan_available && link_server && article_doi){
+          if (!l.access && !scan_available && link_server && article_identifier){
             var openURL = new OpenURLGenerator(data, link_server);
             openURL.createOpenURL();
             electr_link = openURL.openURL;

--- a/src/js/mixins/link_generator_mixin.js
+++ b/src/js/mixins/link_generator_mixin.js
@@ -95,14 +95,16 @@ var linkGenerator = {
 
           data = (data !== undefined) ? data : {};
           var link_server = (data.link_server !== undefined) ? data.link_server : false;
+          var article_doi = (data.doi !== undefined) ? true : false;
 
           // Only create an openURL if the following is true:
+          //   - The article HAS a DOI
           //   - There is NO open access available
           //   - There is NO scan available from the ADS
           //   - The user is authenticated
           //   - the user HAS a library link server
 
-          if (!l.access && !scan_available && link_server){
+          if (!l.access && !scan_available && link_server && article_doi){
             var openURL = new OpenURLGenerator(data, link_server);
             openURL.createOpenURL();
             electr_link = openURL.openURL;

--- a/src/js/mixins/openurl_generator.js
+++ b/src/js/mixins/openurl_generator.js
@@ -148,6 +148,9 @@ define([], function() {
                 'rfr_id': this.rfr_id,
                 'rft_val_fmt': this.rft_val_fmt,
                 'rft_id': this.rft_id,
+                'issn': this.rft_issn,
+                'id': this.id,
+                'isbn': this.rft_isbn,
                 'rft.spage': this.rft_spage,
                 'rft.issue': this.rft_issue,
                 'rft.volume': this.rft_vol,
@@ -168,10 +171,7 @@ define([], function() {
                 'aulast': this.rft_aulast,
                 'aufirst': this.rft_aufirst,
                 'date': this.rft_date,
-                'issn': this.rft_issn,
-                'id': this.id,
-                'genre': this.genre,
-                'isbn': this.rft_isbn
+                'genre': this.genre
             };
         };
 

--- a/test/mocha/js/mixins/link_generator_mixin.spec.js
+++ b/test/mocha/js/mixins/link_generator_mixin.spec.js
@@ -202,7 +202,7 @@ define(['js/mixins/link_generator_mixin'],
           "doi": ["10.1093/mnras/stv960"],
           "issue": 1,
           "issn": ["0035-8711"],
-          "link_server": undefined
+          "link_server": "MyBaseURL"
         };
 
         var stub_links_data = [
@@ -249,7 +249,6 @@ define(['js/mixins/link_generator_mixin'],
           '{"title":"", "type":"electr", "instances":"", "access":""}',
           '{"title":"", "type":"gif", "instances":"", "access":"open"}'
         ];
-        var stub_link_server = undefined;
 
         // Check that an openURL is NOT created
         var output = mixin.getTextAndDataLinks(stub_links_data, stub_meta_data.bibcode, stub_meta_data);
@@ -262,7 +261,7 @@ define(['js/mixins/link_generator_mixin'],
 
         /**
          * Test passes the following situation:
-         *   - user is NOT authenticated
+         *   - user is NOT authenticated (no link server)
          *   - user has library link service
          *   - journal has NO open access
          *   - journal has NO scan available from the ADS
@@ -288,7 +287,6 @@ define(['js/mixins/link_generator_mixin'],
           '{"title":"", "type":"preprint", "instances":"", "access":"open"}',
           '{"title":"", "type":"electr", "instances":"", "access":""}'
         ];
-        var stub_link_server = undefined;
 
         // Check that an openURL is NOT created
         var output = mixin.getTextAndDataLinks(stub_links_data, stub_meta_data.bibcode, stub_meta_data);
@@ -319,16 +317,52 @@ define(['js/mixins/link_generator_mixin'],
           "volume": "451",
           "doi": ["10.1093/mnras/stv960"],
           "issue": 1,
-          "issn": ["0035-8711"]
+          "issn": ["0035-8711"],
+          "link_server": undefined
         };
 
         var stub_links_data = [
           '{"title":"", "type":"article", "instances":"", "access":""}',
           '{"title":"", "type":"preprint", "instances":"", "access":"open"}',
-          '{"title":"", "type":"electr", "instances":"", "access":""}',
-          '{"title":"", "type":"gif", "instances":"", "access":"open"}'
+          '{"title":"", "type":"electr", "instances":"", "access":""}'
         ];
-        var stub_link_server = undefined;
+
+        // Check that an openURL is NOT created
+        var output = mixin.getTextAndDataLinks(stub_links_data, stub_meta_data.bibcode, stub_meta_data);
+        expect(_.where(output.text, {title : "Publisher Article"})[0]["link"]).to.not.contain("url_ver");
+        expect(_.where(output.text, {title : "Publisher Article"})[0]["openUrl"]).to.eql(false);
+
+      });
+
+      it("should not generate an openURL at all if there is no DOI", function (){
+        /**
+         * Test passes the following situation
+         *   - user is authenticated
+         *   - user has a library link service
+         *   - journal has NO open access
+         *   - journal has NO scan available from the ADS
+         *   - journal has NO doi available
+         */
+        var stub_meta_data = {
+          "bibcode": "2015MNRAS.451.4686F",
+          "first_author": "Friis, M.",
+          "year": "2015",
+          "page": ["4686-4690"],
+          "pub": "Monthly Notices of the Royal Astronomical Society",
+          "pubdate": "2015-05-00",
+          "title": ["The warm, the excited, and the molecular gas: " +
+          "GRB 121024A shining through its star-forming galaxy"],
+          "volume": "451",
+          "issue": 1,
+          "issn": ["0035-8711"],
+          "link_server": "MyBaseUrl"
+        };
+
+        var stub_links_data = [
+          '{"title":"", "type":"article", "instances":"", "access":""}',
+          '{"title":"", "type":"preprint", "instances":"", "access":"open"}',
+          '{"title":"", "type":"electr", "instances":"", "access":""}'
+        ];
 
         // Check that an openURL is NOT created
         var output = mixin.getTextAndDataLinks(stub_links_data, stub_meta_data.bibcode, stub_meta_data);

--- a/test/mocha/js/mixins/link_generator_mixin.spec.js
+++ b/test/mocha/js/mixins/link_generator_mixin.spec.js
@@ -334,7 +334,7 @@ define(['js/mixins/link_generator_mixin'],
 
       });
 
-      it("should not generate an openURL at all if there is no DOI", function (){
+      it("should not generate an openURL at all if there is no DOI/ISSN/ISBN", function (){
         /**
          * Test passes the following situation
          *   - user is authenticated
@@ -354,7 +354,6 @@ define(['js/mixins/link_generator_mixin'],
           "GRB 121024A shining through its star-forming galaxy"],
           "volume": "451",
           "issue": 1,
-          "issn": ["0035-8711"],
           "link_server": "MyBaseUrl"
         };
 
@@ -364,10 +363,32 @@ define(['js/mixins/link_generator_mixin'],
           '{"title":"", "type":"electr", "instances":"", "access":""}'
         ];
 
+
         // Check that an openURL is NOT created
         var output = mixin.getTextAndDataLinks(stub_links_data, stub_meta_data.bibcode, stub_meta_data);
         expect(_.where(output.text, {title : "Publisher Article"})[0]["link"]).to.not.contain("url_ver");
         expect(_.where(output.text, {title : "Publisher Article"})[0]["openUrl"]).to.eql(false);
+
+        // Check that an openURL IS created
+        var identifierList = ['isbn', 'issn', 'doi'];
+        for (var i=0; i < identifierList.length; ++i){
+
+          var tempIdentifiers = identifierList.slice(0);
+          tempIdentifiers.splice(i,1);
+
+          stub_meta_data[identifierList[i]] = 'fake'
+          var output = mixin.getTextAndDataLinks(stub_links_data, stub_meta_data.bibcode, stub_meta_data);
+          expect(_.where(output.text, {title : "Publisher Article"})[0]["link"]).to.contain(identifierList[i]);
+          tempIdentifiers.forEach(function (value){
+            expect(_.where(output.text, {title : "Publisher Article"})[0]["link"]).to.not.contain(value);
+            expect(_.where(output.text, {title : "Publisher Article"})[0]["link"]).to.not.contain(value);
+          });
+
+          expect(_.where(output.text, {title : "Publisher Article"})[0]["openUrl"]).to.eql(true);
+
+          stub_meta_data[identifierList[i]] = undefined
+
+        }
 
       });
     })


### PR DESCRIPTION
This is a commit for part 1) of the requirements defined in the issue.

Modifications are such that an OpenURL is only ever generated if the object (article, journal, whatever)
has a DOI. Otherwise, it is not made at all.

A test has been included within the link generator mixin.

Some other tidying was done in minor places.