### PR TITLE
removed page controllers' redundant calls to render, etc

### DIFF
--- a/src/js/components/app_storage.js
+++ b/src/js/components/app_storage.js
@@ -28,7 +28,6 @@ define([
       },
 
       initialize: function() {
-        var that = this;
         this.on('change:selectedPapers', function(model) {
           this._updateNumSelected();
           if (this.hasPubSub())

--- a/src/js/components/application.js
+++ b/src/js/components/application.js
@@ -467,6 +467,7 @@ define([
         w = this._getWidget(name);
       }
 
+      // this happens right after the callback
       setTimeout(function() {
         defer.done(function(widget) {
           if (_.isArray(name)) {

--- a/src/js/page_managers/controller.js
+++ b/src/js/page_managers/controller.js
@@ -73,10 +73,10 @@ define([
         this.assembled = true;
         this.view.render();
 
-        var that = this;
+        var that = this, el;
         _.extend(that.widgetDoms, that.getWidgetsFromTemplate(that.view.$el));
 
-        _.each(_.keys(that.widgetDoms), function(widgetName) {
+        _.each(that.widgetDoms, function(widgetDom, widgetName) {
           if (!app.hasWidget(widgetName)) {
             delete that.widgetDoms[widgetName];
             delete that.widgets[widgetName];
@@ -84,15 +84,29 @@ define([
           }
 
           var widget = app._getWidget(widgetName);
+          if (this.persistentWidgets && this.persistentWidgets.indexOf(widgetName) > -1){
+            // this increments the counter so the widget won't be de-referenced when this
+            // page manager is disassembled
+            app._getWidget(widgetName);
+          }
+
           if (widget) {
             // maybe it is a page-manager (this is a security hole though!)
             if (widget.assemble) {
               widget.assemble(app);
             }
-            $(that.widgetDoms[widgetName]).empty().append(widget.render().el);
+
+            //reducing unneccessary rendering
+            if (widget.getEl){
+              el = widget.getEl()
+            }
+            else {
+              el = widget.render().el;
+            }
+            $(that.widgetDoms[widgetName]).empty().append(el);
             that.widgets[widgetName] = widget;
           }
-        });
+        }, this);
       },
 
       disAssemble: function(app) {

--- a/src/js/widgets/alerts/widget.js
+++ b/src/js/widgets/alerts/widget.js
@@ -87,7 +87,7 @@ define([
           });
           return;
         }
-        Marionette.ItemView.prototype.render.apply(this, arguments);
+        return Marionette.ItemView.prototype.render.apply(this, arguments);
       },
 
       onRender: function() {

--- a/src/js/widgets/base/base_widget.js
+++ b/src/js/widgets/base/base_widget.js
@@ -232,13 +232,27 @@ define([
     /**
      * Convention inside Backbone and Marionette is to return 'this'
      * - since 'this' usually refers to a 'View', we'll return the
-     * view here
+     * view's el here
+     * doesn't render unless it has to
      *
-     * @returns {view}
+     * @returns {view.el}
      */
+    getEl : function(){
+      if ( this.view.el && this.view.$el.children().length ){
+        return this.view.el
+      }
+      else {
+        return this.view.render().el;
+      }
+    },
+    /*
+    *
+    * convenience function for tests, always re-renders
+    *
+    * */
+
     render : function(){
-      this.view.render();
-      return this.view;
+      return this.view.render();
     },
 
 

--- a/src/js/widgets/search_bar/search_bar_widget.js
+++ b/src/js/widgets/search_bar/search_bar_widget.js
@@ -98,7 +98,7 @@ define([
       template: SearchBarTemplate,
 
       render : function(){
-        Marionette.ItemView.prototype.render.apply(this, arguments);
+        return Marionette.ItemView.prototype.render.apply(this, arguments);
         this.render = function(){ return this}
       },
 

--- a/src/js/widgets/sort/widget.js
+++ b/src/js/widgets/sort/widget.js
@@ -158,13 +158,13 @@ define(['marionette',
 
       onAll: function (ev, data) {
         if (ev == "sortChange") {
-          //    find current sort values
-          this.submitQuery(data)
+          //find current sort values
+          this.submitQuery(data);
         }
       },
 
       submitQuery: function (data) {
-        var apiQuery = this.getCurrentQuery();
+        var apiQuery = this.getCurrentQuery().clone();
         apiQuery.set("sort", data);
         this.getPubSub().publish(this.getPubSub().START_SEARCH, apiQuery);
       },
@@ -180,7 +180,7 @@ define(['marionette',
 
       extractSort: function (q) {
 
-        var params, sortVals;
+        var sortVals;
 
         if (q.has('sort')) {
           sortVals = q.get('sort')[0].split(/\s+/);

--- a/src/js/widgets/tabs/tabs_widget.js
+++ b/src/js/widgets/tabs/tabs_widget.js
@@ -70,7 +70,7 @@ define([
 
       this.$el.html($tempEl.html());
       _.each(this.tabs, function (t) {
-        this.$("#" + t.id).append(t.widget.render().el)
+        this.$("#" + t.id).append(t.widget.getEl());
       }, this);
 
       this.bindUIElements();

--- a/src/js/wraps/abstract_page_manager/abstract_page_manager.js
+++ b/src/js/wraps/abstract_page_manager/abstract_page_manager.js
@@ -12,6 +12,8 @@ define([
 
   var PageManager = PageManagerController.extend({
 
+    persistentWidgets : ["SearchWidget", "ShowAbstract", "ShowCitations", "ShowReferences", "tocWidget"],
+
     TOCTemplate : TOCTemplate,
 
     createView: function(options) {

--- a/src/js/wraps/discovery_mediator.js
+++ b/src/js/wraps/discovery_mediator.js
@@ -391,19 +391,27 @@ define([
           this.getPubSub().subscribe(pubsub.START_SEARCH, _.bind(function(apiQuery, senderKey) {
             var pubsub = this.getPubSub();
             var app = this.getApp();
+            var qm, widget, storage;
 
             if (!pubsub)
               return; // gone
 
-            var qm = app.getController('QueryMediator');
+            qm = app.getController('QueryMediator');
 
             if (!qm)
               return; // gone
 
-            var mpm = app.getObject('MasterPageManager');
-            var widget;
+            storage = app.getObject('AppStorage');
 
-            var storage = app.getObject('AppStorage');
+            if (storage && storage.getCurrentQuery() ){
+              try{
+                console.log("URL: ", storage.getCurrentQuery().url());
+
+              }
+              catch (e){
+
+              }
+              }
 
             //ignore repeated queries (if the widgets are loaded with data)
             if (storage && storage.hasCurrentQuery() &&

--- a/src/js/wraps/results_page_manager.js
+++ b/src/js/wraps/results_page_manager.js
@@ -8,11 +8,15 @@ define([
   PageManagerTemplate) {
 
   var PageManager = PageManagerController.extend({
+
+    persistentWidgets : ["SearchWidget", "BreadcrumbsWidget", "Sort", "ExportDropdown", "VisualizationDropdown", "AuthorFacet", "DatabaseFacet", "RefereedFacet", "KeywordFacet", "BibstemFacet", "BibgroupFacet", "DataFacet", "VizierFacet", "GrantsFacet", "Results", "OrcidBigWidget", "QueryInfo", "GraphTabs"],
+
     createView: function(options) {
       options = options || {};
       options.template = options.template || PageManagerTemplate;
       return new PageManagerView({template: PageManagerTemplate})
     }
+
   });
   return PageManager;
 });

--- a/test/mocha/js/widgets/abstract_widget.spec.js
+++ b/test/mocha/js/widgets/abstract_widget.spec.js
@@ -31,6 +31,9 @@ define(['backbone', 'marionette', 'jquery', 'js/widgets/abstract/widget',
           }
         }))({verbose: false});
 
+        var fakeAppStorage = {getHardenedInstance :function(){return this}, getCurrentQuery : function(){return new MinimalPubSub.prototype.T.QUERY()}};
+        minsub.beehive.addObject("AppStorage", fakeAppStorage);
+
       });
 
       afterEach(function(){
@@ -50,7 +53,6 @@ define(['backbone', 'marionette', 'jquery', 'js/widgets/abstract/widget',
 
         var spy = sinon.spy(aw, 'processResponse');
         aw.activate(minsub.beehive.getHardenedInstance());
-
 
         minsub.publish(minsub.DISPLAY_DOCUMENTS, minsub.createQuery({'q': 'bibcode:foo'}));
 

--- a/test/mocha/js/widgets/library_individual.spec.js
+++ b/test/mocha/js/widgets/library_individual.spec.js
@@ -337,7 +337,7 @@ define([
       var spy = sinon.spy();
       w.getPubSub = function() {return {publish : spy}};
 
-      $("#test").append(w.render().el);
+      $("#test").append(w.getEl());
 
       w.model.set({view : "library", id : "1"});
 
@@ -395,7 +395,7 @@ define([
       var spy = sinon.spy();
       w.getPubSub = function() {return {publish : spy, NAVIGATE: minsub.NAVIGATE}};
 
-      $("#test").append(w.render().el);
+      $("#test").append(w.getEl());
 
       w.model.set({view : "library", id : "1", "publicView" : true});
 
@@ -419,7 +419,7 @@ define([
 
       w.getBeeHive().getService("PubSub").publish = spy;
 
-      $("#test").append(w.render().el);
+      $("#test").append(w.getEl());
 
       w.model.set({view:"library", id : "1"});
 
@@ -524,7 +524,7 @@ define([
 
       w.activate(minsub.beehive.getHardenedInstance());
 
-      $("#test").append(w.render().el);
+      $("#test").append(w.getEl());
 
 
       w.model.set({view : "library", id : "1"});
@@ -565,7 +565,7 @@ define([
 
       w.activate(minsub.beehive.getHardenedInstance());
 
-      $("#test").append(w.render().el);
+      $("#test").append(w.getEl());
 
 
       w.model.set({view : "library", id : "1"});
@@ -616,7 +616,7 @@ define([
 
       w.activate(minsub.beehive.getHardenedInstance());
 
-      $("#test").append(w.render().el);
+      $("#test").append(w.getEl());
 
 
       w.setSubView({id : "1"});

--- a/test/mocha/js/widgets/preferences_widget.spec.js
+++ b/test/mocha/js/widgets/preferences_widget.spec.js
@@ -121,7 +121,7 @@ define([
       minsub.publish(minsub.APP_STARTED);
       minsub.publish(minsub.USER_ANNOUNCEMENT, User.prototype.USER_INFO_CHANGE, fakeMyADS);
 
-      $("#test").append(p.render().el);
+      $("#test").append(p.getEl());
 
       expect($("#test .current-link-server").length).to.eql(1);
 
@@ -168,7 +168,7 @@ define([
         anotherVal : "foo"
       } );
 
-      $("#test").append(p.render().el);
+      $("#test").append(p.getEl());
 
       expect($("#test .current-link-server").length).to.eql(0);
 

--- a/test/mocha/js/widgets/tabs_widget.spec.js
+++ b/test/mocha/js/widgets/tabs_widget.spec.js
@@ -10,9 +10,9 @@ define(['marionette', 'backbone', 'js/widgets/tabs/tabs_widget'], function (Mari
 
     beforeEach(function (done) {
       view1 = new Backbone.View()
-      view1.render = function () {
+      view1.getEl = function () {
         this.$el.html("<p>this is view 1</p>")
-        return this
+        return this.el
       }
 
       view1.remove = function(){
@@ -20,9 +20,9 @@ define(['marionette', 'backbone', 'js/widgets/tabs/tabs_widget'], function (Mari
       }
 
       view2 = new Backbone.View()
-      view2.render = function () {
+      view2.getEl = function () {
         this.$el.html("<p>this is view 2<p/>")
-        return this
+        return this.el
       }
       view2.remove = function(){
         removeCount++


### PR DESCRIPTION
In this pull request:

1. Removed redundant call to widgets’ “render” method in controller.assemble. The widgets re-render themselves anyway when they get new data, so this was adding lots of overhead: the new method getEl on the base widget attempts to avoid this if possible for the particular widget, and now rendering is snappy without having to prevent disassembling of the entire page, as was my original plan. It turns out this actually makes things a bit faster than before the refactor.

2. Page controllers can take the parameter “persistentWidgets”, which will increment the __barbarianInstances counter by 2 every time the widget is requested

3. Abstract widgets request docs from the search when they are instantiated so that the abstract texts are cached.

4. Fixed a bug where sort widget was not cloning the current apiQuery, but rather modifying it directly, preventing search cycle from starting.
