### PR TITLE
Add Additional Meta Tags For Twitter Cards/Open Graph

### DIFF
--- a/src/js/widgets/abstract/templates/metadata_template.html
+++ b/src/js/widgets/abstract/templates/metadata_template.html
@@ -1,4 +1,20 @@
+<meta name="og:type" content="article" data-highwire="true">
+<meta name="twitter:card" content="summary" data-highwire="true">
+
 <meta name="citation_title" content="{{title}}" data-highwire="true">
+<meta name="og:title" content="{{title}}" data-highwire="true">
+<meta name="twitter:title" content="{{title}}" data-highwire="true">
+
+<meta name="og:url" content="{{url}}" data-highwire="true">
+<meta name="twitter:url" content="{{url}}" data-highwire="true">
+
+<meta name="og:image" content="https://ui.adsabs.harvard.edu/styles/img/transparent_logo.svg" data-highwire="true">
+<meta name="twitter:image" content="https://ui.adsabs.harvard.edu/styles/img/transparent_logo.svg" data-highwire="true">
+
+{{#if abstract}}
+    <meta name="og:description" content="{{abstract}}" data-highwire="true">
+    <meta name="twitter:description" content="{{abstract}}" data-highwire="true">
+{{/if}}
 {{#each author}}
     <meta name="citation_author" content="{{this}}" data-highwire="true">
 {{/each}}
@@ -15,8 +31,8 @@
     <meta name="citation_volume" content="{{volume}}" data-highwire="true">
 {{/if}}
 {{#if issue}}
-<meta name="citation_issue" content="{{issue}}" data-highwire="true">
+    <meta name="citation_issue" content="{{issue}}" data-highwire="true">
 {{/if}}
 {{#if doi}}
-<meta name="citation_doi" content="{{doi.doi}}" data-highwire="true">
+    <meta name="citation_doi" content="{{doi.doi}}" data-highwire="true">
 {{/if}}

--- a/src/js/widgets/abstract/widget.js
+++ b/src/js/widgets/abstract/widget.js
@@ -175,6 +175,8 @@ define([
 
         if (MathJax) MathJax.Hub.Queue(["Typeset", MathJax.Hub, this.el]);
 
+        this.model.set('url', Backbone.history.location.href);
+
         $("head").append(metadataTemplate(this.model.toJSON()));
         //and set the title
         document.title = this.model.get("title");


### PR DESCRIPTION
* This should *hopefully* allow services like twitter, facebook, slack, etc. to properly unfurl links on the abstract pages
* Unable to test this properly until this is merged due to only having the changes locally.

- #1162