### PR TITLE
Add pubnote to Abstract Pages

### DIFF
--- a/src/js/widgets/abstract/templates/abstract_template.html
+++ b/src/js/widgets/abstract/templates/abstract_template.html
@@ -60,7 +60,7 @@
 <dl class="s-abstract-dl-horizontal">
 
     {{#if pub_raw}}
-    <dt>Publication</dt>
+    <dt>Publication:</dt>
     <dd>
         <div id="article-publication">{{{pub_raw}}}</div>
     </dd>
@@ -81,7 +81,7 @@
     </dd>
     {{/if}}
 
-    <dt>Bibcode</dt>
+    <dt>Bibcode:</dt>
     <dd>
       <a href="#abs/{{bibcode}}/abstract">
         {{ bibcode }}
@@ -91,7 +91,7 @@
 
     {{#if keyword}}
     <div id="keywords">
-        <dt>Keywords</dt>
+        <dt>Keywords:</dt>
         <dd>
             <ul class="list-inline">
                 {{#each keyword}}
@@ -108,7 +108,7 @@
 
     {{#if comment}}
     <div id="comment">
-        <dt>Comments</dt>
+        <dt>Comments:</dt>
         <dd>
             <ul class="list-unstyled">
                 {{#each commentList}}
@@ -126,6 +126,25 @@
     </div>
     {{/if}}
 
+    {{#if pubnote}}
+    <div id="pubnote">
+        <dt>E-Print Comments:</dt>
+        <dd>
+            <ul class="list-unstyled">
+                {{#each pubnoteList}}
+                    <li>{{{this}}}</li>
+                {{/each}}
+                {{#if hasExtraPubnotes}}
+                    {{#if showAllPubnotes}}
+                    <li><a href="#" id="show-less-pubnotes">show less</a></li>
+                    {{else}}
+                    <li><a href="#" id="show-all-pubnotes">show all</a></li>
+                    {{/if}}
+                {{/if}}
+            </ul>
+        </dd>
+    </div>
+    {{/if}}
 
 </dl>
 <br/>

--- a/src/js/widgets/abstract/widget.js
+++ b/src/js/widgets/abstract/widget.js
@@ -45,7 +45,8 @@ function (
         'pub_raw': undefined,
         'doi': undefined,
         'citation_count': undefined,
-        'titleLink': undefined
+        'titleLink': undefined,
+        'pubnote': undefined
       };
     },
 
@@ -127,6 +128,23 @@ function (
         doc.commentList = _.first(doc.comment, MAX_COMMENTS);
       }
 
+      if (doc.pubnote) {
+        if (!_.isArray(doc.pubnote)) {
+          doc.pubnote = [doc.pubnote];
+        }
+
+        var tmp = doc.pubnote;
+        // attempt to parse it out
+        try {
+          doc.pubnote = doc.pubnote[0].split(';');
+        } catch (e) {
+          // do nothing
+          doc.pubnote = tmp;
+        }
+        doc.hasExtraPubnotes = doc.pubnote.length > MAX_COMMENTS;
+        doc.pubnoteList = _.first(doc.pubnote, MAX_COMMENTS);
+      }
+
       return doc;
     }
   });
@@ -146,6 +164,8 @@ function (
     events: {
       'click #show-all-comments': 'showAllComments',
       'click #show-less-comments': 'showLessComments',
+      'click #show-all-pubnotes': 'showAllPubnotes',
+      'click #show-less-pubnotes': 'showLessPubnotes',
       'click #toggle-aff': 'toggleAffiliation',
       'click #toggle-more-authors': 'toggleMoreAuthors',
       'click a[data-target="more-authors"]': 'toggleMoreAuthors',
@@ -168,6 +188,24 @@ function (
       m.set({
         commentList: _.first(m.get('comment'), MAX_COMMENTS),
         showAllComments: false
+      });
+    },
+
+    showAllPubnotes: function (e) {
+      e.preventDefault();
+      var m = this.model;
+      m.set({
+        pubnoteList: m.get('comment'),
+        showAllPubnotes: true
+      });
+    },
+
+    showLessPubnotes: function (e) {
+      e.preventDefault();
+      var m = this.model;
+      m.set({
+        pubnoteList: _.first(m.get('pubnote'), MAX_COMMENTS),
+        showAllPubnotes: false
       });
     },
 
@@ -240,7 +278,7 @@ function (
     },
 
     defaultQueryArguments: {
-      fl: 'title,abstract,comment,bibcode,author,keyword,id,citation_count,[citations],pub,aff,volume,pubdate,doi,pub_raw,page',
+      fl: 'title,abstract,comment,bibcode,author,keyword,id,citation_count,[citations],pub,pubnote,aff,volume,pubdate,doi,pub_raw,page',
       rows: 1
     },
 


### PR DESCRIPTION
Resolves #1658 

Added `pubnote` as "E-Print Comments," we can update the name if we decide to anytime.
In lieu of the permalink, the bibcode is now a link

![image](https://user-images.githubusercontent.com/6970899/49753863-9a54d900-fc82-11e8-90ed-bb6783fc8595.png)
