### PR TITLE
Route Associated Links Within App

### DIFF
--- a/src/js/components/analytics.js
+++ b/src/js/components/analytics.js
@@ -15,10 +15,15 @@ define([
    */
   var TARGETS = {
     'resolver': {
-      hooks: ['toc-link-followed', 'abstract-link-followed', 'citations-link-followed'],
+      hooks: [
+        'toc-link-followed',
+        'abstract-link-followed',
+        'citations-link-followed',
+        'associated-link-followed'
+      ],
       types: [
         'abstract', 'citations', 'references',
-        'metrics', 'coreads', 'graphics'
+        'metrics', 'coreads', 'graphics', 'associated'
       ],
       url: _.template('link_gateway/<%= bibcode %>/<%= target %>')
     }
@@ -46,11 +51,11 @@ define([
 
     // if label or data is not present, do nothing
     if (_.isString(label) || _.isPlainObject(data)) {
-      _.forEach(TARGETS, function (val, key) {
+      _.forEach(TARGETS, function (val) {
 
         // send event if we find a hook and the target is in the list of types
         if (_.contains(val.hooks, label) && _.contains(val.types, data.target)) {
-          sendEvent(val.url(data));
+          sendEvent(data.url ? data.url : val.url(data));
         }
       });
     }

--- a/src/js/widgets/associated/components/app.jsx.js
+++ b/src/js/widgets/associated/components/app.jsx.js
@@ -38,7 +38,7 @@ define([
     <ul style={styles.list}>
       {items.map(i =>
         <li key={i.id} style={styles.link}>
-          <a href={i.url} target="_blank" onClick={e => onClick(i)}>{i.name}</a>
+          <a href={i.url} onClick={e => onClick(i)}>{i.name}</a>
         </li>
       )}
     </ul>
@@ -75,19 +75,22 @@ define([
     }
 
     // check items length, and slice them smaller if necessary
-    componentWillReceiveProps(props) {
-      if (props.items.length > 4) {
+    componentWillReceiveProps({ items }) {
+      if (items.length > 4) {
         this.setState({
-          items: props.items.slice(0, 4),
+          items: items.slice(0, 4),
           showAllBtn: true
         });
       } else {
-        this.setState({ items: props.items });
+        this.setState({
+          items: items,
+          showAllBtn: false
+        });
       }
     }
 
     render() {
-      const { loading, handleLinkClick, hasError } = this.props;
+      const { handleLinkClick } = this.props;
       const { items, showAllBtn } = this.state;
 
       if (items.length > 0) {

--- a/src/js/widgets/associated/components/app.jsx.js
+++ b/src/js/widgets/associated/components/app.jsx.js
@@ -38,7 +38,9 @@ define([
     <ul style={styles.list}>
       {items.map(i =>
         <li key={i.id} style={styles.link}>
-          <a href={i.url} onClick={e => onClick(i)}>{i.name}</a>
+          {i.circular ? i.name :
+            <a href={i.url} onClick={e => onClick(i)}>{i.name}</a>
+          }
         </li>
       )}
     </ul>

--- a/src/js/widgets/associated/redux/middleware/api.js
+++ b/src/js/widgets/associated/redux/middleware/api.js
@@ -73,8 +73,19 @@ define([
    * @param {array} items - The array to parse
    */
   const parseItems = (items) => {
+    const parseUrl = (url) => {
+      try {
+
+        // decode and rip the "/#abs..." part off the url
+        return decodeURIComponent(url.slice(url.indexOf(':') + 1));
+      } catch (e) {
+        return url;
+      }
+    }
+
     return _.map(items, i => ({
-      url: i.url,
+      rawUrl: i.url,
+      url: parseUrl(i.url),
       name: i.title,
       id: _.uniqueId()
     }));

--- a/src/js/widgets/associated/widget.jsx.js
+++ b/src/js/widgets/associated/widget.jsx.js
@@ -80,15 +80,17 @@ define([
       BaseWidget.prototype.dispatchRequest.call(this, query);
     },
     composeRequest: function (apiQuery) {
-      const { getState } = this.store;
-      const { bibcode } = getState().api;
+      const { bibcode } = this.store.getState().api;
       return new ApiRequest({
         target: `${ApiTargets.RESOLVER}/${bibcode}/associated`,
         query: new ApiQuery()
       });
     },
     emitAnalytics: function (data) {
-      analytics('send', 'event', 'interaction', 'associated-link-followed', data);
+      analytics('send', 'event', 'interaction', 'associated-link-followed', {
+        target: 'associated',
+        url: data.rawUrl
+      });
     },
     onApiFeedback: function (feedback) {
       const { dispatch } = this.store;


### PR DESCRIPTION
- Makes associated widget links transition to a route, instead of loading the redirect in another page.
- Makes an GET request to link_gateway to log the click
- Minor cleanup and updates