### PR TITLE
Results jump to entry

### DIFF
--- a/src/js/widgets/abstract/widget.js
+++ b/src/js/widgets/abstract/widget.js
@@ -210,6 +210,7 @@ function (
 
       // and set the title, maintain tags
       document.title = $('<div>' + this.model.get('title') + '</div>').text();
+      $('#app-container').scrollTop(0);
     }
   });
 

--- a/src/js/widgets/results/widget.js
+++ b/src/js/widgets/results/widget.js
@@ -99,8 +99,16 @@ function (
       this.view.collection.reset();
     },
 
-    onStartSearch: function () {
-      this._clearResults();
+    onStartSearch: function (apiQuery) {
+      // quickly check if the query changed
+      try {
+        var recentQuery = this.getBeeHive().getObject('AppStorage').getCurrentQuery().toJSON();
+        var currentQuery = apiQuery.toJSON();
+      } catch (e) {}
+
+      if (!_.isEqual(recentQuery, currentQuery)) {
+        this._clearResults();
+      }
     },
 
     onUserAnnouncement: function (message, data) {


### PR DESCRIPTION
Fixes issue with abstract pages not scrolling back to top on load
Scrolls to the last selected entry on results page
Stops unnecessary resets (going back from abstract page)