### PR TITLE
renamed #alertBox  to the clearer #page-top-alert

### DIFF
--- a/src/js/widgets/alerts/modal_view.js
+++ b/src/js/widgets/alerts/modal_view.js
@@ -29,7 +29,7 @@ define([
       //this will prevent creation of infinite modals at the end of the document as before
       if (!$("#modal-alert-content").length){
         //append to end of document
-        $("body").append('<div class="modal fade" id="alert-modal" tabindex="-1" role="dialog" aria-labelledby="alertBoxLabel" aria-hidden="true"></div>');
+        $("body").append('<div class="modal fade" id="alert-modal" tabindex="-1" role="dialog" aria-labelledby="alert-modal-label" aria-hidden="true"></div>');
         this.setElement($("#alert-modal")[0]);
       }
 

--- a/src/js/widgets/alerts/page_top_alert.js
+++ b/src/js/widgets/alerts/page_top_alert.js
@@ -17,7 +17,7 @@ define([
     },
 
     events: {
-      'click #alertBox button.close': 'close'
+      'click #page-top-alert button.close': 'close'
     },
 
     close : function(){

--- a/src/js/widgets/alerts/templates/modal_template.html
+++ b/src/js/widgets/alerts/templates/modal_template.html
@@ -1,16 +1,12 @@
 
 <!--html for modal alerts-->
-<div class="modal fade" id="alert-modal" tabindex="-1" role="dialog" aria-labelledby="alertBoxLabel" aria-hidden="true">
-
-</div>
-
 
 <div class="modal-dialog {{type}}">
         <div class="modal-content" id="modal-alert-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
 
-                <h4 class="modal-title" id="alertBoxLabel">
+                <h4 class="modal-title" id="alert-modal-label">
                     {{#compare type "danger"}}
                     <i class="icon-danger fa-2x"></i>
                     {{/compare}}

--- a/src/js/widgets/alerts/templates/page_top_alert.html
+++ b/src/js/widgets/alerts/templates/page_top_alert.html
@@ -1,5 +1,5 @@
  {{#if msg}}
-    <div class="alert alert-{{type}}" id="alertBox">
+    <div class="alert alert-{{type}}" id="page-top-alert">
         {{{msg}}}
         <button type="button" class="close"><span aria-hidden="true"><i class="fa fa-2x fa-times"></i></span><span class="sr-only">Close</span></button>
     </div>

--- a/src/js/wraps/discovery_mediator.js
+++ b/src/js/wraps/discovery_mediator.js
@@ -466,7 +466,7 @@ define([
                 msg: '<p>You will be redirected to ORCID.</p> <p>Please sign in with your ORCID credentials and click on the "authorize" button.</p><p><b>This service is experimental. Should you have any suggestions, please let us know at <a href="mailto:adshelp@cfa.harvard.edu">adshelp@cfa.harvard.edu</a></b></p><button class="btn btn-success" id="okOrcid">Take me to ORCID</button>',
                 modal: true,
                 events: {
-                  'click button#okOrcid': 'OK'
+                  'clickbutton#okOrcid': 'OK'
                 }
               }))
                 .done(function(resp) {

--- a/test/mocha/js/components/alerts_mediator.spec.js
+++ b/test/mocha/js/components/alerts_mediator.spec.js
@@ -89,13 +89,13 @@ define([
       promise = x.m.onAlert(new ApiFeedback({
         msg: 'this is <a href="foo">html</a> message',
         events: {
-          'click #alertBox a': 'foo-bar'
+          'click #page-top-alert a': 'foo-bar'
         }
       }))
       .done(function(x) {
         expect(x).to.be.eql('foo-bar');
       });
-      $w.find('#alertBox a').click();
+      $w.find('#page-top-alert a').click();
       expect(promise.state()).to.be.eql('resolved');
 
 
@@ -104,10 +104,10 @@ define([
       promise = x.m.onAlert(new ApiFeedback({
         msg: 'this is <a href="foo">html</a> message',
         events: {
-          'click #alertBox a': spy
+          'click #page-top-alert a': spy
         }
       }));
-      $w.find('#alertBox a').click();
+      $w.find('#page-top-alert a').click();
       expect(promise.state()).to.eql('resolved');
       expect(spy.called).to.be.true;
 
@@ -116,13 +116,13 @@ define([
       promise = x.m.onAlert(new ApiFeedback({
         msg: 'this is <a href="foo">html</a> message',
         events: {
-          'click #alertBox a': {
+          'click #page-top-alert a': {
             action: Alerts.ACTION.TRIGGER_FEEDBACK,
             arguments: {code: 0}
           }
         }
       }));
-      $w.find('#alertBox a').click();
+      $w.find('#page-top-alert a').click();
       expect(x.m.getPubSub().publish.called).to.be.true;
 
     });

--- a/test/mocha/js/widgets/alerts_widget.spec.js
+++ b/test/mocha/js/widgets/alerts_widget.spec.js
@@ -48,19 +48,19 @@ define([
       $('#test').append($w);
 
       widget.model.set('msg', 'this is simple message');
-      expect($w.find('#alertBox').text().indexOf('this is simple message') > -1).to.be.true;
+      expect($w.find('#page-top-alert').text().indexOf('this is simple message') > -1).to.be.true;
 
       widget.model.set('msg', '');
-      expect($w.find('#alertBox').length).to.be.eql(0);
+      expect($w.find('#page-top-alert').length).to.be.eql(0);
 
       widget.model.set('msg', 'this is <a href="foo">html</a> message');
-      expect($w.find('#alertBox a').attr('href')).to.be.eql('foo');
+      expect($w.find('#page-top-alert a').attr('href')).to.be.eql('foo');
 
       // we can pass pass events
       var promise = widget.alert({
         msg: 'this is <a href="foo">html</a> message',
         events: {
-          'click #alertBox a': {
+          'click #page-top-alert a': {
             action: Alerts.ACTION.CALL_PUBSUB,
             signal: minsub.BIG_FIRE,
             arguments: ['foo', 'bar']
@@ -71,7 +71,7 @@ define([
       var spy;
       promise.done((spy = sinon.spy()));
 
-      $w.find('#alertBox a').click();
+      $w.find('#page-top-alert a').click();
       expect(promise.state()).to.be.eql('resolved');
       expect(spy.lastCall.args[0]).to.be.eql({
         action: Alerts.ACTION.CALL_PUBSUB,
@@ -86,18 +86,18 @@ define([
       widget.alert({
         msg: 'this is <a href="foo">html</a> message',
         events: {
-          'click #alertBox a': 'foo-bar'
+          'click #page-top-alert a': 'foo-bar'
         }
       });
-      $w.find('#alertBox a').click();
+      $w.find('#page-top-alert a').click();
 
       widget.alert({
         msg: 'this is <a href="foo">html</a> message',
         events: {
-          'click #alertBox a': 'foo-bar'
+          'click #page-top-alert a': 'foo-bar'
         }
       });
-      $w.find('#alertBox a').click();
+      $w.find('#page-top-alert a').click();
 
       // if the previous handler was removed, we'll get only 2 calls
       expect(_.filter(_.flatten(widget.model.get.args), function(x) {return x == 'promise'}).length).to.be.eql(2);


### PR DESCRIPTION
the orcid button failed because i renamed the modal alert container but kept the old classname

the remaining #alertbox references were mostly correctly referring to the alert bar instead of the modal but I renamed them for clarity's sake