### PR TITLE
Orcid Fixes

### DIFF
--- a/src/js/mixins/papers_utils.js
+++ b/src/js/mixins/papers_utils.js
@@ -137,7 +137,10 @@ define([
       data.details = data.details || {shortAbstract: data.shortAbstract, pub: data.pub, abstract : data.abstract};
       data.num_citations = data["[citations]"] ? data["[citations]"]["num_citations"] : undefined;
       data.identifier = data.bibcode;
-      data.encodedIdentifier = encodeURIComponent(data.identifier);
+
+      // make sure undefined doesn't become "undefined"
+      data.encodedIdentifier = _.isUndefined(data.identifier) ? 
+        data.identifier : encodeURIComponent(data.identifier);
 
       if (data.pubdate || data.shortAbstract){
         data.popover = true;

--- a/src/js/modules/orcid/widget/widget.js
+++ b/src/js/modules/orcid/widget/widget.js
@@ -77,8 +77,6 @@ define([
         var pubsub = this.getPubSub(), query = new ApiQuery({q : searchTerm, sort: 'date desc'});
         pubsub.publish(pubsub.START_SEARCH, query);
       });
-
-      this.on('orcid-update-finished', this.mergeDuplicateRecords);
     },
 
     orcidWidget : true,

--- a/src/js/modules/orcid/work.js
+++ b/src/js/modules/orcid/work.js
@@ -58,18 +58,34 @@ define([
     // find the inner summary as the root
     this._root = (work['work-summary']) ? work['work-summary'][0] : work;
 
-    var sources = '';
-    Object.defineProperty(this, 'sources', {
-      set: function (data) {
-        sources = data;
-      },
-      get: function () {
-        if (sources.length > 0) {
-          return sources;
-        }
+    this.sources = [];
+
+    /**
+     * get the sources array
+     * if the array is empty, it returns an array containing the single source name
+     * 
+     * @returns {Array} - the sources
+     */
+    this.getSources = function () {
+      if (_.isEmpty(this.sources)) {
         return [this.getSourceName()];
       }
-    });
+
+      return this.sources;
+    };
+
+    /**
+     * Set the sources array
+     * 
+     * @param {Array} sources
+     * @returns {Array} - the sources
+     */
+    this.setSources = function (sources) {
+      if (_.isArray(sources)) {
+        this.sources = sources;
+      }
+      return this.sources;
+    };
 
     /**
      * Get the value at path
@@ -124,7 +140,7 @@ define([
         title: [this.getTitle()],
         formattedDate: this.getFormattedPubDate(),
         abstract: this.getShortDescription(),
-        source_name: this.sources.join('; '),
+        source_name: this.getSources().join('; '),
         pub: this.getJournalTitle(),
         _work: this
       });
@@ -182,8 +198,9 @@ define([
       var ids = this.getExternalIds();
       var out = {};
       _.eachRight(props, function (p) {
-        if (ids[p]) {
-          out = p;
+        if (_.isString(ids[p])) {
+          out = ids[p];
+          return false;
         }
       });
       return out;

--- a/src/js/widgets/list_of_things/templates/item-template.html
+++ b/src/js/widgets/list_of_things/templates/item-template.html
@@ -112,9 +112,19 @@
 <div class="row">
 
     <div class="col-xs-10 col-xs-offset-1">
-        <a href="#abs/{{encodedIdentifier}}/abstract">
-            <h3 class="s-results-title">{{{title}}}</h3>
-        </a>
+        {{#if isOrcidWidget}}
+            {{#if encodedIdentifier}}
+                <a href="#abs/{{encodedIdentifier}}/abstract">
+                    <h3 class="s-results-title">{{{title}}}</h3>
+                </a>
+            {{else}}
+                <h3 class="s-results-title">{{{title}}}</h3>
+            {{/if}}
+        {{else}}
+            <a href="#abs/{{encodedIdentifier}}/abstract">
+                <h3 class="s-results-title">{{{title}}}</h3>
+            </a>
+        {{/if}}
     </div>
 </div>
 

--- a/src/js/widgets/results/widget.js
+++ b/src/js/widgets/results/widget.js
@@ -191,7 +191,10 @@ define([
           //used by link generator mixin
           d.link_server = link_server;
           d.identifier = d.bibcode;
-          d.encodedIdentifier = encodeURIComponent(d.identifier);
+
+          // make sure undefined doesn't become "undefined"
+          d.encodedIdentifier = _.isUndefined(d.identifier) ? 
+            d.identifier : encodeURIComponent(d.identifier);
           var h = {};
 
           if (_.keys(highlights).length) {


### PR DESCRIPTION
Fixes issues with non-matching records showing a "Loading..." message

Changes the orcid database query from `identifier:foo OR identifier:bar` to `identifier:(foo OR bar)`

Minor fixes and improvements for matching on null or undefined entries