### PR TITLE
Fixes issue with blocked google recaptcha

### DIFF
--- a/src/discovery.config.js
+++ b/src/discovery.config.js
@@ -231,10 +231,13 @@ require.config({
       'libs/file-saver/index'
     ],
     'google-analytics': [
-      '//www.google-analytics.com/analytics',
+      '//google-analytics.com/analytics',
       'data:application/javascript,'
     ],
-    'google-recaptcha': '//www.google.com/recaptcha/api.js?&render=explicit&onload=onRecaptchaLoad',
+    'google-recaptcha': [
+      '//google.com/recaptcha/api.js?&render=explicit&onload=onRecaptchaLoad',
+      'data:application/javascript,'
+    ],
     'hbs': 'libs/require-handlebars-plugin/hbs',
     'immutable': 'libs/immutable/index',
     'jquery': [


### PR DESCRIPTION
Running the site through webpagetest.org, you can see `google*` requests getting long timeouts.  The analytics is working properly, this fixes the same thing with recaptcha.