### PR TITLE
Update of tooltip text for "fulltext"

### DIFF
--- a/src/js/widgets/search_bar/templates/search_bar_template.html
+++ b/src/js/widgets/search_bar/templates/search_bar_template.html
@@ -17,7 +17,7 @@
                 <button class="btn btn-link btn-sm" title="e.g. year:1999 or <br/> year:1999-2016" data-toggle="tooltip"
                         data-field="year">Year
                 </button>
-                <button class="btn btn-link btn-sm" title="search titles, abstract, and text of the articles"
+                <button class="btn btn-link btn-sm" title="search titles, abstract, text, keywords and acknowledgements of the articles"
                         data-toggle="tooltip" data-field="full" data-punc="(">Fulltext
                 </button>
                 <button class="btn btn-link btn-sm" title="find review articles e.g. reviews(exoplanets)"


### PR DESCRIPTION
I've updated the tooltip help text for "Fulletxt" above the query box to give a complete description of what fields are searched. If this is too much text, let's keep the original text.