### PR TITLE
Fix Infinite Loop Caused By Token Expiration

### DIFF
--- a/grunt/mocha-runner.js
+++ b/grunt/mocha-runner.js
@@ -27,7 +27,7 @@ module.exports = function (grunt) {
     // support grepping for tests, this is passed to mocha
     var grep = grunt.option('grep');
     if (grep) {
-      _.merge({}, options.args, { grep: grep });
+      options.args = _.merge({}, options.args, { grep: grep });
     }
 
     // stringify the args passed in as options

--- a/src/js/mixins/api_access.js
+++ b/src/js/mixins/api_access.js
@@ -49,7 +49,11 @@ define([
         var redirect_uri = location.origin + location.pathname;
         var self = this;
         var defer = $.Deferred();
-        api.request(new ApiRequest({
+
+        // if token expired, make a _request
+        var request = options.tokenRefresh ? '_request' : 'request';
+
+        api[request](new ApiRequest({
             query: new ApiQuery({redirect_uri: redirect_uri}),
             target: this.bootstrapUrls ? this.bootstrapUrls[0] : '/accounts/bootstrap'}),
           {

--- a/src/js/services/api.js
+++ b/src/js/services/api.js
@@ -200,7 +200,7 @@ define([
       //fewer than 2 minutes before token expires
       if (difference > -2 ){
         var d = $.Deferred();
-        this.getApiAccess().done(function(){
+        this.getApiAccess({ tokenRefresh: true }).done(function(){
           d.resolve(that._request(request, options));
         });
         return d.promise();

--- a/test/mocha/js/services/api.spec.js
+++ b/test/mocha/js/services/api.spec.js
@@ -228,6 +228,30 @@ define([
 
     });
 
+    it("should correctly reset the token if it has expired", function () {
+      var api = new Api({url: '/api/1'});
+      sinon.stub(api, 'getBeeHive', function () {
+        return {
+          getService: function () {
+            return api;
+          }
+        };
+      });
+      api.access_token = 'foo';
+      api.expire_in = Date.now();
+
+      var sendRequest = function () {
+        api.request(new ApiRequest({
+          target: '/test',
+          query: new ApiQuery({ q: 'foo' }),
+          sender: 'woo'
+        }));
+      };
+
+      expect(sendRequest).to.not.throw('Maximum call stack size exceeded');
+      api.getBeeHive.restore();
+    });
+
     describe("Testing request options", function() {
 
       var ajaxSpy;


### PR DESCRIPTION
If the token expires this would get into an infinite loop, which is actually impossible to resolve, since no request is ever made.  This makes sure that the bootstrap request is actually sent during the request for access. 

One fix for #1224 