### PR TITLE
Fix bootstrap persistence

### DIFF
--- a/src/js/apps/discovery/main.js
+++ b/src/js/apps/discovery/main.js
@@ -37,7 +37,10 @@ define(['config', 'module'], function (config, module) {
     var debug = window.location.href.indexOf('debug=true') > -1;
 
     // app object will load everything
-    var app = new (Application.extend(DiscoveryBootstrap))({ debug: debug, timeout: 30000 });
+    var app = new (Application.extend(DiscoveryBootstrap))({
+      debug: debug,
+      timeout: 300000 // 5 minutes
+    });
 
     // load the objects/widgets/modules (using discovery.config.js)
     var defer = app.loadModules(module.config());

--- a/src/js/mixins/api_access.js
+++ b/src/js/mixins/api_access.js
@@ -38,9 +38,7 @@ function (
         var userName = data.anonymous ? undefined : data.username;
         userObject.setUser(userName);
         var storage = beehive.getService('PersistentStorage');
-        if (_.isPlainObject(storage) && _.isFunction(storage.set)) {
-          storage.set('appConfig', data);
-        }
+        storage && storage.set && storage.set('appConfig', data);
       } else {
         console.warn('bootstrap didn\'t provide access_token!');
       }


### PR DESCRIPTION
Fixes issue that was causing the bootstrap to not persist
Also increases the app timeout from 30 seconds to 5 minutes.  

The idea is that if it takes more than 30 seconds because of an error most likely the user will reload, otherwise if they wait it should load after some time on slow connections.