### PR TITLE
switch to currenttarget instead of target

### DIFF
--- a/src/js/widgets/list_of_things/paginated_view.js
+++ b/src/js/widgets/list_of_things/paginated_view.js
@@ -199,13 +199,13 @@ define([
       changePageWithButton: function (e) {
 
         e.preventDefault();
-        var $target = $(e.target);
+        var $target = $(e.currentTarget);
         if ($target.parent().hasClass("disabled")) return;
         var transform = $target.hasClass("next-page") ? 1 : -1;
         var pageVal = this.model.get("page") + transform;
         this.trigger('pagination:select', pageVal);
 
-        if (this.resultsWidget) {analytics('send', 'event', 'interaction', 'results-list-pagination', pageVal); }
+        if (this.resultsWidget) {analytics('send', 'event', 'interaction', 'results-list-pagination', pageVal) }
       },
 
       tabOrEnterChangePageWithInput : function (e) {
@@ -215,6 +215,9 @@ define([
         if (e.keyCode == 13 || e.keyCode == 9){
           this.trigger('pagination:select', pageVal);
         }
+
+        if (this.resultsWidget) {analytics('send', 'event', 'interaction', 'results-list-pagination', pageVal) }
+
       },
 
 


### PR DESCRIPTION
The random times the next button didn't do anything reported in issue #794 was due to the fact that if you clicked directly on the caret icon rather than anywhere else on the button, the event would be ignored.  

This was because I was using the "target" value of the event (actual thing clicked) rather than "currenttarget" (element to which event was attached).