### PR TITLE
Fix safari issue

### DIFF
--- a/src/404.html
+++ b/src/404.html
@@ -1,37 +1,56 @@
 <!doctype html>
 <html>
 <head>
-    <link rel="preload" href="./styles/css/styles.css" as="style">
-    <link rel="stylesheet" href="./styles/css/styles.css">
-    <script src="//cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
-    <script>
-        !window.requirejs && document.write('<script src="./libs/requirejs/require.js">\x3C/script>');
-    </script>
-    <script>
-        require.config({
-            paths: {
-                'underscore': '//cdnjs.cloudflare.com/ajax/libs/lodash.js/2.4.2/lodash.min',
-                'google-analytics': '//www.google-analytics.com/analytics',
-                'analytics': 'js/components/analytics',
-                'jquery': '//cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min'
-            },
-            map: {
-                'analytics': {
-                    'analytics_config': 'discovery.vars'
-                }
-            }
-        });
-        require(['analytics'], function(analytics) {
-            analytics('send', 'pageview');
-            analytics('send', 'event', 'error', 'automatic_redirection', '404.html');
-        });
-    </script>
+  <link rel="preload" href="./styles/css/styles.css" as="style">
+  <link rel="stylesheet" href="./styles/css/styles.css">
+  <script src="//cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
+  <script>
+    !window.requirejs && document.write('<script src="./libs/requirejs/require.js">\x3C/script>');
+  </script>
+  <script>
+    require.config({
+      paths: {
+        'underscore': '//cdnjs.cloudflare.com/ajax/libs/lodash.js/2.4.2/lodash.min',
+        'google-analytics': [
+          '//www.google-analytics.com/analytics',
+          'data:application/javascript,'
+        ],
+        'analytics': 'js/components/analytics',
+        'jquery': '//cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min'
+      },
+      shim: {
+        'google-analytics': {
+          exports: '__ga__'
+        },
+        'analytics': {
+          deps: ['google-analytics']
+        }
+      },
+      callback: function () {
+        require(['discovery.vars'], function (config) {
 
+          // google analytics config
+          window.GoogleAnalyticsObject = '__ga__';
+          window.__ga__ = {
+            q: [
+              ['create', config.googleTrackingCode || '', config.googleTrackingOptions ||
+                'auto'
+              ]
+            ],
+            l: Date.now()
+          };
+        });
+      }
+    });
+    require(['analytics'], function (analytics) {
+      analytics('send', 'pageview');
+      analytics('send', 'event', 'error', 'automatic_redirection', '404.html');
+    });
+  </script>
 </head>
 <body>
-
-<div >
+  <div>
     <p> Bumblebee failed to load. Please try again.</p>
-</div>
+  </div>
 </body>
 </html>

--- a/src/500.html
+++ b/src/500.html
@@ -1,78 +1,92 @@
 <!doctype html>
 <html>
+
 <head>
