### PR TITLE
fixing tooltip usability issue

### DIFF
--- a/src/js/widgets/search_bar/search_bar_widget.js
+++ b/src/js/widgets/search_bar/search_bar_widget.js
@@ -271,7 +271,7 @@ define([
             }
           });
 
-          this.$('[data-toggle="tooltip"]').tooltip();
+          this.$('[data-toggle="tooltip"]').tooltip({ html : true });
 
         },
 

--- a/src/js/widgets/search_bar/templates/search_bar_template.html
+++ b/src/js/widgets/search_bar/templates/search_bar_template.html
@@ -14,7 +14,7 @@
                 <button class="btn btn-link btn-sm" title="limit search to abstract, title and keyword fields"
                         data-toggle="tooltip" data-field="abs" data-punc='('>Abstract
                 </button>
-                <button class="btn btn-link btn-sm" title="e.g. year:1999 or year:1999-2001" data-toggle="tooltip"
+                <button class="btn btn-link btn-sm" title="e.g. year:1999 or <br/> year:1999-2016" data-toggle="tooltip"
                         data-field="year">Year
                 </button>
                 <button class="btn btn-link btn-sm" title="search titles, abstract, and text of the articles"

--- a/src/styles/sass/ads-sass/bootstrap-overrides.scss
+++ b/src/styles/sass/ads-sass/bootstrap-overrides.scss
@@ -234,3 +234,8 @@ p {
   border-radius: 0px;
   box-shadow: none;
 }
+
+.tooltip .tooltip-inner {
+  font-size: $font-size-base;
+  padding: 6px;
+}


### PR DESCRIPTION
usability tests caught that a line break in the tooltip for the year button was confusing, and the text was slightly too small