### PR TITLE
Fix Landing Page History Loop

### DIFF
--- a/src/js/apps/discovery/router.js
+++ b/src/js/apps/discovery/router.js
@@ -1,4 +1,5 @@
 define([
+    'underscore',
     'jquery',
     'backbone',
     'js/components/api_query',
@@ -11,6 +12,7 @@ define([
 
   ],
   function (
+    _,
     $,
     Backbone,
     ApiQuery,
@@ -20,7 +22,6 @@ define([
     ApiTargets,
     ApiAccessMixin,
     ApiQueryUpdater
-
     ) {
 
     "use strict";
@@ -30,6 +31,26 @@ define([
       initialize : function(options){
         options = options || {};
         this.queryUpdater = new ApiQueryUpdater('Router');
+      },
+
+      execute: function (callback, args) {
+
+        // only perform actions if history has started
+        if (Backbone.History.started) {
+
+          var route = Backbone.history.getFragment();
+          route = route === '' ? 'index' : route;
+
+          // Workaround for issue where hitting back button from the index page
+          // goes to an empty `search/` route, so capture that here and go back 2
+          if (route === 'search/' && _.isEmpty(_.reject(args, _.isUndefined))) {
+            return Backbone.history.history.go(-2);
+          }
+        }
+
+        if (_.isFunction(callback)) {
+          callback.apply(this, args);
+        }
       },
 
       activate: function (beehive) {


### PR DESCRIPTION
Should fix the history issue.  Seems like from the landing page a back button press generates an empty `search/` url, and the default for that is to route back to the landing page, causing the loop. 

This fix just detects that and goes back 2 entries in history, and does not trigger any callbacks.

Also, this takes the user back to the actual previous page, for example:
`tugboat` -> `ads search results page` (back button results in `tugboat`)

instead of the current behavior of going to landing page first.
 