### PR TITLE
Shorten Wait After Max Failures to 5 Seconds

### DIFF
--- a/src/js/components/query_mediator.js
+++ b/src/js/components/query_mediator.js
@@ -44,7 +44,9 @@ define(['underscore',
         this._cache = null;
         this.debug = options.debug || false;
         this.queryUpdater = new ApiQueryUpdater('QueryMediator');
-        this.failedRequestsCache = this._getNewCache();
+        this.failedRequestsCache = this._getNewCache({
+          'expiresAfterWrite': 5
+        });
         this.maxRetries = options.maxRetries || 3;
         this.recoveryDelayInMs = _.isNumber(options.recoveryDelayInMs) ? options.recoveryDelayInMs : 700;
         this.__searchCycle = {waiting:{}, inprogress: {}, done: {}, failed: {}};


### PR DESCRIPTION
Forces the cached entry to be invalidated after 5 seconds.  This will mean that a calm period (without the same failing request) of 5 seconds needs to happen before that same request can be sent to the api again.  

This replaces the default of 30 minutes