### PR TITLE
remove redirect_uri from the /bootstrap request

### DIFF
--- a/src/js/mixins/api_access.js
+++ b/src/js/mixins/api_access.js
@@ -49,7 +49,6 @@ function (
     getApiAccess: function (options) {
       options = options || {};
       var api = this.getBeeHive().getService('Api');
-      var redirect_uri = location.origin + location.pathname;
       var self = this;
       var defer = $.Deferred();
 
@@ -57,7 +56,7 @@ function (
       var request = options.tokenRefresh ? '_request' : 'request';
 
       api[request](new ApiRequest({
-        query: new ApiQuery({ redirect_uri: redirect_uri }),
+        query: new ApiQuery(),
         target: this.bootstrapUrls ? this.bootstrapUrls[0] : '/accounts/bootstrap'
       }),
       {


### PR DESCRIPTION
The parameter is disallowed for anonymous applications and for bbb it makes sense not to used it