### PR TITLE
3 autocomplete fixes

### DIFF
--- a/src/js/widgets/search_bar/autocomplete.js
+++ b/src/js/widgets/search_bar/autocomplete.js
@@ -10,8 +10,8 @@ define([
     {value: "author:\"^\"" , label : "First Author", match: "^author"},
     {value: "author:\"^\"" , label : "First Author", match: "author:\"^"},
 
-    {value: "bibstem:\"\"" , label : "Publication", match: "bibstem:\""},
-    {value: "bibstem:\"\"", label : "Publication", match: "publication (bibstem)"},
+    {value: "bibstem:\"\"" , label : "Publication (must use bibstem)", desc: "e.g. bibstem:ApJ", match: "bibstem:\""},
+    {value: "bibstem:\"\"", label : "Publication (must use bibstem)", desc: "e.g. bibstem:ApJ", match: "publication (bibstem)"},
 
     {value: "arXiv:" , label : "arXiv ID", match: "arxiv:"},
     {value: "doi:" , label : "DOI", match: "doi:"},

--- a/src/js/widgets/search_bar/search_bar_widget.js
+++ b/src/js/widgets/search_bar/search_bar_widget.js
@@ -149,6 +149,12 @@ define([
               return;
             }
 
+            //dont look for a match if cursor is not at the end of search bar
+            if ($input.getCursorPosition() !== $input.val().length) {
+              $input.autocomplete("close");
+              return;
+            }
+
             toMatch = findActiveAndInactive(request.term).active;
             if (!toMatch)
               return
@@ -220,11 +226,16 @@ define([
 
           //re-insert actual text w/ optional addition of autocompleted stuff
           select : function( event, ui ){
+
             $input.val( $input.data("ui-autocomplete").suggestedQ);
             //move cursor before final " or )
             var final = ui.item.value.split("").reverse()[0];
             if ( final == '"' || final == ")" ){
               $input.selectRange($input.val().length - 1);
+            }
+            else {
+              //just move cursor to the end, e.g. for property: refereed
+              $input.selectRange($input.val().length);
             }
 
             analytics('send', 'event', 'interaction', 'autocomplete-used', ui.item.value);

--- a/test/mocha/js/widgets/search_bar_widget.spec.js
+++ b/test/mocha/js/widgets/search_bar_widget.spec.js
@@ -258,6 +258,17 @@ define([
       autolist.find("li").first().click();
       expect($input.val()).to.eql("author:\"\"");
 
+      //autocomplete should return unless user cursor is at end of input text
+      //so this should not activate autocomplete options
+      $input.autocomplete("search", "author:\"foo\" a");
+      var autolist = $("ul.ui-autocomplete").last();
+
+      expect(autolist.css("display")).to.eql("none");
+
+      //this has set the cursor position in the right place, so it should work
+      $input.val("author:\"foo\" a");
+      $input.selectRange($input.val().length);
+
       $input.autocomplete("search", "author:\"foo\" a");
 
       //should try to autocomplete on only the 'a' just as before


### PR DESCRIPTION
These are in response to user suggestions, specifically issue #799 and a question on twitter

-there was a firefox issue where "enter" did not de-select everything and jump the cursor to the end like it did in chrome
-there was a bug where editing things at the beginning of a search query would jump cursor to end if there was a partially finished phrase at the end that the autocomplete could match
-user on twitter was confused about the fact that "publication" was autocompleted by "bibstem:" so i tried to clarify in the description