### PR TITLE
Facet Names From Url

### DIFF
--- a/src/js/components/api_query_updater.js
+++ b/src/js/components/api_query_updater.js
@@ -47,7 +47,11 @@ define(['underscore', 'js/components/api_query'], function (_, ApiQuery) {
      * @param operator
      *      String: this will serve as concatenator for the conditions
      */
-    updateQuery: function(apiQuery, field, mode, queryCondition) {
+    updateQuery: function(apiQuery, field, mode, queryCondition, options) {
+
+      options = _.defaults({}, options, {
+        prefix: '__'
+      });
 
       if (!field || !_.isString(field)) {
         throw new Error("You must tell us what parameter to update in the ApiQuery");
@@ -67,8 +71,8 @@ define(['underscore', 'js/components/api_query'], function (_, ApiQuery) {
         operator = 'OR';
       }
       else if (mode == 'replace') {
-        this._closeExistingVals(apiQuery, this._n(field));
-        apiQuery.set(this._n(field), ['AND', queryCondition[0]]);
+        this._closeExistingVals(apiQuery, this._n(field, options.prefix));
+        apiQuery.set(this._n(field, options.prefix), ['AND', queryCondition[0]]);
         return apiQuery.set(field, queryCondition[0]);
       }
       else {
@@ -78,7 +82,7 @@ define(['underscore', 'js/components/api_query'], function (_, ApiQuery) {
       if (!(apiQuery.has(field))) {
         var conditions = [operator].concat(queryCondition);
         apiQuery.set(field, this._buildQueryFromConditions(conditions));
-        apiQuery.set(this._n(field), conditions);
+        apiQuery.set(this._n(field, options.prefix), conditions);
         return;
       }
 
@@ -86,7 +90,7 @@ define(['underscore', 'js/components/api_query'], function (_, ApiQuery) {
       //globalOperator = this._sanitizeOperator(globalOperator);
 
       // local name
-      var n = this._n(field);
+      var n = this._n(field, options.prefix);
 
       // create copy of the field
       var q = _.clone(apiQuery.get(field));
@@ -375,11 +379,9 @@ define(['underscore', 'js/components/api_query'], function (_, ApiQuery) {
       return apiQuery[n];
     },
 
-    _n: function(name) {
-      return '__' + this.context + '_' + name;
+    _n: function(name, prefix) {
+      return (_.isString(prefix) ? prefix : '__') + this.context + '_' + name;
     },
-
-
 
     _buildQueryFromConditions: function(conditions) {
       if (conditions.length <= 1) {

--- a/src/js/components/persistent_storage.js
+++ b/src/js/components/persistent_storage.js
@@ -90,13 +90,13 @@ define([
     },
 
     _setKey: function(key) {
-      var keys = this.keys();
+      var keys = this.keys() || {};
       keys[key] = 1;
       this._store.set('#keys', JSON.stringify(keys));
     },
 
     _delKey: function(key) {
-      var keys = this.keys();
+      var keys = this.keys() || {};
       delete keys[key];
       this._store.set('#keys', JSON.stringify(keys));
     },

--- a/src/js/wraps/ned_object_facet.js
+++ b/src/js/wraps/ned_object_facet.js
@@ -189,8 +189,8 @@ define([
         // and NGC_789 in this example). These should be present as keys in the cache generated in
         // the object facet widget, returning the associated (canonical) object names
         //create an array with just the user-friendly names of the facets
-        var logic = q.get('__ned_object_facet_hier_fq_ned_object_facet_hier')[0];
-        q.set('__ned_object_facet_hier_fq_ned_object_facet_hier', [logic].concat(selectedFacets));
+        var logic = q.get('filter_ned_object_facet_hier_fq_ned_object_facet_hier')[0];
+        q.set('filter_ned_object_facet_hier_fq_ned_object_facet_hier', [logic].concat(selectedFacets));
       }
 
       q.unset('facet.prefix');

--- a/src/js/wraps/simbad_object_facet.js
+++ b/src/js/wraps/simbad_object_facet.js
@@ -187,8 +187,8 @@ define([
         // and 1575544 in this example). These should be present as keys in the cache generated in
         // the object facet widget, returning the associated (canonical) object names
         //create an array with just the user-friendly names of the facets
-        var logic = q.get('__simbad_object_facet_hier_fq_simbad_object_facet_hier')[0];
-        q.set('__simbad_object_facet_hier_fq_simbad_object_facet_hier', [logic].concat(selectedFacets));
+        var logic = q.get('filter_simbad_object_facet_hier_fq_simbad_object_facet_hier')[0];
+        q.set('filter_simbad_object_facet_hier_fq_simbad_object_facet_hier', [logic].concat(selectedFacets));
       }
 
       q.unset('facet.prefix');

--- a/test/mocha/js/widgets/facet_widget.spec.js
+++ b/test/mocha/js/widgets/facet_widget.spec.js
@@ -591,7 +591,7 @@ define([
           'fq_author': [
                   '(author_facet_hier:"0/Accomazzi, A" OR author_facet_hier:"0/Kurtz, M")'
                 ],
-          '__author_facet_hier_fq_author': [
+          'filter_author_facet_hier_fq_author': [
                   'OR',
                   'author_facet_hier:"0/Accomazzi, A"',
                   'author_facet_hier:"0/Kurtz, M"'
@@ -717,7 +717,7 @@ define([
           'fq_author': [
               '(author_facet_hier:"0/Accomazzi, A")'
             ],
-          '__author_facet_hier_fq_author': [
+          'filter_author_facet_hier_fq_author': [
               'AND',
               'author_facet_hier:"0/Accomazzi, A"'
             ],


### PR DESCRIPTION
Allows filters applied through facets to remain in the URL between searches, page can be refreshed and the filters stick.

Initially testing this out, it makes the URL pretty long -- but I believe the 3 filter max will restrict it some.  We will have to do some testing to be sure it's okay.

Resolves: #1462 