### PR TITLE
Tone down error messages

### DIFF
--- a/src/js/components/user.js
+++ b/src/js/components/user.js
@@ -181,8 +181,7 @@ define([
           error = "error unknown";
         }
 
-        var message = 'Unable to update information for endpoint ' + target + ' (' + error + ')' ;
-        pubsub.publish(pubsub.ALERT, new ApiFeedback({code: 0, msg: message, type : "danger"}));
+        console.error('POST request failed for endpoint: [' + target + ']', error);
       },
 
       handleFailedGET :  function(jqXHR, status, errorThrown, target){
@@ -196,8 +195,7 @@ define([
           error = "error unknown";
         }
 
-        var message = 'Unable to retrieve information for endpoint ' + target + ' (' + error + ')' ;
-        pubsub.publish(pubsub.ALERT, new ApiFeedback({code: 0, msg: message, type : "danger"}));
+        console.error('GET request failed for endpoint: [' + target + ']', error);
       },
 
       fetchData : function(target){

--- a/src/js/wraps/discovery_mediator.js
+++ b/src/js/wraps/discovery_mediator.js
@@ -21,9 +21,8 @@ define([
     analytics
     ) {
 
-    var genericErrorMessage = '<b>Our server returned an error.</b>\n' +
-    'For the moment, please try <a href="http://adsabs.harvard.edu/abstract_service.html"> the classic service</a> instead.\n' +
-    'As Bumblebee usage increases, our servers occasionally get overwhelmed, although this will become less of a problem as we scale up.'
+    var genericErrorMessage = '<h4><strong>Something went wrong</strong></h4>' +
+    'Please <a onclick="window.location.reload()" href="' + window.location.href + '">reload</a> to try again';
 
     var handlers = {};
 

--- a/test/mocha/js/components/user.spec.js
+++ b/test/mocha/js/components/user.spec.js
@@ -506,19 +506,10 @@ define([
      u.redirectIfNecessary = sinon.stub();
 
      u.fetchData("fakeTarget");
-
-     //on fail
-
-     expect(u.getPubSub().publish.args[0][0]).to.eql("[Alert]-Message");
-     expect(u.getPubSub().publish.args[0][1].toJSON()).to.eql( {"code":0,"msg":"Unable to retrieve information for endpoint fakeTarget (OH NO)"});
-
      u.postData("fakeTarget");
 
-     expect(u.getPubSub().publish.args[1][0]).to.eql("[Alert]-Message");
-     expect(u.getPubSub().publish.args[1][1].toJSON()).to.eql({"code":0,"msg":"Unable to update information for endpoint fakeTarget (OH NO)"});
-
+     expect(u.getPubSub().publish.calledOn()).to.eql(false);
      requestStub.restore();
-
    });
 
  });


### PR DESCRIPTION
* Remove full banner error messages for User GET/POST failures
  * They will now show up in the console
* Change language on generic error from "return to classic" to "reload and try again"