-    <link rel="preload" href="./styles/css/styles.css" as="style">
-    <link rel="preload" href="//cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js" as="script">
-    <link rel="stylesheet" href="./styles/css/styles.css">
-    <script src="//cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
-    <script>
-        !window.requirejs && document.write('<script src="./libs/requirejs/require.js">\x3C/script>');
-    </script>
-    <script>
-        require.config({
-            paths: {
-                'underscore': '//cdnjs.cloudflare.com/ajax/libs/lodash.js/2.4.2/lodash.min',
-                'google-analytics': '//www.google-analytics.com/analytics',
-                'analytics': 'js/components/analytics',
-                'jquery': '//cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min'
-            },
-            map: {
-                'analytics': {
-                    'analytics_config': 'discovery.vars'
-                }
-            }
+  <link rel="preload" href="./styles/css/styles.css" as="style">
+  <link rel="preload" href="//cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js" as="script">
+  <link rel="stylesheet" href="./styles/css/styles.css">
+  <script src="//cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js"></script>
+  <script>
+    !window.requirejs && document.write('<script src="./libs/requirejs/require.js">\x3C/script>');
+  </script>
+  <script>
+    require.config({
+      paths: {
+        'underscore': '//cdnjs.cloudflare.com/ajax/libs/lodash.js/2.4.2/lodash.min',
+        'google-analytics': [
+          '//www.google-analytics.com/analytics',
+          'data:application/javascript,'
+        ],
+        'analytics': 'js/components/analytics',
+        'jquery': '//cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min'
+      },
+      shim: {
+        'google-analytics': {
+          exports: '__ga__'
+        },
+        'analytics': {
+          deps: ['google-analytics']
+        }
+      },
+      callback: function () {
+        require(['discovery.vars'], function (config) {
+
+          // google analytics config
+          window.GoogleAnalyticsObject = '__ga__';
+          window.__ga__ = {
+            q: [
+              ['create', config.googleTrackingCode || '', config.googleTrackingOptions ||
+                'auto'
+              ]
+            ],
+            l: Date.now()
+          };
         });
-        require(['analytics'], function(analytics) {
-            analytics('send', 'pageview');
-            analytics('send', 'event', 'error', 'automatic_redirection', '404.html');
-        });
-    </script>
+      }
+    });
+    require(['analytics'], function (analytics) {
+      analytics('send', 'pageview');
+      analytics('send', 'event', 'error', 'automatic_redirection', '404.html');
+    });
+  </script>
+  <style>
+    @keyframes moveAcross {
+      from {
+        left: -75%;
+      }
+      to {
+        left: 75%;
+      }
+    }
 
-    <style>
-        @keyframes moveAcross
-        {
-            from {
-                left: -75%;
-            }
-            to {
-                left: 75%;
-            }
-        }
+    body {
+      max-width: 100%;
+      overflow-x: hidden;
+    }
 
-        body {
-            max-width: 100%;
-            overflow-x: hidden;
-        }
+    .mobile-bbb {
+      position: relative;
+      width: 40%;
+      margin-bottom: 40px;
+      animation: moveAcross linear 20s forwards infinite;
+    }
 
-        .mobile-bbb {
-            position: relative;
-            width: 40%;
-            margin-bottom: 40px;
-            animation : moveAcross linear 20s forwards infinite;
-        }
-        p {
-            font-size: 18px;
-        }
-    </style>
-
+    p {
+      font-size: 18px;
+    }
+  </style>
 </head>
 <body>
-
-<div style="text-align: center;margin-top:10%">
-
-    <img src="styles/img/500_bumblerocket.png" alt="500 error image" class="mobile-bbb"/>
-
+  <div style="text-align: center;margin-top:10%">
+    <img src="styles/img/500_bumblerocket.png" alt="500 error image" class="mobile-bbb" />
     <h1>500</h1>
     <h3>We've made an error.</h3>
     <p>
-        <a href="/">Click here to try going to the home page.</a>
+      <a href="/">Click here to try going to the home page.</a>
     </p>
     <p>
-        If that doesn't work, please try again later.
+      If that doesn't work, please try again later.
     </p>
-
-
-</div>
-
+  </div>
 </body>
 </html>

--- a/src/discovery.config.js
+++ b/src/discovery.config.js
@@ -1,4 +1,4 @@
-  // Main config file for the Discovery application
+// Main config file for the Discovery application
 require.config({
   // Initialize the application with the main application file or if we run
   // as a test, then load the test unittests
@@ -150,8 +150,7 @@ require.config({
   // application) see http://requirejs.org/docs/api.html#config-map
   map: {
     '*': {
-      'pubsub_service_impl': 'js/services/default_pubsub',
-      'analytics_config': 'discovery.vars'
+      'pubsub_service_impl': 'js/services/default_pubsub'
     }
   },
 
@@ -231,7 +230,10 @@ require.config({
       '//cdnjs.cloudflare.com/ajax/libs/FileSaver.js/1.3.8/FileSaver.min',
       'libs/file-saver/index'
     ],
-    'google-analytics': '//www.google-analytics.com/analytics',
+    'google-analytics': [
+      '//www.google-analytics.com/analytics',
+      'data:application/javascript,'
+    ],
     'google-recaptcha': '//www.google.com/recaptcha/api.js?&render=explicit&onload=onRecaptchaLoad',
     'hbs': 'libs/require-handlebars-plugin/hbs',
     'immutable': 'libs/immutable/index',
@@ -345,6 +347,10 @@ require.config({
       exports : 'Marionette'
     },
 
+    analytics: {
+      'deps': ['google-analytics']
+    },
+
     cache: {
       exports: 'Cache'
     },
@@ -363,6 +369,10 @@ require.config({
 
     'd3-cloud': {
       deps: ['d3']
+    },
+
+    'google-analytics': {
+      exports: '__ga__'
     },
 
     'jquery-ui' : {
@@ -403,7 +413,19 @@ require.config({
     }
   },
 
-  callback: function() {
+  callback: function () {
+
+    require(['discovery.vars'], function (config) {
+
+      // google analytics config
+      window.GoogleAnalyticsObject = '__ga__';
+      window.__ga__ = {
+        q: [
+          ['create', config.googleTrackingCode || '', config.googleTrackingOptions || 'auto']
+        ],
+        l: Date.now()
+      };
+    });
 
     require([
       'hbs/handlebars'

--- a/src/js/components/analytics.js
+++ b/src/js/components/analytics.js
@@ -1,11 +1,7 @@
-
-
 define([
   'underscore',
-  'require',
-  'analytics_config',
   'jquery'
-], function (_, require, config, $) {
+], function (_, $) {
   /*
    * Set of targets
    * each has a set of hooks which coorespond to the event label passed
@@ -58,48 +54,19 @@ define([
     }
   };
 
-  if (window.GoogleAnalyticsObject) return function () { window[window.GoogleAnalyticsObject].apply(this, arguments); };
+  var ga = window[window.GoogleAnalyticsObject];
 
-  if (!config) {
-    console.error('Analytics will not work because require.config["js/components/analytics"]["require"] does not tells where to find config');
-    return function () {}; // empty function, ignoring
+  window[window.GoogleAnalyticsObject] = function () {
+    ga.q = (_.isArray(ga.q) ? ga.q : []).push(_.toArray(arguments));
+    if (ga.q.length > 100) {
+      ga.q = ga.q.slice(0, 50);
+    }
   }
 
-  var Analytics,
-    gaName = 'ga'; // Global name of analytics object. Defaults to `ga`.
-
-  // Setup temporary Google Analytics objects.
-  window.GoogleAnalyticsObject = gaName;
-  window[gaName] = function () {
-    (
-      window[gaName].q = window[gaName].q || []).push(arguments);
-    // safety measure
-    if (window[gaName].q.length > 100) window[gaName].q = window[gaName].q.slice(0, 50);
-  };
-  window[gaName].l = 1 * new Date();
-
-  // Create a function that wraps `window[gaName]`.
-  // This allows dependant modules to use `window[gaName]` without knowingly
-  // programming against a global object.
-  Analytics = function () {
+  var Analytics = function () {
     adsLogger.apply(null, _.rest(arguments, 3));
-    window[gaName].apply(this, arguments);
+    window[window.GoogleAnalyticsObject].apply(this, arguments);
   };
-
-  // Immediately add a pageview event to the queue.
-  window[gaName]('create', config.googleTrackingCode, config.googleTrackingOptions);
-
-  // Asynchronously load Google Analytics, letting it take over our `window[gaName]`
-  // object after it loads. This allows us to add events to `window[gaName]` even
-  // before the library has fully loaded.
-  var defer = $.Deferred();
-  require(['google-analytics'], function (ga) {
-    defer.resolve();
-  }, function (err) {
-    console.warn('google-analytics could not be loaded; we will work just fine without it', err);
-    defer.reject();
-  });
-  Analytics.promise = defer.promise();
 
   return Analytics;
 });


### PR DESCRIPTION
This fixes an issue that would cause blocked 'google-analytics/*' requests from breaking the site.  

Specifically using extensions such as 'uBlock Origin' or similar which don't block but send back an empty script element, causing an error.