### PR TITLE
overriding require.js waitseconds at very beginning

### DIFF
--- a/src/discovery.config.js
+++ b/src/discovery.config.js
@@ -16,6 +16,7 @@ require.config({
   }()),
 
 
+  //this will be overridden in the compiled file
   waitSeconds: 30,
 
   // Configuration we want to make available to modules of ths application

--- a/src/index.html
+++ b/src/index.html
@@ -34,6 +34,14 @@
         </div>
 </div>
 
+    <script>
+        // define waitSeconds above require script tag
+        // to override the default, until main.js loads
+        //see https://github.com/yeoman/yeoman/issues/1051
+        window.require = {
+            waitSeconds: 30
+        };
+    </script>
 
 <!-- start the discovery application -->
 <script data-main="./discovery.config"  src="./libs/requirejs/require.js"></script>


### PR DESCRIPTION
This hack is suggested (sort of) here: https://github.com/yeoman/yeoman/issues/1051 for  bundles compiled with r.js.

It definitely solves the problem, but there are probably better ways of doing it -- I just can't figure out what they are.