### PR TITLE
fix vis not opening

### DIFF
--- a/src/js/apps/discovery/navigator.js
+++ b/src/js/apps/discovery/navigator.js
@@ -875,8 +875,7 @@ function (
       this.set('visualization-closed', this.get('results-page'));
 
       var showResultsPage = function (pages, toActivate) {
-        return app.getObject('MasterPageManager').show('SearchPage',
-          pages)
+        return app.getObject('MasterPageManager').show('SearchPage', pages);
       };
 
       /*

--- a/src/js/apps/discovery/router.js
+++ b/src/js/apps/discovery/router.js
@@ -111,8 +111,11 @@ function (
       if (query) {
         try {
           var q = new ApiQuery().load(query);
-          this.routerNavigate('search-page', {q: q, page: 'show-' + widgetName, replace: true })
-
+          this.routerNavigate('search-page', {
+            q: q,
+            page: widgetName && ('show-' + widgetName),
+            replace: true
+          });
         } catch (e) {
           console.error('Error parsing query from a string: ', query, e);
           this.getPubSub().publish(this.getPubSub().NAVIGATE, 'index-page');

--- a/src/js/wraps/discovery_mediator.js
+++ b/src/js/wraps/discovery_mediator.js
@@ -28,9 +28,6 @@ function (
       var child = mpm.getCurrentActiveChild();
       if (child.view && child.view.showCols) {
         child.view.showCols({ right: false, left: false });
-        // open the view again
-        this.getBeeHive().getService('PubSub').once(this.getPubSub().START_SEARCH,
-          _.once(function () { child.view.showCols({ right: true }); }));
       }
     }
     this.getBeeHive().getService('PubSub').once(this.getPubSub().DELIVERING_REQUEST, _.bind(function (apiRequest, psk) {
@@ -428,11 +425,7 @@ function (
               && app.getPluginOrWidgetName(senderKey.getId()) != 'widget:SearchWidget'
               && app.getWidgetRefCount('Results') >= 1
           ) {
-            // simply navigate to search results page, widgets are already stocked with data
-            if (app.hasService('Navigator')) {
-              app.getService('Navigator').navigate('results-page', { replace: true });
-              stupidGoAhead = false;
-            }
+            stupidGoAhead = false;
           }
 
           if (this.getCurrentPage() !== 'SearchPage' && app.getWidgetRefCount('Results') <= 0) {


### PR DESCRIPTION
@romanchyla this was the culprit as far as I can tell for why the `Explore` menu is doing this double routing thing.  Any reason these lines can't be removed? I haven't seen any negative impact.

The navigator works initially to route to `/metrics` but when `START_SEARCH` is triggered, it hits the navigate line in discovery.mediator and routes back to `/search`

Resolves: #1736 