### PR TITLE
fix orcid modal not redirecting after close

### DIFF
--- a/src/js/apps/discovery/navigator.js
+++ b/src/js/apps/discovery/navigator.js
@@ -757,7 +757,10 @@ function (
               alerter.alert(new ApiFeedback({
                 code: ApiFeedback.CODES.ALERT,
                 msg: 'Error getting OAuth code to access ORCID',
-                modal: true
+                modal: true,
+                events: {
+                  'click': 'button[data-dismiss=modal]'
+                }
               })).done(function() {
                 self.get('index-page').execute(); // after modal is closed
               })

--- a/src/js/components/alerts_mediator.js
+++ b/src/js/components/alerts_mediator.js
@@ -47,7 +47,7 @@ function (
         console.error('If you want to use AlertController, you also need to have a Widget capable of displaying the messages (default: AlertsWidget)');
         pubsub.publish(pubsub.BIG_FIRE, "Alerts Widget not available");
       });
-      
+
     },
 
     onNavigate: function (route) {
@@ -113,12 +113,12 @@ function (
         .fail(function() {
           defer.reject();
         })
-      } 
+      }
       return defer.promise();
     },
 
     alert: function (apiFeedback) {
-      
+
       var defer = $.Deferred();
       this.getWidget().done(function(w) {
         if (!w) {
@@ -127,7 +127,7 @@ function (
         }
         else {
           // since alerts widget returns a promise that gets
-          // resolved once the widget rendered; we have to 
+          // resolved once the widget rendered; we have to
           // wait little bit more
           w.alert(apiFeedback).done(function() {
             defer.resolve.apply(defer, arguments);

--- a/src/js/widgets/alerts/widget.js
+++ b/src/js/widgets/alerts/widget.js
@@ -45,6 +45,11 @@ function (
       * this allows for custom events to be added to the alert views
       * when the events happen, a promise is resolved with the name of the event
       * NOTE: this assumes there is only 1 event per alert view
+      *
+      * Need to add events object to apiFeedback passed into alerts:
+      * events: {
+      *   'click': 'button[data-dismiss=modal]'
+      * }
       * */
 
   function delegateAdditionalEvents() {


### PR DESCRIPTION
Fixes issue with orcid modal doing nothing after clicking close.  I think in the future the alerts should expose a better events api instead of expecting the calling methods to know the element selector.