### PR TITLE
Fix slider redirect issues

### DIFF
--- a/src/js/widgets/facet/graph-facet/h_index_graph.js
+++ b/src/js/widgets/facet/graph-facet/h_index_graph.js
@@ -334,8 +334,10 @@ function (BaseGraphView,
         },
         slide: function (event, ui) {
           that.$('.show-slider-data-first').val(ui.value);
+        },
+        create: function (event) {
+          $('a', event.target).attr('href', 'javascript:void(0)');
         }
-
       });
 
       this.$('.show-slider-data-first').val(max);

--- a/src/js/widgets/facet/graph-facet/year_graph.js
+++ b/src/js/widgets/facet/graph-facet/year_graph.js
@@ -356,8 +356,10 @@ function (
             ui2 = ui.values[1];
           that.$('.show-slider-data-first').val(ui1);
           that.$('.show-slider-data-second').val(ui2);
+        },
+        create: function (event) {
+          $('a', event.target).attr('href', 'javascript:void(0)');
         }
-
       });
       this.$('.show-slider-data-first').val(min);
       this.$('.show-slider-data-second').val(max);

--- a/src/js/widgets/wordcloud/widget.js
+++ b/src/js/widgets/wordcloud/widget.js
@@ -174,6 +174,9 @@ define([
         step: 1,
         slide: function (event, ui) {
           that.model.set({ currentSliderVal: ui.value });
+        },
+        create: function (event) {
+          $('a', event.target).attr('href', 'javascript:void(0)');
         }
       });
     },


### PR DESCRIPTION
The sliders by default create links that have `#` as the href, we want to make sure to convert them so they don't redirect.