### PR TITLE
Fix Navigation/History Issue

### DIFF
--- a/src/js/apps/discovery/router.js
+++ b/src/js/apps/discovery/router.js
@@ -111,7 +111,10 @@ function (
       if (query) {
         try {
           var q = new ApiQuery().load(query);
-          this.routerNavigate('search-page', {q: q, page: 'show-' + widgetName, replace: true })
+          this.routerNavigate('search-page', {
+            q: q,
+            page: widgetName && 'show-' + widgetName
+          });
 
         } catch (e) {
           console.error('Error parsing query from a string: ', query, e);

--- a/src/js/widgets/abstract/widget.js
+++ b/src/js/widgets/abstract/widget.js
@@ -260,7 +260,9 @@ function (
       if (MathJax) MathJax.Hub.Queue(['Typeset', MathJax.Hub, this.el]);
 
       // and set the title, maintain tags
-      document.title = $('<div>' + this.model.get('title') + '</div>').text();
+      if (document.title === 'NASA/ADS Search' && this.model.has('title')) {
+        document.title = $('<div>' + this.model.get('title') + '</div>').text() + ' - ' + document.title;
+      }
       if (!window.__PRERENDERED) {
         document.body.scrollTop = document.documentElement.scrollTop = 0;
         $('#app-container').scrollTop(0);


### PR DESCRIPTION
Fixes issue that caused double history entries on search page
Adds better document titles
Removes most of the `replaceState` calls, making history a little more complete (as in all sub-pages are added)
Fixes the issue with default collections getting combined (mostly)