### PR TITLE
More qa fixes

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -45,7 +45,6 @@ http{
 
               expires 6M;
 
-
               # forbid browsers to cache the main index and the discovery.config....js
               location ^~ /discovery.config {
                   expires 0;
@@ -78,7 +77,7 @@ http{
               }
         }
 
-
+        # the rules below are for push-state
         location /search/ {
             alias /app/production/;
             index index.html;
@@ -92,7 +91,7 @@ http{
             include /etc/nginx/mime.types;
             try_files $uri /index.html;
         }
-        
+
         location /user/ {
             alias /app/production/;
             index index.html;
@@ -114,6 +113,26 @@ http{
             try_files $uri /index.html;
         }
 
+        location /public-libraries {
+            alias /app/production/;
+            index index.html;
+            include /etc/nginx/mime.types;
+            try_files $uri /index.html;
+        }
+
+        location /classic-form {
+            alias /app/production/;
+            index index.html;
+            include /etc/nginx/mime.types;
+            try_files $uri /index.html;
+        }
+
+        location /paper-form {
+            alias /app/production/;
+            index index.html;
+            include /etc/nginx/mime.types;
+            try_files $uri /index.html;
+        }
     }
 
     server {

--- a/src/js/apps/discovery/main.js
+++ b/src/js/apps/discovery/main.js
@@ -129,62 +129,6 @@ define(['discovery.config', 'module'], function (config, module) {
             window.bbb = app;
           }
 
-            // apply a global link handler for push state
-
-          var routes = [
-            'classic-form',
-            'paper-form',
-            'index',
-            'search',
-            'execute-query',
-            'abs',
-            'user',
-            'orcid-instructions',
-            'public-libraries'
-          ];
-          var regx = new RegExp('^#(\/?(' + routes.join('|') + ').*\/?)?$', 'i');
-
-          var $el = [];
-          var transformHref = function (ev) {
-            if (!Backbone.history
-              || !Backbone.history.options
-              || !Backbone.history.options.pushState
-            ) return;
-            $el = $(ev.currentTarget);
-            var href = $el.attr('href');
-            if (regx.test(href)) {
-              var url = href.replace(/^\/?#\/?/, '/');
-              $el.attr('href', url);
-              return false;
-            }
-            $el = [];
-          };
-
-          var handleNavigation = function (el) {
-            if ($el.length && window.bbb) {
-              var href = $el.attr('href');
-
-              // clear it so we don't have one lingering around
-              $el = [];
-              try {
-                var nav = bbb.getBeeHive().getService('Navigator');
-                nav.router.navigate(href, { trigger: true, replace: false });
-                return false;
-              } catch (e) {
-                console.error(e.message);
-              }
-            }
-            return true;
-          };
-
-          if (Backbone.history
-            && Backbone.history.options
-            && Backbone.history.options.pushState) {
-              $(document)
-                .on('mousedown', 'a', transformHref)
-                .on('click', 'a', handleNavigation);
-            }
-
           // app is loaded, send timing event
 
           if (__PAGE_LOAD_TIMESTAMP) {

--- a/src/js/apps/discovery/router.js
+++ b/src/js/apps/discovery/router.js
@@ -62,9 +62,6 @@ function (
 
     routerNavigate: function (route, options) {
       var options = options || {};
-      // this tells navigator not to create 2 history entries, which causes
-      // problems with the back button
-      _.extend({ replace: false }, options);
       this.getPubSub().publish(this.getPubSub().NAVIGATE, route, options);
     },
 
@@ -112,7 +109,10 @@ function (
       if (query) {
         try {
           var q = new ApiQuery().load(query);
-          this.routerNavigate('search-page', {q: q, page: 'show-' + widgetName, replace: true })
+          this.routerNavigate('search-page', {
+            q: q,
+            page: widgetName && 'show-' + widgetName
+          });
 
         } catch (e) {
           console.error('Error parsing query from a string: ', query, e);

--- a/src/js/apps/discovery/router.js
+++ b/src/js/apps/discovery/router.js
@@ -68,8 +68,8 @@ function (
     routes: {
       '/': 'index',
       '': 'index',
-      'classic-form': 'classicForm',
-      'paper-form': 'paperForm',
+      'classic-form(/)': 'classicForm',
+      'paper-form(/)': 'paperForm',
       'index/(:query)': 'index',
       'search/(:query)(/)(:widgetName)': 'search',
       'execute-query/(:query)': 'executeQuery',

--- a/src/js/components/app_storage.js
+++ b/src/js/components/app_storage.js
@@ -45,6 +45,8 @@ define([
         throw new Error('You must save ApiQuery instance');
       }
       this.set('currentQuery', apiQuery);
+      var ps = this.hasPubSub() && this.getPubSub();
+      ps.publish(ps.UPDATE_CURRENT_QUERY, apiQuery);
       // save to storage
       if (this.getBeeHive().hasService('PersistentStorage')) {
         this.getBeeHive().getService('PersistentStorage').set('currentQuery', apiQuery.toJSON());

--- a/src/js/components/pubsub_events.js
+++ b/src/js/components/pubsub_events.js
@@ -167,7 +167,9 @@ define([], function () {
     * */
     STORAGE_PAPER_UPDATE: '[User]-Paper-Update',
 
-    LIBRARY_CHANGE: '[PubSub]-Library-Change'
+    LIBRARY_CHANGE: '[PubSub]-Library-Change',
+
+    'UPDATE_CURRENT_QUERY': '[User]-Update-Current-Query'
 
   };
 

--- a/src/js/components/query_mediator.js
+++ b/src/js/components/query_mediator.js
@@ -202,7 +202,7 @@ function (
       }
 
       // check if this is an "object:" query
-      else if (apiQuery.get('q')[0].indexOf('object:') > -1) {
+      else if (apiQuery.has('q') && apiQuery.get('q')[0].indexOf('object:') > -1) {
         // we have an "object:" query as part of the query
         // first define a callback function to process the response of the micro service
         // and bind it to "this" so that we can use the trigger
@@ -223,6 +223,15 @@ function (
        * Happens at the beginning of the new search cycle. This is the 'race started' signal
        */
     startSearchCycle: function (apiQuery, senderKey) {
+
+      // If we are passed a blank query, it will fail below this
+      // set the q param to make sure we at least can start cycle
+      if (!(apiQuery instanceof ApiQuery)) {
+        apiQuery = new ApiQuery({ q: '*:*' });
+      } else if (!apiQuery.has('q')) {
+        apiQuery.set('q', '*:*');
+      }
+
       // we have to clear selected records in app storage here too
       if (this.getBeeHive().getObject('AppStorage')) {
         this.getBeeHive().getObject('AppStorage').clearSelectedPapers();

--- a/src/js/mixins/side_bar_manager.js
+++ b/src/js/mixins/side_bar_manager.js
@@ -1,0 +1,74 @@
+/**
+ * manages the state of the side bars
+ */
+define([
+  'backbone',
+  'js/components/api_feedback'
+], function (Backbone, ApiFeedback) {
+
+  var state = new (Backbone.Model.extend({
+    defaults: {
+      hide: true
+    }
+  }));
+
+  var SideBarManager = {
+    _getUpdateFromUserData: function () {
+      try {
+        var ud = this.getBeeHive().getObject('User').getUserData();
+        if (!ud) return false;
+
+        return /hide/i.test(ud.defaultHideSidebars);
+      } catch (e) {
+        return false;
+      }
+    },
+
+    init: function () {
+      state.set('hide', this._getUpdateFromUserData());
+      _.bindAll(this, ['_onFeedback', '_onUserAnnouncement', '_update']);
+      var ps = this.getPubSub();
+      if (!ps) return;
+      ps.subscribe(ps.FEEDBACK, this._onFeedback);
+      ps.subscribe(ps.USER_ANNOUNCEMENT, this._onUserAnnouncement);
+      state.on('change:hide', this._update);
+    },
+
+    _update: function () {
+      var val = this.getSidebarState();
+      var view = this.view;
+      if (view && view.showCols) {
+        view.showCols({ left: val, right: val });
+      }
+      this.broadcast('page-manager-message', 'side-bars-update', val);
+      this.trigger('page-manager-message', 'side-bars-update', val);
+    },
+
+    _onUserAnnouncement: function () {
+      state.set('hide', this._getUpdateFromUserData());
+    },
+
+    _onFeedback: function (feedback) {
+      switch(feedback.code) {
+        case ApiFeedback.CODES.MAKE_SPACE:
+        case ApiFeedback.CODES.UNMAKE_SPACE:
+          this._update();
+      };
+    },
+
+    toggleSidebarState: function () {
+      this.setSidebarState(!this.getSidebarState());
+    },
+
+    setSidebarState: function (value) {
+      state.set('hide', value);
+      state.trigger('change:hide');
+    },
+
+    getSidebarState: function () {
+      return state.get('hide');
+    }
+  };
+
+  return SideBarManager;
+});

--- a/src/js/page_managers/toc_controller.js
+++ b/src/js/page_managers/toc_controller.js
@@ -97,15 +97,7 @@ function (_, Marionette, BasicPageManagerController, TOCWidget, analytics) {
         data.widgetId = widgetId;
         this.broadcast('page-manager-message', event, data);
       } else if (event == 'widget-selected') {
-        this.broadcast('page-manager-message', 'widget-selected', data);
-        this.getPubSub().publish(this.getPubSub().NAVIGATE, data.idAttribute, data);
-
-        var bibcode = widget.model.get('bibcode');
-        var target = data.idAttribute.toLowerCase().replace('show', '');
-        analytics('send', 'event', 'interaction', 'toc-link-followed', {
-          target: target,
-          bibcode: bibcode
-        });
+        this.onWidgetSelected.apply(this, arguments);
       } else if (event == 'broadcast-payload') {
         this.broadcast('page-manager-message', event, data);
       } else if (event == 'navigate') { // XXX:rca - why to almost equal events?
@@ -113,6 +105,17 @@ function (_, Marionette, BasicPageManagerController, TOCWidget, analytics) {
       } else if (event == 'apply-function') { // XXX:rca - to remove
         data.func.apply(this);
       }
+    },
+
+    onWidgetSelected: function (widget, event, data) {
+      var bibcode = widget.model.get('bibcode');
+      var target = data.idAttribute.toLowerCase().replace('show', '');
+      analytics('send', 'event', 'interaction', 'toc-link-followed', {
+        target: target,
+        bibcode: bibcode
+      });
+      this.broadcast('page-manager-message', 'widget-selected', data);
+      this.getPubSub().publish(this.getPubSub().NAVIGATE, data.idAttribute, data);
     },
 
     onPageManagerMessage: _.noop,

--- a/src/js/page_managers/toc_widget.js
+++ b/src/js/page_managers/toc_widget.js
@@ -67,7 +67,7 @@ define([
           m.set('isSelected', false, { silent: true });
         }
       });
-      s.set('isSelected', true);
+      s ? s.set('isSelected', true) : this.first().set('isSelected', true);
     },
 
     comparator: function (m) {
@@ -201,16 +201,13 @@ define([
       }
       var path = this.model.get('path') || 'abstract';
 
-      // only trigger if the bibcode is present or we are not on an abstract page
-      if (this.model.has('bibcode') || path.startsWith('user')) {
-        var data = {
-          idAttribute: this.model.get('idAttribute') || 'showAbstract',
-          subView: this.model.get('subView') || '',
-          href: 'abs/' + (this.model.get('bibcode') || '') + '/' + path,
-          bibcode: this.model.get('bibcode')
-        };
-        this.trigger('page-manager-event', 'widget-selected', data);
-      }
+      var data = {
+        idAttribute: this.model.get('idAttribute') || 'showAbstract',
+        subView: this.model.get('subView') || '',
+        href: 'abs/' + (this.model.get('bibcode') || '') + '/' + path,
+        bibcode: this.model.get('bibcode')
+      };
+      this.trigger('page-manager-event', 'widget-selected', data);
     },
 
     onPageManagerMessage: function (event, data) {

--- a/src/js/widgets/abstract/widget.js
+++ b/src/js/widgets/abstract/widget.js
@@ -260,7 +260,9 @@ function (
       if (MathJax) MathJax.Hub.Queue(['Typeset', MathJax.Hub, this.el]);
 
       // and set the title, maintain tags
-      document.title = $('<div>' + this.model.get('title') + '</div>').text();
+      if (this.model.has('title')) {
+        document.title = $('<div>' + this.model.get('title') + '</div>').text() + ' - NASA/ADS Search';
+      }
       if (!window.__PRERENDERED) {
         document.body.scrollTop = document.documentElement.scrollTop = 0;
         $('#app-container').scrollTop(0);

--- a/src/js/widgets/library_individual/templates/library-header.html
+++ b/src/js/widgets/library_individual/templates/library-header.html
@@ -54,7 +54,7 @@
             <li class="tab s-tab  {{#compare active 'library'}} active {{/compare}}" data-tab="library"><i class="fa fa-list"></i> View Library</li>
             <li class="s-tab s-disabled" title="Add some papers to this library to gain this option"> <i class="icon-export"></i> Export</li>
             <li class="s-tab s-disabled" title="Add some papers to this library to gain this option"><i class="icon-explore"></i> Metrics </li>
-            <li class="s-tab s-disabled" title="Add some papers to this library to gain this option"> <i class="fa fa-eye"></i> Visualize </li>
+            <li class="s-tab s-disabled" title="Add some papers to this library to gain this option"> <i class="fa fa-eye"></i> Explore </li>
             <li class="s-tab s-disabled" title="Add some papers to this library to gain this option"> <i class="fa fa-flask"></i> Citation Helper </li>
         </ul>
     {{else}}
@@ -76,7 +76,7 @@
             <li class="tab s-tab  {{#compare active 'metrics'}} active {{/compare}}" data-tab="metrics"><i class="icon-explore"></i> Metrics </li>
             <li class="tab s-tab dropdown  {{#compare active 'visualization'}} active {{/compare}}">
                 <div data-toggle="dropdown" aria-haspopup="true" role="button" aria-expanded="false">
-                    <i class="fa fa-eye"></i> Visualize
+                    <i class="fa fa-eye"></i> Explore
                     <span class="fa fa-lg fa-caret-down"></span>
                 </div>
                 <ul class="dropdown-menu" role="menu">
@@ -222,7 +222,7 @@
 
             <li class="s-tab s-disabled" title="Add some papers to this library to gain this option"> <i class="icon-export"></i> Export</li>
             <li class="s-tab s-disabled" title="Add some papers to this library to gain this option"><i class="icon-explore"></i> Metrics </li>
-            <li class="s-tab s-disabled" title="Add some papers to this library to gain this option"> <i class="fa fa-eye"></i> Visualize </li>
+            <li class="s-tab s-disabled" title="Add some papers to this library to gain this option"> <i class="fa fa-eye"></i> Explore </li>
             <li class="s-tab s-disabled" title="Add some papers to this library to gain this option"><i class="fa fa-flask"></i> Citation Helper </li>
         </ul>
     {{else}}
@@ -250,7 +250,7 @@
             <li class="tab s-tab  {{#compare active 'metrics'}} active {{/compare}}" data-tab="metrics"><i class="icon-explore"></i> Metrics </li>
             <li class="tab s-tab dropdown  {{#compare active 'visualization'}} active {{/compare}}">
                 <div data-toggle="dropdown" aria-haspopup="true" role="button" aria-expanded="false">
-                    <i class="fa fa-eye"></i> Visualize
+                    <i class="fa fa-eye"></i> Explore
                     <span class="fa fa-lg fa-caret-down"></span>
                 </div>
                 <ul class="dropdown-menu" role="menu">

--- a/src/js/widgets/library_individual/views/library_header.js
+++ b/src/js/widgets/library_individual/views/library_header.js
@@ -71,7 +71,6 @@ define([
       this.$('[data-toggle="tooltip"]').tooltip();
     },
 
-
     formatDate: function (d) {
       return moment.utc(d).local().format('MMM D YYYY, h:mma');
     },

--- a/src/js/widgets/library_individual/widget.js
+++ b/src/js/widgets/library_individual/widget.js
@@ -230,7 +230,7 @@ function (
               __bigquerySource: 'Library: ' + that.headerModel.get('name'),
               sort: 'date desc'
             });
-            pubsub.publish(pubsub.START_SEARCH, query);
+            pubsub.publish(pubsub.NAVIGATE, 'search-page', { q: query });
           });
       }
     }

--- a/src/js/widgets/library_individual/widget.js
+++ b/src/js/widgets/library_individual/widget.js
@@ -84,6 +84,9 @@ function (
             loggedIn: loggedIn
           }
         ));
+
+        // force headerModel to change (render)
+        this.headerModel.trigger('change', this.headerModel);
       }.bind(this);
 
       this.getBeeHive()

--- a/src/js/widgets/list_of_things/paginated_view.js
+++ b/src/js/widgets/list_of_things/paginated_view.js
@@ -56,6 +56,7 @@ function (
         showAbstract: 'closed',
         // often they won't exist
         showHighlights: false,
+        hideSidebars: false,
         pagination: true,
         start: 0,
         highlightsLoaded: false
@@ -136,7 +137,7 @@ function (
     events: {
       'click .show-highlights': 'toggleHighlights',
       'click .show-abstract': 'toggleAbstract',
-      'click .toggle-make-space': 'toggleMakeSpace',
+      'click .toggle-sidebars': 'toggleHideSidebars',
       'click #go-to-bottom': 'goToBottom',
       'click #backToTopBtn': 'goToTop',
       'click a.page-control': 'changePageWithButton',
@@ -165,9 +166,9 @@ function (
       }
     },
 
-    toggleMakeSpace: function () {
-      var val = !this.model.get('makeSpace');
-      this.model.set('makeSpace', val);
+    toggleHideSidebars: function () {
+      var val = !this.model.get('hideSidebars');
+      this.model.set('hideSidebars', val);
       analytics('send', 'event', 'interaction', 'sidebars-toggled-' + val ? 'on' : 'off');
     },
 

--- a/src/js/widgets/network_vis/network_widget.js
+++ b/src/js/widgets/network_vis/network_widget.js
@@ -1316,7 +1316,11 @@ function (Marionette,
 
       var request = new ApiRequest({
         target: Marionette.getOption(this, 'endpoint'),
-        query: new ApiQuery({ bibcodes: bibcodes }),
+        query: new ApiQuery({
+
+          // endpoint caps at 1000
+          bibcodes: bibcodes.slice(0, 1000)
+        }),
         options: {
           type: 'POST',
           contentType: 'application/json'

--- a/src/js/widgets/results/templates/container-template.html
+++ b/src/js/widgets/results/templates/container-template.html
@@ -25,10 +25,10 @@
             {{else}}
               <button class="btn show-abstract btn-sm btn-inverse btn-primary"> Show abstracts</button>
             {{/compare}}
-            {{#if makeSpace}}
-                <button class="btn btn-sm btn-primary toggle-make-space hidden-xs hidden-sm">Show Sidebars</button>
+            {{#if hideSidebars}}
+                <button class="btn btn-sm btn-inverse btn-primary toggle-sidebars hidden-xs hidden-sm">Hide Sidebars</button>
             {{else}}
-                <button class="btn btn-sm btn-inverse btn-primary toggle-make-space hidden-xs hidden-sm">Hide Sidebars</button>
+                <button class="btn btn-sm btn-primary toggle-sidebars hidden-xs hidden-sm">Show Sidebars</button>
             {{/if}}
             <button class="btn-sm btn-link pull-right" id="go-to-bottom">Go To Bottom</button>
           {{/unless}}

--- a/src/js/widgets/tabs/tabs_widget.js
+++ b/src/js/widgets/tabs/tabs_widget.js
@@ -46,11 +46,7 @@ function (
         if (!t.widget) {
           throw new Error('Missing "widget" for: ' + t.title + ' [' + i + ']');
         }
-        if (t['default']) {
-          t.widget.trigger('active');
-        } else {
-          t.widget.trigger('hidden');
-        }
+        t.widget.trigger(t['default'] ? 'active' : 'hidden');
         return t.widget;
       });
       this.on('active', this.onActive);

--- a/src/js/widgets/wordcloud/widget.js
+++ b/src/js/widgets/wordcloud/widget.js
@@ -445,6 +445,7 @@ define([
         // query.set("rows", "1000");
         // this.getPubSub().publish(this.getPubSub().DELIVERING_REQUEST, this.composeRequest(query));
       } else {
+        this.setCurrentQuery(query);
         var request = new ApiRequest({
           target: Marionette.getOption(this, 'endpoint') || ApiTargets.SERVICE_WORDCLOUD,
           query: this.customizeQuery(query),
@@ -453,7 +454,6 @@ define([
             contentType: 'application/json'
           }
         });
-
         this.getPubSub().publish(this.getPubSub().DELIVERING_REQUEST, request);
       }
     },
@@ -468,6 +468,7 @@ define([
       query.set('q', 'bibcode:(' + bibcodes.join(' OR ') + ')');
       query.set('rows', this.max_rows);
 
+      this.setCurrentQuery(query);
       var request = new ApiRequest({
         target: Marionette.getOption(this, 'endpoint') || ApiTargets.SERVICE_WORDCLOUD,
         query: new ApiQuery({ query: JSON.stringify(query.toJSON()) }),
@@ -476,6 +477,7 @@ define([
           contentType: 'application/json'
         }
       });
+
       this.getPubSub().publish(this.getPubSub().EXECUTE_REQUEST, request);
     },
 

--- a/src/js/widgets/wordcloud/widget.js
+++ b/src/js/widgets/wordcloud/widget.js
@@ -538,6 +538,7 @@ define([
 
         this._updateFq(q, newQ);
         this.getPubSub().publish(this.getPubSub().START_SEARCH, q);
+        this.closeWidget();
       }
     },
 

--- a/src/js/wraps/abstract_page_manager/abstract_page_manager.js
+++ b/src/js/wraps/abstract_page_manager/abstract_page_manager.js
@@ -74,7 +74,8 @@ define([
         bibcode: bibcode
       });
 
-      PageManagerController.prototype.onWidgetSelected.apply(this, arguments);
+      // do not navigate, only broadcast
+      this.broadcast('page-manager-message', 'widget-selected', data);
     },
 
     navConfig: {

--- a/src/js/wraps/abstract_page_manager/abstract_page_manager.js
+++ b/src/js/wraps/abstract_page_manager/abstract_page_manager.js
@@ -2,12 +2,14 @@ define([
   'js/page_managers/toc_controller',
   'js/page_managers/three_column_view',
   'hbs!js/wraps/abstract_page_manager/abstract-page-layout',
-  'hbs!js/wraps/abstract_page_manager/abstract-nav'
+  'hbs!js/wraps/abstract_page_manager/abstract-nav',
+  'analytics'
 ], function (
   PageManagerController,
   PageManagerView,
   PageManagerTemplate,
-  TOCTemplate
+  TOCTemplate,
+  analytics
 ) {
   var PageManager = PageManagerController.extend({
 
@@ -33,7 +35,7 @@ define([
       var self = this;
       return PageManagerController.prototype.assemble.apply(this, arguments).done(function() {
         self.addQuery(self.getCurrentQuery());
-      })
+      });
     },
 
     addQuery: function (apiQuery) {
@@ -62,6 +64,17 @@ define([
         bibcode = bibcode[0].replace('bibcode:', '');
         this.widgets.tocWidget.model.set('bibcode', bibcode);
       }
+    },
+
+    onWidgetSelected: function (widget, event, data) {
+      var bibcode = widget.model.get('bibcode');
+      var target = data.idAttribute.toLowerCase().replace('show', '');
+      analytics('send', 'event', 'interaction', 'toc-link-followed', {
+        target: target,
+        bibcode: bibcode
+      });
+
+      PageManagerController.prototype.onWidgetSelected.apply(this, arguments);
     },
 
     navConfig: {

--- a/src/js/wraps/discovery_mediator.js
+++ b/src/js/wraps/discovery_mediator.js
@@ -28,9 +28,6 @@ function (
       var child = mpm.getCurrentActiveChild();
       if (child.view && child.view.showCols) {
         child.view.showCols({ right: false, left: false });
-        // open the view again
-        this.getBeeHive().getService('PubSub').once(this.getPubSub().START_SEARCH,
-          _.once(function () { child.view.showCols({ right: true }); }));
       }
     }
     this.getBeeHive().getService('PubSub').once(this.getPubSub().DELIVERING_REQUEST, _.bind(function (apiRequest, psk) {
@@ -55,15 +52,12 @@ function (
     this._tmp.cycle_started = true;
 
     var app = this.getApp();
-
     if (feedback.query) {
       app.getObject('AppStorage').setCurrentQuery(feedback.query);
       app.getObject('AppStorage').setCurrentNumFound(feedback.numFound);
     } else {
       app.getObject('AppStorage').setCurrentQuery(null);
     }
-
-    //this.getPubSub().publish(this.getPubSub().NAVIGATE, 'results-page');
 
     if (feedback.request && feedback.request.get('target').indexOf('search') > -1 && feedback.query && !feedback.numFound) {
       var q = feedback.query;
@@ -446,8 +440,9 @@ function (
             stupidGoAhead = false;
           }
 
-          if (stupidGoAhead)
+          if (stupidGoAhead) {
             qm.getQueryAndStartSearchCycle.apply(qm, arguments);
+          }
 
         }, this));
       },

--- a/src/js/wraps/discovery_mediator.js
+++ b/src/js/wraps/discovery_mediator.js
@@ -427,6 +427,7 @@ function (
               && apiQuery.url() == storage.getCurrentQuery().url()
               && app.getPluginOrWidgetName(senderKey.getId()) != 'widget:SearchWidget'
               && app.getWidgetRefCount('Results') >= 1
+              && app.getObject('DocStashController').getDocs().length
           ) {
             // simply navigate to search results page, widgets are already stocked with data
             if (app.hasService('Navigator')) {

--- a/src/js/wraps/landing_page_manager/landing_page_manager.js
+++ b/src/js/wraps/landing_page_manager/landing_page_manager.js
@@ -2,12 +2,14 @@ define([
   'js/page_managers/toc_controller',
   'js/page_managers/one_column_view',
   'hbs!js/wraps/landing_page_manager/landing-page-layout',
-  'hbs!js/wraps/landing_page_manager/landing-page-nav'
+  'hbs!js/wraps/landing_page_manager/landing-page-nav',
+  'analytics'
 ], function (
   PageManagerController,
   PageManagerView,
   PageManagerTemplate,
-  TOCTemplate
+  TOCTemplate,
+  analytics
 ) {
   var PageManager = PageManagerController.extend({
 

--- a/src/js/wraps/paper_network.js
+++ b/src/js/wraps/paper_network.js
@@ -706,9 +706,9 @@ function (
     newQuery.set('__bigquery', filterBibcodes);
 
     this.resetWidget();
-    this.getPubSub().publish(this.getPubSub().START_SEARCH, newQuery);
+    var ps = this.getPubSub();
+    ps.publish(ps.NAVIGATE, 'search-page', { q: newQuery });
   };
-
 
   options.widgetName = 'PaperNetwork';
 

--- a/src/js/wraps/results_page_manager.js
+++ b/src/js/wraps/results_page_manager.js
@@ -1,11 +1,14 @@
 define([
   'js/page_managers/controller',
   'js/page_managers/three_column_view',
-  'hbs!js/page_managers/templates/results-page-layout'
+  'hbs!js/page_managers/templates/results-page-layout',
+  'js/mixins/side_bar_manager'
 ], function (
   PageManagerController,
   PageManagerView,
-  PageManagerTemplate) {
+  PageManagerTemplate,
+  SideBarManagerMixin
+) {
   var PageManager = PageManagerController.extend({
 
     persistentWidgets: [
@@ -15,6 +18,13 @@ define([
       'BibgroupFacet', 'DataFacet', 'VizierFacet', 'GrantsFacet', 'Results',
       'OrcidBigWidget', 'QueryInfo', 'GraphTabs', 'OrcidSelector'
     ],
+
+    activate: function () {
+      PageManagerController.prototype.activate.apply(this, arguments);
+
+      // calls the sideBarManager mixin init handler
+      this.init();
+    },
 
     createView: function (options) {
       options = options || {};
@@ -29,8 +39,36 @@ define([
       var button = '<a href="#" class="back-button btn btn-sm btn-default"> <i class="fa fa-arrow-left"></i> Start New Search</a>';
       ret.$el.find('.s-back-button-container').empty().html(button);
       return ret;
-    }
+    },
 
+    assemble: function () {
+      var self = this;
+      return PageManagerController.prototype.assemble.apply(this, arguments).done(function () {
+        _.each(_.keys(self.widgets), function (w) {
+          self.listenTo(self.widgets[w], 'page-manager-event', _.bind(self.onPageManagerEvent, self, self.widgets[w]));
+        }, self);
+      });
+    },
+
+    broadcastTo: _.curry(function (widgets, event) {
+      var args = arguments;
+      var wids = _.pick(this.widgets, widgets);
+      _.each(wids, function (w) {
+        w.trigger.apply(w, [
+          'page-manager-message', event
+        ].concat(_.toArray(args).slice(2)));
+      });
+    }, 2),
+
+    onPageManagerEvent: function (widget, event, data) {
+
+      // this event is emitted from results widget
+      if (event === 'side-bars-update') {
+        this.setSidebarState(data);
+      }
+    }
   });
+
+  _.extend(PageManager.prototype, SideBarManagerMixin);
   return PageManager;
 });

--- a/test/mocha/js/page_managers/toc_manager_test.spec.js
+++ b/test/mocha/js/page_managers/toc_manager_test.spec.js
@@ -130,14 +130,14 @@ define([
                     expect(pageManager.view.$el.find('[data-widget-id="ShowAbstract"]>div').hasClass('s-nav-inactive')).to.be.false;
                     expect(pageManager.view.$el.find('[data-widget-id="ShowReferences"]>div').hasClass('s-nav-inactive')).to.be.false;
 
-                    // click on the link (NAVIGATE event SHOULD be triggered)
+                    // click on the link (NAVIGATE event should NOT be triggered)
                     // navigation happens via the global handler
 
                     var pubsub = app.getService('PubSub').getHardenedInstance();
                     var spy = sinon.spy();
                     pubsub.subscribe(pubsub.NAVIGATE, spy);
                     pageManager.view.$el.find('[data-widget-id="ShowReferences"]').click();
-                    expect(spy.callCount).to.eql(1);
+                    expect(spy.callCount).to.eql(0);
 
                     // it has to be selected and contain numcount
                     //the navigator is what actually selects the nav so I removed that test
@@ -229,8 +229,8 @@ define([
 
               view.$("a[data-widget-id=ShowPaperExport__default]").click();
 
-              // should be navigating
-              expect(spy.args.length).to.be.gt(0);
+              // should NOT navigate
+              expect(spy.args.length).to.eq(0);
 
               pageManager.widgets.ShowPaperExport.setSubView = sinon.spy();
 

--- a/test/mocha/js/page_managers/toc_manager_test.spec.js
+++ b/test/mocha/js/page_managers/toc_manager_test.spec.js
@@ -130,13 +130,14 @@ define([
                     expect(pageManager.view.$el.find('[data-widget-id="ShowAbstract"]>div').hasClass('s-nav-inactive')).to.be.false;
                     expect(pageManager.view.$el.find('[data-widget-id="ShowReferences"]>div').hasClass('s-nav-inactive')).to.be.false;
 
-                    // click on the link (NAVIGATE event should be triggered)
+                    // click on the link (NAVIGATE event SHOULD be triggered)
+                    // navigation happens via the global handler
 
                     var pubsub = app.getService('PubSub').getHardenedInstance();
                     var spy = sinon.spy();
                     pubsub.subscribe(pubsub.NAVIGATE, spy);
                     pageManager.view.$el.find('[data-widget-id="ShowReferences"]').click();
-                    expect(spy.callCount).to.be.gt(0);
+                    expect(spy.callCount).to.eql(1);
 
                     // it has to be selected and contain numcount
                     //the navigator is what actually selects the nav so I removed that test
@@ -228,9 +229,8 @@ define([
 
               view.$("a[data-widget-id=ShowPaperExport__default]").click();
 
-              expect(spy.args[1][0]).to.eql("ShowPaperExport");
-              expect(spy.args[1][1]["idAttribute"]).to.eql("ShowPaperExport");
-              expect(spy.args[1][1]["href"]).to.eql("abs/foo/export");
+              // should be navigating
+              expect(spy.args.length).to.be.gt(0);
 
               pageManager.widgets.ShowPaperExport.setSubView = sinon.spy();
 

--- a/test/mocha/js/widgets/library_individual.spec.js
+++ b/test/mocha/js/widgets/library_individual.spec.js
@@ -794,9 +794,10 @@ define([
 
       setTimeout(function(){
 
-        expect(publishStub.args[0][0]).to.eql("[PubSub]-New-Query");
+        // should navigate
+        expect(publishStub.args[0][0]).to.eql("[Router]-Navigate-With-Trigger");
 
-        expect(publishStub.args[0][1].toJSON()).to.eql({
+        expect(publishStub.args[0][2].q.toJSON()).to.eql({
             "__bigquery": [
               "1",
               "2",

--- a/test/mocha/js/widgets/list_of_things_widget.spec.js
+++ b/test/mocha/js/widgets/list_of_things_widget.spec.js
@@ -327,7 +327,7 @@ define(['marionette',
         widget.trigger("pagination:changePerPage", 50);
         expect(widget.model.get("perPage")).to.eql(50);
 
-        expect(JSON.stringify(widget.model.toJSON())).to.eql('{"mainResults":false,"showAbstract":"closed","showHighlights":"closed","pagination":true,"start":0,"highlightsLoaded":false,"perPage":50,"numFound":100,"currentQuery":{"q":["foo:bar"]},"pageData":{"perPage":50,"totalPages":2,"currentPage":1,"previousPossible":false,"nextPossible":true},"page":0,"showRange":[0,49],"query":false,"loading":false}');
+        expect(JSON.stringify(widget.model.toJSON())).to.eql('{"mainResults":false,"showAbstract":"closed","showHighlights":"closed","hideSidebars":false,"pagination":true,"start":0,"highlightsLoaded":false,"perPage":50,"numFound":100,"currentQuery":{"q":["foo:bar"]},"pageData":{"perPage":50,"totalPages":2,"currentPage":1,"previousPossible":false,"nextPossible":true},"page":0,"showRange":[0,49],"query":false,"loading":false}');
 
         expect($("#per-page-select>option:selected").text().trim()).to.eql("50");
         expect($("input.page-control").val()).to.eql("1");

--- a/test/mocha/js/widgets/lot_derivates.spec.js
+++ b/test/mocha/js/widgets/lot_derivates.spec.js
@@ -96,14 +96,14 @@ define([
       widget.activate(minsub.beehive.getHardenedInstance());
       $("#test").append(widget.getEl());
       minsub.publish(minsub.DISPLAY_DOCUMENTS, new ApiQuery({'q': 'bibcode:bar'}));
-      expect(JSON.stringify(widget.model.toJSON())).to.eql('{"mainResults":false,"showAbstract":"closed","showHighlights":"closed","pagination":true,"start":0,"highlightsLoaded":false,"perPage":25,"numFound":841359,"currentQuery":{"q":["bibcode:bar"],"fl":["title,bibcode,author,keyword,pub,aff,volume,year,[citations],property,pubdate,abstract,esources,data"],"rows":[25],"start":[0]},"pageData":{"perPage":25,"totalPages":33655,"currentPage":1,"previousPossible":false,"nextPossible":true},"bibcode":"bar","query":false,"page":0,"showRange":[0,24],"loading":false}');
+      expect(JSON.stringify(widget.model.toJSON())).to.eql('{"mainResults":false,"showAbstract":"closed","showHighlights":"closed","hideSidebars":false,"pagination":true,"start":0,"highlightsLoaded":false,"perPage":25,"numFound":841359,"currentQuery":{"q":["bibcode:bar"],"fl":["title,bibcode,author,keyword,pub,aff,volume,year,[citations],property,pubdate,abstract,esources,data"],"rows":[25],"start":[0]},"pageData":{"perPage":25,"totalPages":33655,"currentPage":1,"previousPossible":false,"nextPossible":true},"bibcode":"bar","query":false,"page":0,"showRange":[0,24],"loading":false}');
 
      //go to second page
       $(".page-control.next-page").click();
       expect(widget.model.get("pageData")).to.eql({perPage: 25, totalPages: 33655, currentPage: 2, previousPossible: true, nextPossible: true});
       minsub.publish(minsub.DISPLAY_DOCUMENTS, new ApiQuery({'q': 'bibcode:anotherbibcode'}));
       expect(widget.model.get("pageData")).to.eql({perPage: 25, totalPages: 10628, currentPage: 1, previousPossible: false, nextPossible: true});
-      expect(JSON.stringify(widget.model.toJSON())).to.eql('{"mainResults":false,"showAbstract":"closed","showHighlights":"closed","pagination":true,"start":0,"highlightsLoaded":false,"perPage":25,"numFound":265682,"currentQuery":{"q":["bibcode:anotherbibcode"],"fl":["title,bibcode,author,keyword,pub,aff,volume,year,[citations],property,pubdate,abstract,esources,data"],"rows":[25],"start":[0]},"pageData":{"perPage":25,"totalPages":10628,"currentPage":1,"previousPossible":false,"nextPossible":true},"bibcode":"anotherbibcode","query":false,"page":0,"showRange":[0,24],"loading":false}');
+      expect(JSON.stringify(widget.model.toJSON())).to.eql('{"mainResults":false,"showAbstract":"closed","showHighlights":"closed","hideSidebars":false,"pagination":true,"start":0,"highlightsLoaded":false,"perPage":25,"numFound":265682,"currentQuery":{"q":["bibcode:anotherbibcode"],"fl":["title,bibcode,author,keyword,pub,aff,volume,year,[citations],property,pubdate,abstract,esources,data"],"rows":[25],"start":[0]},"pageData":{"perPage":25,"totalPages":10628,"currentPage":1,"previousPossible":false,"nextPossible":true},"bibcode":"anotherbibcode","query":false,"page":0,"showRange":[0,24],"loading":false}');
 
 
       $("#test").empty();

--- a/test/mocha/js/widgets/paper_network_widget.spec.js
+++ b/test/mocha/js/widgets/paper_network_widget.spec.js
@@ -19051,8 +19051,8 @@ define([
       $("#test").find(".apply-filter").click();
 
       expect(paperNetwork.getPubSub().publish.called).to.be.true;
-      expect(paperNetwork.getPubSub().publish.args[0][0]).to.eql("[PubSub]-New-Query");
-      expect(paperNetwork.getPubSub().publish.args[0][1].toJSON()).to.eql({
+      expect(paperNetwork.getPubSub().publish.args[0][0]).to.eql("[Router]-Navigate-With-Trigger");
+      expect(paperNetwork.getPubSub().publish.args[0][2].q.toJSON()).to.eql({
         "q": [
           "original search"
         ],


### PR DESCRIPTION
@romanchyla, please check this PR out.  This is based off the other PR, which I'll close.  It removes the check loop in favor of a new pubsub event `UPDATE_CURRENT_QUERY` which it watches for instead.  

I need some guidance on how to keep repeated queries from happening, this line: https://github.com/adsabs/bumblebee/blob/master/src/js/wraps/discovery_mediator.js#L433
I had to remove it, since it was causing a lot of the double-navigation issues.  What would be the best way to fix it? 