### PR TITLE
Fix Export Widget Download Button

### DIFF
--- a/src/js/widgets/export/widget.js
+++ b/src/js/widgets/export/widget.js
@@ -18,8 +18,8 @@ define([
     'module',
     'js/components/api_targets',
     'js/mixins/dependon',
-    'clipboard'
-
+    'clipboard',
+    'filesaver'
   ],
   function(
     Marionette,


### PR DESCRIPTION
For some reason `saveAs` no longer had a reference, added `filesaver` as a dependency for the export widget, should fix it.

Fixes: #1241 