### PR TITLE
Add opensearch doc

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
 
-<head>
+<head profile="http://a9.com/-/spec/opensearch/1.1/">
   <meta charset="utf-8"/>
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
@@ -10,6 +10,10 @@
   <meta name="description" content="A powerful, streamlined new Astrophysics Data System" />
   <link rel="stylesheet" href="./styles/css/styles.css" />
   <link rel="icon" type="image/png" sizes="32x32" href="./styles/img/favicon.ico"/>
+  <link rel="search"
+    type="application/opensearchdescription+xml"
+    href="https://ui.adsabs.harvard.edu/opensearch.xml"
+    title="ADS Search" />
 </head>
 
   <body>

--- a/src/opensearch.xml
+++ b/src/opensearch.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <ShortName>ADS Search</ShortName>
+  <Description>NASA Astrophysics Data System</Description>
+  <Tags>NASA ADS</Tags>
+  <Contact>adshelp@cfa.harvard.edu</Contact>
+  <Url type="text/html"
+       template="https://ui.adsabs.harvard.edu/#search/q={searchTerms}"/>
+  <LongName>NASA ADS Search</LongName>
+  <Image height="32" width="32" type="image/vnd.microsoft.icon">https://ui.adsabs.harvard.edu/styles/img/favicon.ico</Image>
+  <Query role="example" searchTerms="star" />
+  <Developer>ADS Team</Developer>
+  <Attribution>
+    Please See Terms of Use: http://adsabs.github.io/help/terms
+  </Attribution>
+  <SyndicationRight>private</SyndicationRight>
+  <AdultContent>false</AdultContent>
+  <Language>en-us</Language>
+  <OutputEncoding>UTF-8</OutputEncoding>
+  <InputEncoding>UTF-8</InputEncoding>
+</OpenSearchDescription>


### PR DESCRIPTION
Fixes: #1468

Adds openSearch document to allow browser that support it to detect custom search engines.