### PR TITLE
Fix References Links

### DIFF
--- a/src/js/widgets/resources/actions.js
+++ b/src/js/widgets/resources/actions.js
@@ -5,7 +5,22 @@ define([
   'analytics'
 ], function (_, ApiQuery, analytics) {
 
-  var FIELDS = ['links_data'];
+  var FIELDS = [
+    'links_data',
+    '[citations]',
+    'property',
+    'bibcode',
+    'first_author',
+    'year',
+    'page',
+    'pub',
+    'pubdate',
+    'title',
+    'volume',
+    'doi',
+    'issue',
+    'issn'
+  ];
   var API_QUERY_DELAY = 300;
 
   var actions = {};

--- a/src/js/widgets/resources/reducers.js
+++ b/src/js/widgets/resources/reducers.js
@@ -1,5 +1,5 @@
 'use strict';
-define([], function (helper) {
+define([], function () {
 
   var initialState = function () {
     return {


### PR DESCRIPTION
Some references links were leaving bibcode undefined, these fields are needed by the link generator to create proper urls.

Fixes #1203 