### PR TITLE
Bugfix: Close Persistent Error Message After Navigation

### DIFF
--- a/src/js/widgets/alerts/widget.js
+++ b/src/js/widgets/alerts/widget.js
@@ -145,6 +145,11 @@ define([
             promise: promise
           });
           return promise.promise();
+        },
+
+        closeView: function () {
+          this.view.close();
+          this.modalView.closeModal();
         }
 
       });


### PR DESCRIPTION
* Error message(s) persisting after navigating from the login page now close correctly
* Implemented `closeView` method