### PR TITLE
Fix Firefox Metrics Issue

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
     "bootstrap-js-components": "~3.1.1",
     "bootstrap-sass": "bootstrap-sass-official#~3.3.5",
     "bourbon": "~4.2.4",
-    "d3": "~3.5.5",
+    "d3": "~3.4.6",
     "d3-cloud": "~1.2.5",
     "dsjslib": "https://github.com/monmohan/dsjslib.git#v0.6.6",
     "fontawesome": "~4.6.0",

--- a/src/discovery.config.js
+++ b/src/discovery.config.js
@@ -212,7 +212,7 @@ require.config({
       'libs/create-react-class/index'
     ],
     'd3': [
-      '//cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min',
+      '//cdnjs.cloudflare.com/ajax/libs/d3/3.4.6/d3.min',
       'libs/d3/d3.min'
     ],
     'd3-cloud': [
@@ -544,17 +544,21 @@ require.config({
             lb.enter().append("rect").classed("legend-box", true)
             li.enter().append("g").classed("legend-items", true)
 
-            svg.selectAll("[data-legend]").each(function() {
-              var self = d3.select(this)
-              items[self.attr("data-legend")] = {
-                pos: self.attr("data-legend-pos") || this.getBBox().y,
-                color: self.attr("data-legend-color") != undefined ? self.attr("data-legend-color") :
-                  self.style("fill") != 'none' ? self.style("fill") : self.style("stroke")
-              }
-            })
+            try {
+              svg.selectAll("[data-legend]").each(function() {
+                var self = d3.select(this)
+                items[self.attr("data-legend")] = {
+                  pos: self.attr("data-legend-pos") || this.getBBox().y,
+                  color: self.attr("data-legend-color") != undefined ? self.attr("data-legend-color") :
+                    self.style("fill") != 'none' ? self.style("fill") : self.style("stroke")
+                }
+              })
+            } catch (e) {
+              // firefox tends to have issue with hidden elements
+              // should continue if it doesn't die here
+            }
 
-            items = d3.entries(items).sort(function(a, b) { return a.value.pos - b.value.pos })
-
+            items = d3.entries(items).sort(function(a, b) { return a.value.pos - b.value.pos });
             var itemOffset = 0;
             li.selectAll("text")
               .data(items, function(d) { return d.key })
@@ -575,16 +579,16 @@ require.config({
               .attr("cy", function(d, i) { return i - 0.25 + "em" })
               .attr("cx", 0)
               .attr("r", "0.4em")
-              .style("fill", function(d) { console.log(d.value.color); return d.value.color })
+              .style("fill", function(d) { return d.value.color })
 
             // Reposition and resize the box
-            var lbbox = li[0][0].getBBox()
+            var lbbox = li[0][0].getBBox();
             lb.attr("x", (lbbox.x - legendPadding))
               .attr("y", (lbbox.y - legendPadding))
               .attr("height", (lbbox.height + 2 * legendPadding))
               .attr("width", (lbbox.width + 2 * legendPadding))
           });
-          return g
+          return g;
         }
       })();
     });

--- a/src/js/widgets/metrics/widget.js
+++ b/src/js/widgets/metrics/widget.js
@@ -177,15 +177,14 @@ define([
         .attr('data-legend', _.identity)
         .attr('data-legend-color', function (d, i) { return that.colors[i]; });;
 
-      var legend = svg.append('g')
+      // must delay to make sure element exists
+      setTimeout(function () {
+        svg.append('g')
         .attr('class', 'legend')
         .attr('transform', 'translate(70, 20)')
         .attr('data-style-padding', 7)
         .style('font-size', '12px')
         .call(d3.legend);
-
-      setTimeout(function () {
-        legend.call(d3.legend);
       }, 500);
 
       // cache it so it can be applied to the rects later
@@ -484,9 +483,9 @@ define([
           .attr({
             'class': 'info-box',
             'width': '200px',
-            'height': '100px'
+            'height': '100px',
+            'x': '100'
           }).style({
-            'padding-left': '100px',
             'opacity': 0.75,
             'font-size': '0.60em'
           });
@@ -624,15 +623,14 @@ define([
         .attr('data-legend', _.identity)
         .attr('data-legend-color', function (d, i) { return that.colors[i]; });;
 
-      var legend = svg.append('g')
+      // must delay to make sure the element is available
+      setTimeout(function () {
+        svg.append('g')
         .attr('class', 'legend')
         .attr('transform', 'translate(70, 36)')
         .attr('data-style-padding', 7)
         .style('font-size', '12px')
         .call(d3.legend);
-
-      setTimeout(function () {
-        legend.call(d3.legend);
       }, 500);
     },
 
@@ -739,6 +737,17 @@ define([
       _.bindAll(this, 'setCurrentQuery', 'processMetrics', 'checkIfSimpleRequired');
       var pubsub = beehive.getService('PubSub');
       pubsub.subscribe(pubsub.INVITING_REQUEST, this.setCurrentQuery);
+      this.activateWidget();
+      this.attachGeneralHandler(this.onApiFeedback);
+    },
+
+    onApiFeedback: function () {
+      this.closeWidget();
+      pubsub.publish(pubsub.ALERT, new ApiFeedback({
+        code: 0,
+        msg: 'Sorry Metrics are unavailable at this time, try again later',
+        type: 'danger'
+      }));
     },
 
     closeWidget: function () {


### PR DESCRIPTION
Fixes the issue with firefox and the metrics charts not showing.  Mainly the issue was that firefox doesn't like to style svg elements that are hidden initially, which is supported by the other browsers.  Delaying the render of the legends does the trick.

Also, adds a bit of error handling, closing the metrics widget when a request fails.

resolves #1574 
resolves #1575 