### PR TITLE
Hotfix: issue#916 incorrect urls

### DIFF
--- a/src/js/widgets/network_vis/templates/default-details-template.html
+++ b/src/js/widgets/network_vis/templates/default-details-template.html
@@ -12,7 +12,7 @@
 
 <br/>
 <div>
-    <a href="http://adsabs.github.io/help/actions/visualize/#author-network" target="_blank">Learn more about the author network.</a>
+    <a href="http://adsabs.github.io/help/actions/visualize#author-network" target="_blank">Learn more about the author network.</a>
 </div>
 
 
@@ -51,6 +51,6 @@
 
 <br/>
 <p>Click on a group to learn more about the papers within the group, as well as the papers cited by those papers.</p>
-<a href="http://adsabs.github.io/help/actions/visualize/#paper-network" target="_blank">Learn more about the paper network.</a>
+<a href="http://adsabs.github.io/help/actions/visualize#paper-network" target="_blank">Learn more about the paper network.</a>
 
 {{/compare}}

--- a/src/js/widgets/network_vis/templates/not-enough-data-template.html
+++ b/src/js/widgets/network_vis/templates/not-enough-data-template.html
@@ -2,7 +2,7 @@
     <br>
     <p>  The network grouping algorithm could not generate group data for your network.</p>
     <p> This might be because the list of papers was too small or sparse to produce multiple meaningful groups.</p>
-    <p><a href="https://adsabs.github.io/help/actions/visualize/">
+    <p><a href="https://adsabs.github.io/help/actions/visualize">
         Learn more about how ADS networks are created and how they can be used.
     </a></p>
 

--- a/src/js/widgets/wordcloud/templates/wordcloud-template.html
+++ b/src/js/widgets/wordcloud/templates/wordcloud-template.html
@@ -7,7 +7,7 @@
         This visualization shows you unique and frequent words from
         a set of the top 100 search results.
         <br/>
-        <b><a href="https://adsabs.github.io/help/actions/visualize/#word-cloud" target="_blank">
+        <b><a href="https://adsabs.github.io/help/actions/visualize#word-cloud" target="_blank">
             Learn more about the concept cloud</a></b>
         <br/>
         <br/>


### PR DESCRIPTION
Minor changes to links to help pages, as kindly pointed out in #916.

Ending / on the URL does not work. Updated files with any usage of it. Checked by hand, but would suggest double checking before merge.