### PR TITLE
added instructions on api key page, and example query

### DIFF
--- a/src/js/widgets/user_settings/templates/api_key.html
+++ b/src/js/widgets/user_settings/templates/api_key.html
@@ -2,10 +2,26 @@
     <legend class="panel-heading"> API Token
     </legend>
     <div class="panel-body">
-        <div class="well">
-            {{#if access_token}} {{access_token}} {{else}} No token currently exists {{/if}}
+
+          <div class="input-group">
+              <input type="text" class="form-control" disabled value="{{#if access_token}}{{access_token}}{{else}} No token currently exists {{/if}}" style="cursor:text">
+              <span class="input-group-btn">
+                <button class="btn btn-success" type="submit">Generate a new key</button>
+              </span>
+        </div><!-- /input-group -->
+
+        <div class="description">
+            <br/>
+            <br/>
+            <p> This API token allows you to access ADS data programmatically. For instance, to fetch the first few document
+                ids for the query "star", make the following request: </p>
+           <p>
+               <code> curl -H Authorization:Bearer:[your token here] http://api.adsabs.harvard.edu/v1/search/query?q=star</code>
+            </p>
+            <p> Documentation on how to use the API is available on the <a href="https://github.com/adsabs/adsabs-dev-api#access-settings"> ADS API Github repo.</a></p>
+            <p> <b>Make sure to keep your API key secret to protect it from abuse.</b></p>
+            <p> If your key has been exposed publically (say, by accidentally  being commited to a Github repo) you can generate a new one by clicking on the button above. </p>
         </div>
-        <button class="btn btn-success pull-right" type="submit">Generate a new key</button>
 
 </div>
 

--- a/test/mocha/js/widgets/user_settings_widget.spec.js
+++ b/test/mocha/js/widgets/user_settings_widget.spec.js
@@ -266,12 +266,13 @@ define([
       $("#test").append(u.view.render().el);
 
       u.setSubView("token");
+      debugger
 
-      expect($("#test .well").text().trim()).to.eql("current_token");
+      expect($("#test input").val()).to.eql("current_token");
 
       $("#test button[type=submit]").click();
 
-      expect($("#test .well").text().trim()).to.eql("new_token");
+      expect($("#test input").val()).to.eql("new_token");
     });
 
   });


### PR DESCRIPTION

I added the text suggested by Alberto and Roman, it looks like this now: 

![screen shot 2015-10-07 at 12 06 31 pm](https://cloud.githubusercontent.com/assets/3680488/10343524/1dde452e-6cec-11e5-91e3-8f8e3705b815.png)
