### PR TITLE
Fix Encoding On Highlights

### DIFF
--- a/src/js/widgets/list_of_things/templates/item-template.html
+++ b/src/js/widgets/list_of_things/templates/item-template.html
@@ -228,16 +228,16 @@
                     {{#if shortAbstract}}
 
                     <div class="short-abstract" aria-label="a truncated version of the abstract">
-                        {{shortAbstract}}
+                        {{{shortAbstract}}}
                         &nbsp; <button class="btn btn-xs btn-default show-full-abstract">more</button>
                     </div>
                     <div class="full-abstract hidden">
-                        {{ abstract }}
+                        {{{abstract}}}
                         &nbsp; <button class="btn btn-xs btn-default hide-full-abstract">less</button>
                     </div>
                     {{else}}
                         <!--the abstract is short enough to be shown all at once-->
-                        {{abstract}}
+                        {{{abstract}}}
                     {{/if}}
                 {{/if}}
         </div>

--- a/src/js/widgets/results/widget.js
+++ b/src/js/widgets/results/widget.js
@@ -202,10 +202,12 @@ define([
               var finalList = [];
               //adding abstract,title, etc highlights to one big list
               _.each(_.pairs(hl), function (pair) {
-                finalList = finalList.concat(pair[1]);
+                var str = (pair[1].length) ? pair[1][0] : '';
+                str = $('<d>' + str + '</d>').text();
+                finalList = finalList.concat([str]);
               });
 
-              if (finalList.length == 1 && finalList[0].trim() == "") {
+              if (finalList.length === 1 && finalList[0].trim() === "") {
                 return {};
               }
 


### PR DESCRIPTION
Unescape highlights code to render proper markup.

Fixes: #1225 