### PR TITLE
Add Deployment Build Step For Compiled Assets

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,10 +6,13 @@ module.exports = function(grunt) {
       pkg: grunt.file.readJSON('package.json'),
       local: grunt.file.exists('local-config.json') ? grunt.file.readJSON('local-config.json') : {}
     },
-    loadGruntTasks: {
-      pattern: 'grunt-*',
-      config: 'package.json',
-      scope: 'devDependencies'
+    jitGrunt: {
+      staticMappings: {
+        express: 'grunt-express-server',
+        hash_require: 'grunt-hash-required',
+        buildcontrol: 'grunt-build-control',
+        bower: 'grunt-bower-task'
+      }
     }
   });
 

--- a/grunt/aliases.yaml
+++ b/grunt/aliases.yaml
@@ -131,3 +131,23 @@ release:
     - 'copy:keep_original'
     - 'copy:bumblebee_app'
     - 'assemble'
+
+deploy:
+  tasks:
+    - 'deploy:master'
+    - 'exec:kubernetes-build'
+    - 'release'
+    - 'deploy:kubernetes'
+    - 'exec:return-to-working-branch'
+
+'deploy:master':
+  description: 'deploy master onto build repo'
+  tasks:
+    - 'clean:deploy'
+    - 'buildcontrol:master'
+
+'deploy:kubernetes':
+  description: 'deploy kubernetes onto build repo'
+  tasks:
+    - 'clean:deploy'
+    - 'buildcontrol:kubernetes'

--- a/grunt/buildcontrol.js
+++ b/grunt/buildcontrol.js
@@ -1,0 +1,31 @@
+'use strict';
+/**
+ * Options for the `buildcontrol` grunt task
+ * This task pushes compiled assets to the bbb-builds repo
+ *
+ * @module grunt/buildcontrol
+ */
+module.exports = {
+  options: {
+    dir: 'dist',
+    commit: true,
+    push: true,
+    force: true,
+    connectCommits: false,
+    shallowFetch: true,
+    message: 'Built %sourceName% from commit %sourceCommit% on branch %sourceBranch%'
+  },
+  kubernetes: {
+    options: {
+      remote: 'git@github.com:adsabs/bbb-builds.git',
+      branch: 'kubernetes',
+      message: 'Built %sourceName% from commit %sourceCommit% on branch kubernetes'
+    }
+  },
+  master: {
+    options: {
+      remote: 'git@github.com:adsabs/bbb-builds.git',
+      branch: 'master'
+    }
+  }
+};

--- a/grunt/clean.js
+++ b/grunt/clean.js
@@ -11,12 +11,18 @@ module.exports = {
   deploy: {
     src: [
       'dist/**/*',
+      '!dist/index.html',
       '!dist/bumblebee_app.*.js',
       '!dist/styles',
+      '!dist/styles/img',
+      '!dist/styles/img/*',
       '!dist/styles/css',
+      '!dist/styles/css/images',
+      '!dist/styles/css/images/*',
       '!dist/styles/css/styles.*.css',
-      '!dist/index.*.html',
-      'dist/index.original.html',
+      '!dist/libs',
+      '!dist/libs/requirejs',
+      '!dist/libs/requirejs/require.js',
     ]
   },
   bower: {

--- a/grunt/clean.js
+++ b/grunt/clean.js
@@ -8,6 +8,17 @@ module.exports = {
   release: {
     src: ['dist/']
   },
+  deploy: {
+    src: [
+      'dist/**/*',
+      '!dist/bumblebee_app.*.js',
+      '!dist/styles',
+      '!dist/styles/css',
+      '!dist/styles/css/styles.*.css',
+      '!dist/index.*.html',
+      'dist/index.original.html',
+    ]
+  },
   bower: {
     src: [
       './bower_components',

--- a/grunt/exec.js
+++ b/grunt/exec.js
@@ -29,5 +29,11 @@ module.exports = {
   },
   'coveralls-report': {
     cmd: 'cat test/coverage/reports/lcov/lcov.info | ./node_modules/coveralls/bin/coveralls.js'
+  },
+  'kubernetes-build': {
+    cmd: 'git checkout kubernetes && git rebase origin master'
+  },
+  'return-to-working-branch': {
+    cmd: 'git checkout -'
   }
 };

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "grunt-bbb-requirejs": "0.1.0-alpha.8",
     "grunt-blanket-mocha": "^0.4.1",
     "grunt-bower-task": "~0.4.0",
+    "grunt-build-control": "^0.7.1",
     "grunt-compile-handlebars": "^2.0.2",
     "grunt-concurrent": "^0.5.0",
     "grunt-contrib-clean": "~0.5.0",


### PR DESCRIPTION
This is to support a way of deploying compiled assets to a sub-repo ([bbb-builds](https://github.com/adsabs/bbb-builds)).  After a `grunt release` you should just have to do a `grunt deploy` and it will commit the assets to bbb-builds.

* Clean up dist directory prior to deployment
* Deploys to bbb-builds special repo for versioning deployments
* Splits deployments between EB and Kubernetes
* Switched to use jit grunt, which speeds up the loading of tasks