### PR TITLE
make sidebar hide/show more solid

### DIFF
--- a/src/js/mixins/side_bar_manager.js
+++ b/src/js/mixins/side_bar_manager.js
@@ -1,0 +1,74 @@
+/**
+ * manages the state of the side bars
+ */
+define([
+  'backbone',
+  'js/components/api_feedback'
+], function (Backbone, ApiFeedback) {
+
+  var state = new (Backbone.Model.extend({
+    defaults: {
+      hide: true
+    }
+  }));
+
+  var SideBarManager = {
+    _getUpdateFromUserData: function () {
+      try {
+        var ud = this.getBeeHive().getObject('User').getUserData();
+        if (!ud) return false;
+
+        return /hide/i.test(ud.defaultHideSidebars);
+      } catch (e) {
+        return false;
+      }
+    },
+
+    init: function () {
+      state.set('hide', this._getUpdateFromUserData());
+      _.bindAll(this, ['_onFeedback', '_onUserAnnouncement', '_update']);
+      var ps = this.getPubSub();
+      if (!ps) return;
+      ps.subscribe(ps.FEEDBACK, this._onFeedback);
+      ps.subscribe(ps.USER_ANNOUNCEMENT, this._onUserAnnouncement);
+      state.on('change:hide', this._update);
+    },
+
+    _update: function () {
+      var val = this.getSidebarState();
+      var view = this.view;
+      if (view && view.showCols) {
+        view.showCols({ left: val, right: val });
+      }
+      this.broadcast('page-manager-message', 'side-bars-update', val);
+      this.trigger('page-manager-message', 'side-bars-update', val);
+    },
+
+    _onUserAnnouncement: function () {
+      state.set('hide', this._getUpdateFromUserData());
+    },
+
+    _onFeedback: function (feedback) {
+      switch(feedback.code) {
+        case ApiFeedback.CODES.MAKE_SPACE:
+        case ApiFeedback.CODES.UNMAKE_SPACE:
+          this._update();
+      };
+    },
+
+    toggleSidebarState: function () {
+      this.setSidebarState(!this.getSidebarState());
+    },
+
+    setSidebarState: function (value) {
+      state.set('hide', value);
+      state.trigger('change:hide');
+    },
+
+    getSidebarState: function () {
+      return state.get('hide');
+    }
+  };
+
+  return SideBarManager;
+});

