### PR TITLE
Fix Issue Causing Error On Abstract Page Export

### DIFF
--- a/src/js/widgets/export/containers/App.jsx.js
+++ b/src/js/widgets/export/containers/App.jsx.js
@@ -101,8 +101,13 @@ define([
      * On Apply, the export process is begun
      */
     handleApplyClick() {
-      const { dispatch } = this.props;
-      dispatch(fetchUsingQuery()).done(() => dispatch(fetchUsingIds()));
+      const { dispatch, ids, query } = this.props;
+
+      if (_.isEmpty(query) && !_.isEmpty(ids)) {
+        dispatch(fetchUsingIds());
+      } else {
+        dispatch(fetchUsingQuery()).done(() => dispatch(fetchUsingIds()));
+      }
     }
 
     /**
@@ -254,7 +259,9 @@ define([
     showCloser: state.main.showCloser,
     showSlider: state.main.showSlider,
     splitCols: state.main.splitCols,
-    showReset: state.main.showReset
+    showReset: state.main.showReset,
+    ids: state.exports.ids,
+    query: state.main.query
   });
 
   return ReactRedux.connect(mapStateToProps)(App);

--- a/src/js/widgets/export/widget.jsx.js
+++ b/src/js/widgets/export/widget.jsx.js
@@ -219,6 +219,8 @@ define([
       }
     },
 
+    processResponse: _.noop,
+
     /**
      * Export the list of identifiers as an ADS Classic result
      *


### PR DESCRIPTION
Check for existence of query, if it doesn't exist, reuse identifiers.

Get rid of "customize this method..." error message