### PR TITLE
simplify master.js, reduce unecessary renders

### DIFF
--- a/src/js/page_managers/controller.js
+++ b/src/js/page_managers/controller.js
@@ -60,9 +60,8 @@ define([
       },
 
       /**
-       * This is the necessary step to activate the page manager; we'll render
-       * the widgets and append them inside the appropriate places inside the
-       * template
+       * Render the widgets and append them inside the appropriate places inside the
+       * template. This happens only 1x during the lifetime of the page manager
        *
        * @param app
        */
@@ -179,10 +178,6 @@ define([
         }
 
         this.triggerMethod("show");
-
-        //scroll to top
-        document.body.scrollTop = document.documentElement.scrollTop = 0;
-
         return this.view;
       },
 

--- a/src/js/wraps/discovery_mediator.js
+++ b/src/js/wraps/discovery_mediator.js
@@ -66,8 +66,6 @@ define([
         app.getObject('AppStorage').setCurrentQuery(null);
       }
 
-      this.getPubSub().publish(this.getPubSub().NAVIGATE, "results-page");
-
       if (feedback.request && feedback.request.get('target').indexOf('search') > -1 && feedback.query && !feedback.numFound) {
         var q = feedback.query;
 


### PR DESCRIPTION
- changeManager is now no longer called redundantly
- document.scrollTop is now only called when there is a change between page managers, not within them
- unnecessary functions and repetitive code has been removed