### PR TITLE
force refresh of expired tokens

### DIFF
--- a/src/js/mixins/api_access.js
+++ b/src/js/mixins/api_access.js
@@ -64,7 +64,7 @@ define([
               defer.resolve(data);
             },
             fail: function () {
-              defer.reject(arguments);
+              defer.reject.apply(defer, arguments);
             },
             type: 'GET'
           });

--- a/src/js/services/api.js
+++ b/src/js/services/api.js
@@ -217,11 +217,7 @@ define([
       return (difference > -2 ) ? refreshToken() : that._request(request, options);
     };
 
-    _.extend(Api.prototype, Mixin.BeeHive);
-    _.extend(Api.prototype, Hardened);
-    _.extend(Api.prototype, ApiAccess);
-
-
+    _.extend(Api.prototype, Mixin.BeeHive, Hardened, ApiAccess);
 
     return Api
   });

--- a/src/js/services/api.js
+++ b/src/js/services/api.js
@@ -189,8 +189,23 @@ define([
     Api.prototype.request = function(request, options) {
 
       var that = this;
+      var refreshRetries = 3;
+      var refreshToken = function () {
+        var d = $.Deferred();
+        var req = that.getApiAccess({ tokenRefresh: true, reconnect: true });
+        req.done(function () {
+          d.resolve(that._request(request, options));
+        });
+        req.fail(function () {
+          (--refreshRetries > 0) ?
+            _.delay(refreshToken, 1000) : d.reject.apply(d, arguments);
+        });
+        return d.promise();
+      };
 
-      if (!this.expire_in) return that._request(request, options);
+      if (!this.expire_in) {
+        return refreshToken();
+      }
 
       //expire_in is in UTC, not local time
       var expiration = Moment.utc(this.expire_in);
@@ -198,18 +213,8 @@ define([
 
       var difference = now.diff(expiration, 'minutes');
       //fewer than 2 minutes before token expires
-      if (difference > -2 ){
-        var d = $.Deferred()
-        var opts = { tokenRefresh: true, reconnect: true };
-        this.getApiAccess(opts).done(function(){
-          d.resolve(that._request(request, options));
-        });
-        return d.promise();
-      }
-      else {
-        return that._request(request, options);
-      }
 
+      return (difference > -2 ) ? refreshToken() : that._request(request, options);
     };
 
     _.extend(Api.prototype, Mixin.BeeHive);

--- a/src/js/services/api.js
+++ b/src/js/services/api.js
@@ -199,8 +199,9 @@ define([
       var difference = now.diff(expiration, 'minutes');
       //fewer than 2 minutes before token expires
       if (difference > -2 ){
-        var d = $.Deferred();
-        this.getApiAccess({ tokenRefresh: true }).done(function(){
+        var d = $.Deferred()
+        var opts = { tokenRefresh: true, reconnect: true };
+        this.getApiAccess(opts).done(function(){
           d.resolve(that._request(request, options));
         });
         return d.promise();

--- a/test/mocha/js/components/discovery_mediator.spec.js
+++ b/test/mocha/js/components/discovery_mediator.spec.js
@@ -36,6 +36,7 @@ define([
     var minsub;
     beforeEach(function() {
       var api = new Api();
+      api.expire_in = Date.now() + 100000000;
       minsub = new MinimalPubSub({verbose: true, Api: api});
 
       this.server = sinon.fakeServer.create();

--- a/test/mocha/js/components/query_mediator.spec.js
+++ b/test/mocha/js/components/query_mediator.spec.js
@@ -64,6 +64,7 @@ define([
         beehive = new BeeHive();
         beehive.addObject("AppStorage", {clearSelectedPapers : sinon.spy()});
         var api = new Api();
+        api.expire_in = Date.now() + 100000000;
         sinon.spy(api, 'request');
         beehive.addService('Api', api);
         var ps = new PubSub();

--- a/test/mocha/js/services/api.spec.js
+++ b/test/mocha/js/services/api.spec.js
@@ -20,6 +20,12 @@ define([
   Moment
   ) {
 
+  var __getApi = function (options) {
+    var api = new Api(options);
+    api.expire_in = Date.now() + 10000000;
+    return api;
+  };
+
   describe("Api Service (api.spec.js)", function() {
     beforeEach(function(done) {
       this.server = sinon.fakeServer.create();
@@ -63,7 +69,7 @@ define([
 
     it("should look at the ApiRequest to check whether to send a get (with url data) or post request (with json data)", function(done){
 
-      var api = new Api({url: '/api/1'}); // url is there, but i want to be explicit
+      var api = __getApi({url: '/api/1'}); // url is there, but i want to be explicit
 
       var q = new ApiQuery({q: 'foo'});
       api.request(new ApiRequest({target: 'search', query: q}));
@@ -85,7 +91,7 @@ define([
     });
 
     it("should allow to override anything via options", function() {
-      var api = new Api({url: '/nonexisting/1'});
+      var api = __getApi({url: '/nonexisting/1'});
       var q = new ApiQuery({q: 'foo'});
       var spy = sinon.spy();
       api.request(new ApiRequest({target: 'search', query: q}), {url: 'http://foo.dot.com'})
@@ -101,7 +107,7 @@ define([
     });
 
     it("should call appropriate callback upon arrival of data", function(done) {
-      var api = new Api({url: '/api/1'}); // url is there, but i want to be explicit
+      var api = __getApi({url: '/api/1'}); // url is there, but i want to be explicit
       sinon.stub(api, 'trigger');
       var q = new ApiQuery({q: 'foo'});
 
@@ -118,7 +124,7 @@ define([
     });
 
     it("should call error handlers on failed request", function(done) {
-      var api = new Api({url: '/api/1'}); // url is there, but i want to be explicit
+      var api = __getApi({url: '/api/1'}); // url is there, but i want to be explicit
       sinon.stub(api, 'trigger');
       var q = new ApiQuery({q: 'foo'});
 
@@ -136,7 +142,7 @@ define([
     });
 
     it("should call error handlers when response is not valid", function() {
-      var api = new Api({url: '/api/1'}); // url is there, but i want to be explicit
+      var api = __getApi({url: '/api/1'}); // url is there, but i want to be explicit
       sinon.stub(api, 'trigger');
       var q = new ApiQuery({q: 'foo'});
 
@@ -153,7 +159,7 @@ define([
     });
 
     it("should call 'always' handler (even if redefined)", function() {
-      var api = new Api({url: '/api/1'}); // url is there, but i want to be explicit
+      var api = __getApi({url: '/api/1'}); // url is there, but i want to be explicit
       var spy = sinon.spy();
       sinon.spy(api, 'always', api.always);
       var q = new ApiQuery({q: 'foo'});
@@ -169,7 +175,7 @@ define([
     });
 
     it("should call 'done' handler (even if redefined)", function() {
-      var api = new Api({url: '/api/1'}); // url is there, but i want to be explicit
+      var api = __getApi({url: '/api/1'}); // url is there, but i want to be explicit
       var spy = sinon.spy();
       sinon.spy(api, 'done', api.done);
       var q = new ApiQuery({q: 'foo'});
@@ -185,7 +191,7 @@ define([
 
     it("should automatically request a new token if there is less than 2 minutes before token expiration", function(){
 
-      var api = new Api({url: '/api/1'}); // url is there, but i want to be explicit
+      var api = __getApi({url: '/api/1'}); // url is there, but i want to be explicit
 
       api.access_token = 'foo';
       api.expire_in = "2016-08-16T18:12:00"
@@ -229,7 +235,7 @@ define([
     });
 
     it("should correctly reset the token if it has expired", function () {
-      var api = new Api({url: '/api/1'});
+      var api = __getApi({url: '/api/1'});
       sinon.stub(api, 'getBeeHive', function () {
         return {
           getService: function () {
@@ -262,7 +268,7 @@ define([
         ajaxSpy.restore();
       });
       it("Should set appropriate options", function() {
-        var api = new Api({url: '/api/1'});
+        var api = __getApi({url: '/api/1'});
         var q = new ApiQuery({q: 'foo'});
         var spy = sinon.spy();
         expect(api.request(new ApiRequest({target: 'search', query: q}),
@@ -361,7 +367,7 @@ define([
     // this.pending = !window.bbbTest.serverReady;
 
     it("should retrieve data from server using GET and POST (default)", function(done) {
-      var api = new Api({url: '/api/1'}); // url is there, but i want to be explicit
+      var api = __getApi({url: '/api/1'}); // url is there, but i want to be explicit
       var q = new ApiQuery({q: 'foo'});
       var spy = sinon.spy();
 


### PR DESCRIPTION
Previous PR left out the `{ reconnect: true }` which when true, updates the user information after a successful bootstrap call.  This adds it back in

__Updates to Bootstrap__

*Current Behavior:*
1. Bootstrap request fails (500)
2. Allows request to proceed naively assuming it is first request (bootstrap)
3. Subsequent request fails, prompting another bootstrap request
4. Second Bootstrap request fails (500).
5. Receive fatal error message or transition to 500 error page

*New Behavior:*
1. Bootstrap request fails (500)
2. Detects and begins attempting a followup bootstrap request (3 times)
3. If one succeeds, the pending request(s) are sent
4. If all three tries fail, it will show fatal error to user