### PR TITLE
moving classic form dates to search bar

### DIFF
--- a/src/js/widgets/classic_form/widget.js
+++ b/src/js/widgets/classic_form/widget.js
@@ -67,7 +67,7 @@ define([
     serializeClassic : function(){
       var qDict = {q : [], fq: []}, database, pubdateVals, dates, datestring, matchers;
       var pubdateDefaults = {
-        month_from: "00",
+        month_from: "01",
         year_from: "0000",
         month_to:  "12",
         year_to: "9999"
@@ -103,7 +103,7 @@ define([
        });
 
        datestring = "[" + dates[1] + "-" + dates[0] + "-0 TO " + dates[3] + "-" + dates[2] + "-0]";
-       qDict.fq.push("pubdate:" + datestring);
+       qDict.q.push("pubdate:" + datestring);
 
       }
 

--- a/test/mocha/js/widgets/classic_search_widget.spec.js
+++ b/test/mocha/js/widgets/classic_search_widget.spec.js
@@ -62,17 +62,18 @@ define([
 
       w.view.$("button[type=submit]").eq(0).click();
 
+
       expect(publishSpy.args[0][2].toJSON()).to.eql({
-      "q": [
-        "property:refereed property:article author:(\"Accomazzi,a\" AND \"Kurtz,M\") title:(star OR planet OR \"gliese 581\") abs:(-hawaii star) bibstem:(apj OR mnras)"
-      ],
-      "sort": [
-        "date desc"
-      ],
-      "fq": [
-        "database:(astronomy OR physics) pubdate:[2010-10-0 TO 9999-12-0]"
-      ]
-    });
+          "q": [
+            "property:refereed property:article pubdate:[2010-10-0 TO 9999-12-0] author:(\"Accomazzi,a\" AND \"Kurtz,M\") title:(star OR planet OR \"gliese 581\") abs:(-hawaii star) bibstem:(apj OR mnras)"
+          ],
+          "sort": [
+            "date desc"
+          ],
+          "fq": [
+            "database:(astronomy OR physics)"
+          ]
+});
 
       //one more
 
@@ -100,13 +101,13 @@ define([
 
       expect(publishSpy.args[1][2].toJSON()).to.eql({
         "q": [
-          "property:refereed author:(\"Accomazzi,a\") title:(star OR planet OR \"gliese 581\") abs:(-hawaii star) bibstem:(apj)"
+          "property:refereed pubdate:[2010-10-0 TO 2012-12-0] author:(\"Accomazzi,a\") title:(star OR planet OR \"gliese 581\") abs:(-hawaii star) bibstem:(apj)"
         ],
         "sort": [
           "date desc"
         ],
         "fq": [
-          "database:astronomy pubdate:[2010-10-0 TO 2012-12-0]"
+          "database:astronomy"
         ]
       });
 


### PR DESCRIPTION
fixes two problems:

1. classic form date goes in q parameter rather than fq so the user can see + edit it more easily,

2. When you just enter in a "from" year and no "from" month, "01" is the default month rather than "00" which retrieved papers from December of the previous year