### PR TITLE
Improve Autocomplete on Paper and Classic Forms

### DIFF
--- a/src/js/widgets/classic_form/form.html
+++ b/src/js/widgets/classic_form/form.html
@@ -76,7 +76,8 @@
         <div class="logic-group">
             <input type="checkbox" class="hidden" value="OR" checked="true"/>
         </div>
-        <label for="#classic-bibstem">Publication</label>
+        <label for="#classic-bibstem">Publication(s)</label>
+        <p class="help-block small">Press Return Key To Add Publication</p>
         <input id="classic-bibstem" type="text" class="form-control" name="bibstem" placeholder="Comma-separated bibstems of journal titles" autocomplete="off"/>
     </div>
 

--- a/src/js/widgets/paper_search_form/widget.js
+++ b/src/js/widgets/paper_search_form/widget.js
@@ -47,7 +47,35 @@ define([
           $(this).trigger('enter');
         }
       });
-      this.$("#pub-input").autocomplete({ source : AutocompleteData, minLength : 2 , autoFocus : true });
+      this.$("#pub-input").autocomplete({
+        minLength : 1,
+        autoFocus : true,
+        source: function (request, response) {
+          var matches = $.map(AutocompleteData, function (item) {
+            if (_.isString(request.term)) {
+              var term = request.term.toUpperCase();
+              var bibstem = item.value.toUpperCase();
+              var label = item.label.toUpperCase();
+              if (
+                bibstem.indexOf(term) === 0 ||
+                label.indexOf(term) === 0 ||
+                label.replace(/^THE\s/, '').indexOf(term) === 0
+              ) {
+                return item;
+              }
+            }
+          });
+          return response(matches);
+        }
+      }).data('ui-autocomplete')._renderItem = function (ul, item) {
+        var re = new RegExp('(' + this.term + ')', 'i');
+        var label = item.label.replace(re,
+          '<span class="ui-state-highlight">$1</span>'
+        );
+        var $li = $('<li/>').appendTo(ul);
+        $('<a/>').attr('href', '#').html(label).appendTo($li);
+        return $li;
+      };
     },
 
     checkPaperFormDisabled : function(){


### PR DESCRIPTION
* Custom matching function, which will search both bibstems and descriptions, with exact matches
* Adds a highlighter for extra fun
* Removes tab button listener, adds not about hitting enter to add publication