### PR TITLE
Side bar fixes

### DIFF
--- a/src/js/widgets/list_of_things/paginated_view.js
+++ b/src/js/widgets/list_of_things/paginated_view.js
@@ -56,7 +56,7 @@ function (
         showAbstract: 'closed',
         // often they won't exist
         showHighlights: false,
-        hideSidebars: false,
+        showSidebars: true,
         pagination: true,
         start: 0,
         highlightsLoaded: false
@@ -137,7 +137,7 @@ function (
     events: {
       'click .show-highlights': 'toggleHighlights',
       'click .show-abstract': 'toggleAbstract',
-      'click .toggle-sidebars': 'toggleHideSidebars',
+      'click .toggle-sidebars': 'toggleShowSidebars',
       'click #go-to-bottom': 'goToBottom',
       'click #backToTopBtn': 'goToTop',
       'click a.page-control': 'changePageWithButton',
@@ -166,9 +166,9 @@ function (
       }
     },
 
-    toggleHideSidebars: function () {
-      var val = !this.model.get('hideSidebars');
-      this.model.set('hideSidebars', val);
+    toggleShowSidebars: function () {
+      var val = !this.model.get('showSidebars');
+      this.model.set('showSidebars', val);
       analytics('send', 'event', 'interaction', 'sidebars-toggled-' + val ? 'on' : 'off');
     },
 
@@ -241,7 +241,6 @@ function (
       return false;
     }
   });
-
 
   return ListOfThingsView;
 });

--- a/src/js/widgets/results/templates/container-template.html
+++ b/src/js/widgets/results/templates/container-template.html
@@ -25,10 +25,10 @@
             {{else}}
               <button class="btn show-abstract btn-sm btn-inverse btn-primary"> Show abstracts</button>
             {{/compare}}
