### PR TITLE
a missing space before the grunt close string interpolation character…

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -233,7 +233,7 @@ module.exports = function(grunt) {
       options: {
         SOLR_ENDPOINT: '<%= local.solr_endpoint || "http://localhost:9000/solr/select" %>',
         API_ENDPOINT: '<%= local.api_endpoint || "http://localhost:5000/api/1" %>',
-        ORCID_OAUTH_CLIENT_ID: '<%= local.orcid_oauth_cliend_id || ""%>',
+        ORCID_OAUTH_CLIENT_ID: '<%= local.orcid_oauth_cliend_id || "" %>',
         ORCID_OAUTH_CLIENT_SECRET:'<%= local.orcid_oauth_client_secret || "" %>',
         ORCID_API_ENDPOINT :'<%= local.orcid_api_endpoint || "" %>'
       },


### PR DESCRIPTION
… (%>) was causing grunt release to run out of memory and fail to complete, which was why index.html was pointing to the wrong bumblebee.app instead of bumblebee.app.hash