### PR TITLE
quick bump up of the hard library export to search results page limit…

### DIFF
--- a/src/js/components/library_controller.js
+++ b/src/js/components/library_controller.js
@@ -304,7 +304,8 @@ define([
 
         var deferred = $.Deferred(),
             that = this,
-            maxReturned = 3000;
+            //hard limit, no more than 10,000 records can be exported to search results page
+            maxReturned = 10000;
 
         //we already have it in the cache, so just resolve + return promise
         if (this._libraryBibcodeCache[id]) {


### PR DESCRIPTION
… to 10000, slow but will have to do until someone can add bigquery to library endpoint