-            {{#if hideSidebars}}
-                <button class="btn btn-sm btn-inverse btn-primary toggle-sidebars hidden-xs hidden-sm">Hide Sidebars</button>
+            {{#if showSidebars}}
+            <button class="btn btn-sm btn-inverse btn-primary toggle-sidebars hidden-xs hidden-sm">Hide Sidebars</button>
             {{else}}
-                <button class="btn btn-sm btn-primary toggle-sidebars hidden-xs hidden-sm">Show Sidebars</button>
+            <button class="btn btn-sm btn-primary toggle-sidebars hidden-xs hidden-sm">Show Sidebars</button>
             {{/if}}
             <button class="btn-sm btn-link pull-right" id="go-to-bottom">Go To Bottom</button>
           {{/unless}}

--- a/src/js/widgets/results/widget.js
+++ b/src/js/widgets/results/widget.js
@@ -41,7 +41,7 @@ function (
           title: undefined,
           // assuming there will always be abstracts
           showAbstract: 'closed',
-          hideSidebars: false,
+          showSidebars: true,
           // often they won't exist
           showHighlights: 'closed',
           pagination: true
@@ -68,7 +68,7 @@ function (
       this.listenTo(this.view, 'toggle-all', this.triggerBulkAction);
       this.minAuthorsPerResult = 3;
 
-      this.model.on('change:hideSidebars', _.bind(this._onToggleSideBars, this));
+      this.model.on('change:showSidebars', _.bind(this._onToggleSidebars, this));
 
       // update the default fields with whatever the abstract page needs
       var abstractFields = AbstractWidget.prototype.defaultQueryArguments.fl.split(',');
@@ -99,7 +99,7 @@ function (
 
     onPageManagerMessage: function (event, data) {
       if (event === 'side-bars-update') {
-        this._onSideBarsUpdate(data);
+        this._onSidebarsUpdate(data);
       }
     },
 
@@ -146,12 +146,12 @@ function (
       this.queryTimer = +new Date();
     },
 
-    _onToggleSideBars: function () {
-      this.trigger('page-manager-event', 'side-bars-update', this.model.get('hideSidebars'));
+    _onToggleSidebars: function () {
+      this.trigger('page-manager-event', 'side-bars-update', this.model.get('showSidebars'));
     },
 
-    _onSideBarsUpdate: function (value) {
-      this.model.set('hideSidebars', value);
+    _onSidebarsUpdate: function (value) {
+      this.model.set('showSidebars', value);
     },
 
     onUserAnnouncement: function (message, data) {
@@ -372,8 +372,15 @@ function (
     triggerBulkAction: function (flag) {
       var bibs = this.collection.pluck('bibcode');
       this.getPubSub().publish(this.getPubSub().BULK_PAPER_SELECTION, bibs, flag);
-    }
+    },
 
+    reset: function () {
+
+      // persist the sidebar state through resets
+      var sidebarState = this.model.get('showSidebars');
+      ListOfThingsWidget.prototype.reset.apply(this, arguments);
+      this.model.set('showSidebars', sidebarState);
+    }
   });
 
   _.extend(ResultsWidget.prototype, LinkGenerator);

--- a/src/js/wraps/results_page_manager.js
+++ b/src/js/wraps/results_page_manager.js
@@ -38,6 +38,9 @@ define([
       var ret = PageManagerController.prototype.show.apply(this, arguments);
       var button = '<a href="#" class="back-button btn btn-sm btn-default"> <i class="fa fa-arrow-left"></i> Start New Search</a>';
       ret.$el.find('.s-back-button-container').empty().html(button);
+
+      // after assembly call the sidebar updater
+      this.setSidebarState(this._getUpdateFromUserData());
       return ret;
     },
 

--- a/test/mocha/js/widgets/list_of_things_widget.spec.js
+++ b/test/mocha/js/widgets/list_of_things_widget.spec.js
@@ -327,7 +327,7 @@ define(['marionette',
         widget.trigger("pagination:changePerPage", 50);
         expect(widget.model.get("perPage")).to.eql(50);
 
-        expect(JSON.stringify(widget.model.toJSON())).to.eql('{"mainResults":false,"showAbstract":"closed","showHighlights":"closed","hideSidebars":false,"pagination":true,"start":0,"highlightsLoaded":false,"perPage":50,"numFound":100,"currentQuery":{"q":["foo:bar"]},"pageData":{"perPage":50,"totalPages":2,"currentPage":1,"previousPossible":false,"nextPossible":true},"page":0,"showRange":[0,49],"query":false,"loading":false}');
+        expect(JSON.stringify(widget.model.toJSON())).to.eql('{"mainResults":false,"showAbstract":"closed","showHighlights":"closed","showSidebars":true,"pagination":true,"start":0,"highlightsLoaded":false,"perPage":50,"numFound":100,"currentQuery":{"q":["foo:bar"]},"pageData":{"perPage":50,"totalPages":2,"currentPage":1,"previousPossible":false,"nextPossible":true},"page":0,"showRange":[0,49],"query":false,"loading":false}');
 
         expect($("#per-page-select>option:selected").text().trim()).to.eql("50");
         expect($("input.page-control").val()).to.eql("1");

--- a/test/mocha/js/widgets/lot_derivates.spec.js
+++ b/test/mocha/js/widgets/lot_derivates.spec.js
@@ -96,14 +96,14 @@ define([
       widget.activate(minsub.beehive.getHardenedInstance());
       $("#test").append(widget.getEl());
       minsub.publish(minsub.DISPLAY_DOCUMENTS, new ApiQuery({'q': 'bibcode:bar'}));
-      expect(JSON.stringify(widget.model.toJSON())).to.eql('{"mainResults":false,"showAbstract":"closed","showHighlights":"closed","hideSidebars":false,"pagination":true,"start":0,"highlightsLoaded":false,"perPage":25,"numFound":841359,"currentQuery":{"q":["bibcode:bar"],"fl":["title,bibcode,author,keyword,pub,aff,volume,year,[citations],property,pubdate,abstract,esources,data"],"rows":[25],"start":[0]},"pageData":{"perPage":25,"totalPages":33655,"currentPage":1,"previousPossible":false,"nextPossible":true},"bibcode":"bar","query":false,"page":0,"showRange":[0,24],"loading":false}');
+      expect(JSON.stringify(widget.model.toJSON())).to.eql('{"mainResults":false,"showAbstract":"closed","showHighlights":"closed","showSidebars":true,"pagination":true,"start":0,"highlightsLoaded":false,"perPage":25,"numFound":841359,"currentQuery":{"q":["bibcode:bar"],"fl":["title,bibcode,author,keyword,pub,aff,volume,year,[citations],property,pubdate,abstract,esources,data"],"rows":[25],"start":[0]},"pageData":{"perPage":25,"totalPages":33655,"currentPage":1,"previousPossible":false,"nextPossible":true},"bibcode":"bar","query":false,"page":0,"showRange":[0,24],"loading":false}');
 
      //go to second page
       $(".page-control.next-page").click();
       expect(widget.model.get("pageData")).to.eql({perPage: 25, totalPages: 33655, currentPage: 2, previousPossible: true, nextPossible: true});
       minsub.publish(minsub.DISPLAY_DOCUMENTS, new ApiQuery({'q': 'bibcode:anotherbibcode'}));
       expect(widget.model.get("pageData")).to.eql({perPage: 25, totalPages: 10628, currentPage: 1, previousPossible: false, nextPossible: true});
-      expect(JSON.stringify(widget.model.toJSON())).to.eql('{"mainResults":false,"showAbstract":"closed","showHighlights":"closed","hideSidebars":false,"pagination":true,"start":0,"highlightsLoaded":false,"perPage":25,"numFound":265682,"currentQuery":{"q":["bibcode:anotherbibcode"],"fl":["title,bibcode,author,keyword,pub,aff,volume,year,[citations],property,pubdate,abstract,esources,data"],"rows":[25],"start":[0]},"pageData":{"perPage":25,"totalPages":10628,"currentPage":1,"previousPossible":false,"nextPossible":true},"bibcode":"anotherbibcode","query":false,"page":0,"showRange":[0,24],"loading":false}');
+      expect(JSON.stringify(widget.model.toJSON())).to.eql('{"mainResults":false,"showAbstract":"closed","showHighlights":"closed","showSidebars":true,"pagination":true,"start":0,"highlightsLoaded":false,"perPage":25,"numFound":265682,"currentQuery":{"q":["bibcode:anotherbibcode"],"fl":["title,bibcode,author,keyword,pub,aff,volume,year,[citations],property,pubdate,abstract,esources,data"],"rows":[25],"start":[0]},"pageData":{"perPage":25,"totalPages":10628,"currentPage":1,"previousPossible":false,"nextPossible":true},"bibcode":"anotherbibcode","query":false,"page":0,"showRange":[0,24],"loading":false}');
 
 
       $("#test").empty();


### PR DESCRIPTION
This makes sure that the results page model doesn't constantly reset the sidebar value
This also flips the `hide` to `show` to make it more consistent with the other results page toggles