--- a/src/js/widgets/list_of_things/paginated_view.js
+++ b/src/js/widgets/list_of_things/paginated_view.js
@@ -56,6 +56,7 @@ function (
         showAbstract: 'closed',
         // often they won't exist
         showHighlights: false,
+        hideSidebars: false,
         pagination: true,
         start: 0,
         highlightsLoaded: false
@@ -136,7 +137,7 @@ function (
     events: {
       'click .show-highlights': 'toggleHighlights',
       'click .show-abstract': 'toggleAbstract',
-      'click .toggle-make-space': 'toggleMakeSpace',
+      'click .toggle-sidebars': 'toggleHideSidebars',
       'click #go-to-bottom': 'goToBottom',
       'click #backToTopBtn': 'goToTop',
       'click a.page-control': 'changePageWithButton',
@@ -165,9 +166,9 @@ function (
       }
     },
 
-    toggleMakeSpace: function () {
-      var val = !this.model.get('makeSpace');
-      this.model.set('makeSpace', val);
+    toggleHideSidebars: function () {
+      var val = !this.model.get('hideSidebars');
+      this.model.set('hideSidebars', val);
       analytics('send', 'event', 'interaction', 'sidebars-toggled-' + val ? 'on' : 'off');
     },
 

--- a/src/js/widgets/results/templates/container-template.html
+++ b/src/js/widgets/results/templates/container-template.html
@@ -25,10 +25,10 @@
             {{else}}
               <button class="btn show-abstract btn-sm btn-inverse btn-primary"> Show abstracts</button>
             {{/compare}}
-            {{#if makeSpace}}
-                <button class="btn btn-sm btn-primary toggle-make-space hidden-xs hidden-sm">Show Sidebars</button>
+            {{#if hideSidebars}}
+                <button class="btn btn-sm btn-inverse btn-primary toggle-sidebars hidden-xs hidden-sm">Hide Sidebars</button>
             {{else}}
-                <button class="btn btn-sm btn-inverse btn-primary toggle-make-space hidden-xs hidden-sm">Hide Sidebars</button>
+                <button class="btn btn-sm btn-primary toggle-sidebars hidden-xs hidden-sm">Show Sidebars</button>
             {{/if}}
             <button class="btn-sm btn-link pull-right" id="go-to-bottom">Go To Bottom</button>
           {{/unless}}

--- a/src/js/widgets/tabs/tabs_widget.js
+++ b/src/js/widgets/tabs/tabs_widget.js
@@ -46,11 +46,7 @@ function (
         if (!t.widget) {
           throw new Error('Missing "widget" for: ' + t.title + ' [' + i + ']');
         }
-        if (t['default']) {
-          t.widget.trigger('active');
-        } else {
-          t.widget.trigger('hidden');
-        }
+        t.widget.trigger(t['default'] ? 'active' : 'hidden');
         return t.widget;
       });
       this.on('active', this.onActive);

--- a/src/js/wraps/results_page_manager.js
+++ b/src/js/wraps/results_page_manager.js
@@ -1,11 +1,14 @@
 define([
   'js/page_managers/controller',
   'js/page_managers/three_column_view',
-  'hbs!js/page_managers/templates/results-page-layout'
+  'hbs!js/page_managers/templates/results-page-layout',
+  'js/mixins/side_bar_manager'
 ], function (
   PageManagerController,
   PageManagerView,
-  PageManagerTemplate) {
+  PageManagerTemplate,
+  SideBarManagerMixin
+) {
   var PageManager = PageManagerController.extend({
 
     persistentWidgets: [
@@ -15,6 +18,13 @@ define([
       'BibgroupFacet', 'DataFacet', 'VizierFacet', 'GrantsFacet', 'Results',
       'OrcidBigWidget', 'QueryInfo', 'GraphTabs', 'OrcidSelector'
     ],
+
+    activate: function () {
+      PageManagerController.prototype.activate.apply(this, arguments);
+
+      // calls the sideBarManager mixin init handler
+      this.init();
+    },
 
     createView: function (options) {
       options = options || {};
@@ -29,8 +39,36 @@ define([
       var button = '<a href="#" class="back-button btn btn-sm btn-default"> <i class="fa fa-arrow-left"></i> Start New Search</a>';
       ret.$el.find('.s-back-button-container').empty().html(button);
       return ret;
-    }
+    },
 
+    assemble: function () {
+      var self = this;
+      return PageManagerController.prototype.assemble.apply(this, arguments).done(function () {
+        _.each(_.keys(self.widgets), function (w) {
+          self.listenTo(self.widgets[w], 'page-manager-event', _.bind(self.onPageManagerEvent, self, self.widgets[w]));
+        }, self);
+      });
+    },
+
+    broadcastTo: _.curry(function (widgets, event) {
+      var args = arguments;
+      var wids = _.pick(this.widgets, widgets);
+      _.each(wids, function (w) {
+        w.trigger.apply(w, [
+          'page-manager-message', event
+        ].concat(_.toArray(args).slice(2)));
+      });
+    }, 2),
+
+    onPageManagerEvent: function (widget, event, data) {
+
+      // this event is emitted from results widget
+      if (event === 'side-bars-update') {
+        this.setSidebarState(data);
+      }
+    }
   });
+
+  _.extend(PageManager.prototype, SideBarManagerMixin);
   return PageManager;
 });

--- a/test/mocha/js/widgets/list_of_things_widget.spec.js
+++ b/test/mocha/js/widgets/list_of_things_widget.spec.js
@@ -327,7 +327,7 @@ define(['marionette',
         widget.trigger("pagination:changePerPage", 50);
         expect(widget.model.get("perPage")).to.eql(50);
 
-        expect(JSON.stringify(widget.model.toJSON())).to.eql('{"mainResults":false,"showAbstract":"closed","showHighlights":"closed","pagination":true,"start":0,"highlightsLoaded":false,"perPage":50,"numFound":100,"currentQuery":{"q":["foo:bar"]},"pageData":{"perPage":50,"totalPages":2,"currentPage":1,"previousPossible":false,"nextPossible":true},"page":0,"showRange":[0,49],"query":false,"loading":false}');
+        expect(JSON.stringify(widget.model.toJSON())).to.eql('{"mainResults":false,"showAbstract":"closed","showHighlights":"closed","hideSidebars":false,"pagination":true,"start":0,"highlightsLoaded":false,"perPage":50,"numFound":100,"currentQuery":{"q":["foo:bar"]},"pageData":{"perPage":50,"totalPages":2,"currentPage":1,"previousPossible":false,"nextPossible":true},"page":0,"showRange":[0,49],"query":false,"loading":false}');
 
         expect($("#per-page-select>option:selected").text().trim()).to.eql("50");
         expect($("input.page-control").val()).to.eql("1");

--- a/test/mocha/js/widgets/lot_derivates.spec.js
+++ b/test/mocha/js/widgets/lot_derivates.spec.js
@@ -96,14 +96,14 @@ define([
       widget.activate(minsub.beehive.getHardenedInstance());
       $("#test").append(widget.getEl());
       minsub.publish(minsub.DISPLAY_DOCUMENTS, new ApiQuery({'q': 'bibcode:bar'}));
-      expect(JSON.stringify(widget.model.toJSON())).to.eql('{"mainResults":false,"showAbstract":"closed","showHighlights":"closed","pagination":true,"start":0,"highlightsLoaded":false,"perPage":25,"numFound":841359,"currentQuery":{"q":["bibcode:bar"],"fl":["title,bibcode,author,keyword,pub,aff,volume,year,[citations],property,pubdate,abstract,esources,data"],"rows":[25],"start":[0]},"pageData":{"perPage":25,"totalPages":33655,"currentPage":1,"previousPossible":false,"nextPossible":true},"bibcode":"bar","query":false,"page":0,"showRange":[0,24],"loading":false}');
+      expect(JSON.stringify(widget.model.toJSON())).to.eql('{"mainResults":false,"showAbstract":"closed","showHighlights":"closed","hideSidebars":false,"pagination":true,"start":0,"highlightsLoaded":false,"perPage":25,"numFound":841359,"currentQuery":{"q":["bibcode:bar"],"fl":["title,bibcode,author,keyword,pub,aff,volume,year,[citations],property,pubdate,abstract,esources,data"],"rows":[25],"start":[0]},"pageData":{"perPage":25,"totalPages":33655,"currentPage":1,"previousPossible":false,"nextPossible":true},"bibcode":"bar","query":false,"page":0,"showRange":[0,24],"loading":false}');
 
      //go to second page
       $(".page-control.next-page").click();
       expect(widget.model.get("pageData")).to.eql({perPage: 25, totalPages: 33655, currentPage: 2, previousPossible: true, nextPossible: true});
       minsub.publish(minsub.DISPLAY_DOCUMENTS, new ApiQuery({'q': 'bibcode:anotherbibcode'}));
       expect(widget.model.get("pageData")).to.eql({perPage: 25, totalPages: 10628, currentPage: 1, previousPossible: false, nextPossible: true});
-      expect(JSON.stringify(widget.model.toJSON())).to.eql('{"mainResults":false,"showAbstract":"closed","showHighlights":"closed","pagination":true,"start":0,"highlightsLoaded":false,"perPage":25,"numFound":265682,"currentQuery":{"q":["bibcode:anotherbibcode"],"fl":["title,bibcode,author,keyword,pub,aff,volume,year,[citations],property,pubdate,abstract,esources,data"],"rows":[25],"start":[0]},"pageData":{"perPage":25,"totalPages":10628,"currentPage":1,"previousPossible":false,"nextPossible":true},"bibcode":"anotherbibcode","query":false,"page":0,"showRange":[0,24],"loading":false}');
+      expect(JSON.stringify(widget.model.toJSON())).to.eql('{"mainResults":false,"showAbstract":"closed","showHighlights":"closed","hideSidebars":false,"pagination":true,"start":0,"highlightsLoaded":false,"perPage":25,"numFound":265682,"currentQuery":{"q":["bibcode:anotherbibcode"],"fl":["title,bibcode,author,keyword,pub,aff,volume,year,[citations],property,pubdate,abstract,esources,data"],"rows":[25],"start":[0]},"pageData":{"perPage":25,"totalPages":10628,"currentPage":1,"previousPossible":false,"nextPossible":true},"bibcode":"anotherbibcode","query":false,"page":0,"showRange":[0,24],"loading":false}');
 
 
       $("#test").empty();


### PR DESCRIPTION
Adds a mixin which handles/holds the internal state of the sidebars, this is a little better than it was when it was attached to the results widget, which caused some issues with consistently opening.  It should manage its state much better now.

Also added a handler to help when figuring out how to limit sidebar widgets from loading.