### PR TITLE
Add api query validator

### DIFF
--- a/src/js/components/query_validator.js
+++ b/src/js/components/query_validator.js
@@ -1,0 +1,139 @@
+define([
+'underscore'
+], function (_) {
+
+  /**
+   * Validator object
+   * provides value checking
+   * @param match
+   * @param opts
+   * @constructor
+   */
+  function Validator (match, opts) {
+    var matcher = new RegExp(match, opts);
+
+    return function test (str) {
+      return (matcher.test(str)) ? null : str;
+    };
+  }
+
+  /**
+   * QueryToken object for holding the field and value
+   * @param field
+   * @param value
+   * @param token
+   * @constructor
+   */
+  function QueryToken (field, value, token) {
+    this.field = field;
+    this.value = value;
+    this.token = token;
+  }
+
+  /**
+   * Parse and validate queries
+   * @constructor
+   */
+  function QueryValidator () {
+
+    /**
+     * Parse the query into new validator objects
+     * @param q
+     * @returns {Array}
+     */
+    var parseTokens = function (q) {
+      var splitter = new RegExp(/[:(]/);
+      var tokens = q.split(/\s+/);
+      var parsedTokens = [];
+      for (var j = 0; j < tokens.length; j++) {
+        var subTokens = tokens[j].split(splitter);
+
+        if (subTokens.length !== 2) {
+
+          // Unable to split or nested fields, either way continue on
+          continue;
+        }
+
+        // clean value of closing paren, if necessary
+        subTokens[1] = subTokens[1].replace(')', '');
+
+        parsedTokens.push(new QueryToken(subTokens[0], subTokens[1], tokens[j]));
+      }
+      return parsedTokens;
+    };
+
+    /**
+     * Composed function finisher, returns boolean equivalent of result
+     * @param res
+     * @returns {boolean}
+     */
+    var completeValidation = function (res) {
+      return !!res;
+    };
+
+    /**
+     * Create composed function from validators
+     * return the boolean result
+     * @param validators
+     * @param tokens
+     * @returns {Array}
+     */
+    var test = function (validators, tokens) {
+      var tests = [];
+      for (var i in tokens) {
+        var res = _.compose.apply(_, validators)(tokens[i].value);
+        if (!res) {
+          tests.push({
+            token: tokens[i].token,
+            result: res
+          });
+        }
+      }
+      return tests;
+    };
+
+    /**
+     * Validate the query string
+     * @param apiQuery
+     * @returns {object}
+     */
+    this.validate = function (apiQuery) {
+      var output = {
+        result: true
+      };
+
+      // Validators - This should match things you DON'T want in the query
+      // any confirmed match will make query invalid
+      var validators = [
+        completeValidation,
+        new Validator(/^("")?$/),
+        new Validator(/^"?\^"?$/)
+      ];
+
+      // Attempt to parse the query string to tokens
+      try {
+        var q = apiQuery.get('q').join(' ').trim();
+        if (!q.length) {
+
+          // query is empty string, continue on
+          return output;
+        }
+        var parsedTokens = parseTokens(q);
+      } catch (e) {
+
+        // parsing error, allow it to continue on
+        return output;
+      }
+
+      var tests = test(validators, parsedTokens);
+      output.result = _.every(_.pluck(tests, 'result'));
+      if (tests.length) {
+        output.tests = tests;
+      }
+
+      return output
+    };
+  }
+
+  return QueryValidator;
+});

--- a/test/mocha/core-suite.js
+++ b/test/mocha/core-suite.js
@@ -17,6 +17,7 @@ define([], function() {
       '/components/beehive.spec.js',
       '/components/api_request.spec.js',
       '/components/query_mediator.spec.js',
+      '/components/query_validator.spec.js',
       '/components/services_container.spec.js',
 //      '/components/analytics.spec.js', // too slow
       '/components/application.spec.js',

--- a/test/mocha/js/components/query_validator.spec.js
+++ b/test/mocha/js/components/query_validator.spec.js
@@ -1,0 +1,151 @@
+define([
+  'js/components/query_validator'
+], function (QueryValidator) {
+
+  var getMockQuery = function () {
+    var args = arguments;
+    return {
+      get: function () {
+        return Array.prototype.concat.apply([], args);
+      }
+    };
+  };
+
+  describe('Query Validator', function () {
+    var qv;
+    beforeEach(function () {
+      qv = new QueryValidator();
+    });
+    afterEach(function () {
+      qv = null;
+    });
+
+    it('correctly parses single input', function () {
+      var q = getMockQuery('abs:""');
+      var res = qv.validate(q);
+
+      expect(res).to.be.instanceOf(Object);
+      expect(res.result).to.be.false;
+      expect(res.tests.length).to.equal(1);
+      expect(res.tests[0].result).to.be.false;
+      expect(res.tests[0].token).to.equal('abs:""')
+    });
+
+    it('correctly parses single input with caret', function () {
+      var q = getMockQuery('abs:"^"');
+      var res = qv.validate(q);
+
+      expect(res).to.be.instanceOf(Object);
+      expect(res.result).to.be.false;
+      expect(res.tests.length).to.equal(1);
+      expect(res.tests[0].result).to.be.false;
+      expect(res.tests[0].token).to.equal('abs:"^"')
+    });
+
+    it('correctly parses single input with paren', function () {
+      var q = getMockQuery('citation("")');
+      var res = qv.validate(q);
+
+      expect(res).to.be.instanceOf(Object);
+      expect(res.result).to.be.false;
+      expect(res.tests.length).to.equal(1);
+      expect(res.tests[0].result).to.be.false;
+      expect(res.tests[0].token).to.equal('citation("")')
+    });
+
+    it('correctly parses empty input', function () {
+      var q = getMockQuery('');
+      var res = qv.validate(q);
+      expect(res.result).to.be.true;
+    });
+
+    it('correctly parses multiple empty input', function () {
+      var q = getMockQuery('', '', '', '     ', '    ');
+      var res = qv.validate(q);
+      expect(res.result).to.be.true;
+    });
+
+    it('correctly parses multiple input', function () {
+      var q = getMockQuery('abs:""', 'bibcode:""', 'full:""', 'author:""', 'bibgroup:""');
+      var res = qv.validate(q);
+
+      expect(res).to.be.instanceOf(Object);
+      expect(res.result).to.be.false;
+      expect(res.tests.length).to.equal(5);
+      expect(res.tests[0].result).to.be.false;
+      expect(res.tests[0].token).to.equal('abs:""');
+
+      expect(res.tests[1].result).to.be.false;
+      expect(res.tests[1].token).to.equal('bibcode:""');
+
+      expect(res.tests[2].result).to.be.false;
+      expect(res.tests[2].token).to.equal('full:""');
+
+      expect(res.tests[3].result).to.be.false;
+      expect(res.tests[3].token).to.equal('author:""');
+
+      expect(res.tests[4].result).to.be.false;
+      expect(res.tests[4].token).to.equal('bibgroup:""');
+    });
+
+    it('correctly parses mixture of bad and good input', function () {
+      var q = getMockQuery('abs:"df"', 'bibcode:""', 'full:"test"', 'author:""', 'bibgroup:"test"');
+      var res = qv.validate(q);
+
+      expect(res).to.be.instanceOf(Object);
+      expect(res.result).to.be.false;
+      expect(res.tests.length).to.equal(2);
+
+      expect(res.tests[0].result).to.be.false;
+      expect(res.tests[0].token).to.equal('bibcode:""');
+
+      expect(res.tests[1].result).to.be.false;
+      expect(res.tests[1].token).to.equal('author:""');
+    });
+
+    it('correctly parses good input, and does not fail', function () {
+      var q = getMockQuery('abs:"test"', 'bibcode:"test"', 'full:"test"', 'author:"test"', 'bibgroup:"test"');
+      var res = qv.validate(q);
+
+      expect(res).to.be.instanceOf(Object);
+      expect(res.result).to.be.true;
+      expect(res.tests).to.be.undefined;
+    });
+
+    it('correctly handles nested fields', function () {
+      var q = getMockQuery('abs:"abs:"""', 'citation("abs:""")');
+      var res = qv.validate(q);
+
+      expect(res).to.be.instanceOf(Object);
+      expect(res.result).to.be.true;
+    });
+
+    it('correctly handles garbled inputs', function () {
+      var q = getMockQuery('sldkfjsdlf:::::::lsdfkjsldjf ::::LDSjfks; :LSKJ;:Ldskjf ((((SD:LFKJ((S(DF S(D F');
+      var res = qv.validate(q);
+
+      expect(res).to.be.instanceOf(Object);
+      expect(res.result).to.be.true;
+    });
+
+    it('correctly handles mixture of garbled and bad inputs', function () {
+      var q = getMockQuery(':()dslkj: ;sd lf:ee :ekjdL: ', 'abs:""', 'test:"test"');
+      var res = qv.validate(q);
+
+      expect(res).to.be.instanceOf(Object);
+      expect(res.result).to.be.false;
+      expect(res.tests.length).to.equal(1);
+
+      expect(res.tests[0].result).to.be.false;
+      expect(res.tests[0].token).to.equal('abs:""');
+    });
+
+    it('correctly handles mixture of garbled and good inputs', function () {
+      var q = getMockQuery(':()ds:lkj: ;sd lf:ee :ekjdL: ', 'abs:"test"', 'test:"test"');
+      var res = qv.validate(q);
+
+      expect(res).to.be.instanceOf(Object);
+      expect(res.result).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
Added a new component to run some common validations on the search bar input.  Now queries that contain empty `""` or `"^"` or `("")` will be caught on the front-end, instead of relying on the api to validate.  However, more complex queries such as nested fields and garbled input will be passed along to the api to parse.  When the validator catches some bad input, an error message is provided to the user.

- Fixes: #1210