### PR TITLE
Fix Links

### DIFF
--- a/src/js/widgets/preferences/templates/openurl.html
+++ b/src/js/widgets/preferences/templates/openurl.html
@@ -95,7 +95,7 @@
             <p>
               If you find your institution in the above list, please select it so that we
               can generate the appropriate links for you. For more information,
-              please visit our <a href="//adsabs.github.io/help/userpreferences/library-servers">Help Docs.</a>
+              please visit our <a rel="noopener" target="_blank" href="//adsabs.github.io/help/userpreferences/library-servers">Help Docs.</a>
             </p>
           </div>
           <div class="col-md-4"></div>


### PR DESCRIPTION
Somewhat hacky way of doing this globally to links.  This will run on all page transitions, every second for 10 seconds it'll check for links (to get around waiting for things to finish loading).  In the future it would be better to have a page event that lets us know when widgets are finished loading.