### PR TITLE
Add Canonical Bibcode Url for Abstracts

### DIFF
--- a/src/js/widgets/abstract/templates/abstract_template.html
+++ b/src/js/widgets/abstract/templates/abstract_template.html
@@ -82,13 +82,11 @@
     {{/if}}
 
     <dt>Bibcode</dt>
-    <dd>{{bibcode}} <i class="icon-help" data-toggle="popover" data-content="The bibcode is assigned by the ADS as a unique identifier for the paper."></i></dd>
-    <dt>Permalink:</dt>
     <dd>
       <a href="#abs/{{bibcode}}/abstract">
-        <div class="sr-only">Permalink to abstract</div>
-        <i class="fa fa-link"></i>
+        {{ bibcode }}
       </a>
+      <i class="icon-help" data-toggle="popover" data-content="The bibcode is assigned by the ADS as a unique identifier for the paper."></i>
     </dd>
 
     {{#if keyword}}


### PR DESCRIPTION
Swapped out the permalink for just making the bibcode a link, similar to how it is done in classic