### PR TITLE
#1 increased Puppet timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Port 8000 is forwarded directly to the host (8000:8000). This directory is synce
 
 1. `vagrant up`
 1. `vagrant ssh`
-1. `cd /vagrant && grunt server`
+1. `cd /bumblebee && grunt server`
 
 
 dev setup - linux

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -48,5 +48,6 @@ exec {
   'grunt_cli':
     command => 'grunt setup',
     cwd     => '/bumblebee/',
+    timeout => 900,
     require => Exec['npm_install_grunt'];
 }


### PR DESCRIPTION
default timeout of 300 was insufficient over home-based internet connection
600 was also too short so it was set to 900.