### PR TITLE
404 page should replace the earlier failed pages url

### DIFF
--- a/src/js/components/navigator.js
+++ b/src/js/components/navigator.js
@@ -83,13 +83,13 @@ define(['underscore',
         }
 
         //router can communicate directly with navigator to replace url
-        var replace = arg1 && arg1.replace ? true : false;
+        var replace = ( transition.replace || arg1 && arg1.replace ) ? true : false;
 
         if (transition.route || transition.route === "") {
           // update the History object
           this.router.navigate(
-            transition.route,
-            {trigger: transition.trigger || false, replace: replace || transition.replace || false}
+              transition.route,
+              { trigger: transition.trigger || false, replace: replace }
           );
         }
       },


### PR DESCRIPTION
this will allow the users to go back to a safe url in bbb if they want to rather than trapping them in a continual bad url -->  404 page loop