### PR TITLE
1388 author affiliation excel output garbled

### DIFF
--- a/src/js/widgets/author_affiliation_tool/actions/index.js
+++ b/src/js/widgets/author_affiliation_tool/actions/index.js
@@ -428,16 +428,14 @@ define([
 
       // if browser, then open a new tab and show message if it's blocked
       if (file.ext === 'browser') {
-        openInNewTab(res);
+        res.text().then(t => openInNewTab(t));
         dispatch(actions.showMessage(
           'info',
           'If new tab doesn\'t appear, you will need to allow popups'
         ));
       } else {
 
-        // otherwise, we can just create a file for download
-        let blob = new Blob([res], { type: `${file.type};charset=utf=8` });
-        saveAs(blob, `authorAffiliations.${file.ext}`);
+        res.blob().then(b => saveAs(b, `authorAffiliations.${file.ext}`));
 
         // show a message about successful download
         dispatch(actions.showMessage('success', 'Export Successful!'));

--- a/src/js/widgets/author_affiliation_tool/actions/index.js
+++ b/src/js/widgets/author_affiliation_tool/actions/index.js
@@ -277,6 +277,11 @@ define([
   const actions = {
 
     /**
+     * Reset the store to initial values
+     */
+    appReset: () => dispatch => dispatch({ type: ACTIONS.appReset }),
+
+    /**
      * Reset the current data set
      */
     reset: () => (dispatch, getState) => {

--- a/src/js/widgets/author_affiliation_tool/constants/actionNames.js
+++ b/src/js/widgets/author_affiliation_tool/constants/actionNames.js
@@ -12,7 +12,8 @@ define([], function () {
     setCount: 'SET_COUNT',
     setMessage: 'SET_MESSAGE',
     setExporting: 'SET_EXPORTING',
-    setAuthor: 'SET_AUTHOR'
+    setAuthor: 'SET_AUTHOR',
+    appReset: 'APP_RESET'
   };
 
   return target;

--- a/src/js/widgets/author_affiliation_tool/containers/App.jsx.js
+++ b/src/js/widgets/author_affiliation_tool/containers/App.jsx.js
@@ -159,7 +159,7 @@ define([
                           value={year}
                           onChange={val => this.onYearChange(val.target.value)}
                         >
-                          {makeOptions([1, 2, 3, 4, 5, 10, 'All'], currentYear)}
+                          {makeOptions([1, 2, 3, 4, 5, 10, 'All'], 0)}
                         </select>
                       </div>
                     </div>

--- a/src/js/widgets/author_affiliation_tool/reducers/index.js
+++ b/src/js/widgets/author_affiliation_tool/reducers/index.js
@@ -68,6 +68,9 @@ define([
       case ACTIONS.setLoading:
         return { ...state, loading: action.value };
 
+      case ACTIONS.appReset:
+        return initialState;
+
       // return the current state
       default: return state;
     }

--- a/src/js/widgets/author_affiliation_tool/widget.jsx.js
+++ b/src/js/widgets/author_affiliation_tool/widget.jsx.js
@@ -188,11 +188,16 @@ define([
 
       const req = new ApiRequest({
         target: ApiTargets.AUTHOR_AFFILIATION_EXPORT,
-        query: new ApiQuery(data),
+        query: new ApiQuery(),
         options : {
-          type : 'POST',
-          contentType : 'application/json',
-          dataType: 'text',
+          useFetch: true,
+          fetchOptions: {
+            body: JSON.stringify(data),
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json'
+            }
+          },
           done: (...args) => $dd.resolve(...args),
           fail: (...args) => $dd.reject(...args),
           always: (...args) => $dd.always(...args)

--- a/src/js/widgets/author_affiliation_tool/widget.jsx.js
+++ b/src/js/widgets/author_affiliation_tool/widget.jsx.js
@@ -220,8 +220,10 @@ define([
      * Close the widget
      */
     closeWidget: function () {
+      const { dispatch } = this.store;
       const pubsub = this.getPubSub();
       pubsub.publish(pubsub.NAVIGATE, "results-page");
+      dispatch(actions.appReset());
     },
 
     /**


### PR DESCRIPTION
Fixes excel issue
Updates the change to the author-affiliation api (0 instead of current year for all years)
Resets the state of the widget on close which should fix issues with state being retained when re-opening the component.