### PR TITLE
Fix Metrics Widget

### DIFF
--- a/src/js/page_managers/templates/results-page-layout.html
+++ b/src/js/page_managers/templates/results-page-layout.html
@@ -36,7 +36,7 @@
                             <div data-widget="ExportWidget"/>
                             <div data-widget="AuthorNetwork"/>
                             <div data-widget="PaperNetwork"/>
-                            <div data-widget="Metrics"/>
+                            <div data-widget="Metrics" data-allow-redirect="true"/>
                             <div data-widget="BubbleChart"/>
                             <div data-widget="ConceptCloud"/>
                             <div data-widget="CitationHelper"/>

--- a/src/js/wraps/paper_metrics.js
+++ b/src/js/wraps/paper_metrics.js
@@ -26,11 +26,21 @@ define([
           var self = this;
           this.containerModel.set("title", data.title);
           this.getMetrics([bibcode]).done(function() {
+
+            // Everything worked, show the widget
             self.trigger('page-manager-event', 'widget-ready', {isActive: true, widget : self});
             if (self._waiting) {
               self.onShow();
               self._waiting = false;
             }
+          }).fail(function () {
+
+            // if the metrics fail, kill it
+            self.trigger('page-manager-event', 'widget-ready', {
+              isActive: false,
+              widget : self
+            });
+            self.destroy();
           });
         },
 


### PR DESCRIPTION
Fixes issue with close button not closing big widget.
Removes error message popup, and properly destroys widget on failure