### PR TITLE
make sure that abstract identifiers are encoded

### DIFF
--- a/src/js/apps/discovery/navigator.js
+++ b/src/js/apps/discovery/navigator.js
@@ -983,6 +983,7 @@ function (
           }
 
           that.route = data.href;
+          that.replace = true;
           defer.resolve();
         });
         return defer.promise();
@@ -1005,6 +1006,7 @@ function (
           }
 
           that.route = data.href;
+          that.replace = true;
           defer.resolve();
         });
         return defer.promise();
@@ -1026,6 +1028,7 @@ function (
             that.title = prefix + ' | ' + title;
           }
           that.route = data.href;
+          that.replace = true;
           defer.resolve();
         });
         return defer.promise();
@@ -1047,6 +1050,7 @@ function (
             that.title = prefix + ' | ' + title;
           }
           that.route = data.href;
+          that.replace = true;
           defer.resolve();
         });
         return defer.promise();
@@ -1068,6 +1072,7 @@ function (
            that.title = prefix + ' | ' + title;
          }
           that.route = data.href;
+          that.replace = true;
           defer.resolve();
         });
         return defer.promise();
@@ -1089,6 +1094,7 @@ function (
             that.title = prefix + ' | ' + title;
           }
           that.route = data.href;
+          that.replace = true;
           defer.resolve();
         });
         return defer.promise();
@@ -1110,6 +1116,7 @@ function (
             that.title = prefix + ' | ' + title;
           }
           that.route = data.href;
+          that.replace = true;
           defer.resolve();
         })
         return defer.promise();
@@ -1132,6 +1139,7 @@ function (
                 w.setActive(id, format);
               }
               that.route = data.href;
+              that.replace = true;
               defer.resolve();
             });
           });
@@ -1147,6 +1155,7 @@ function (
             w.setActive(id);
           }
           that.route = data.href;
+          that.replace = true;
           defer.resolve();
         });
         return defer.promise();

--- a/src/js/apps/discovery/router.js
+++ b/src/js/apps/discovery/router.js
@@ -140,13 +140,13 @@ function (
     },
 
     view: function (bibcode, subPage) {
-      var navigateString,
-              href;
+      var navigateString, href;
       if (!subPage) {
         navigateString = 'ShowAbstract';
+        href = '#abs/' + encodeURIComponent(bibcode) + '/abstract';
       } else {
         navigateString = 'Show' + subPage[0].toUpperCase() + subPage.slice(1);
-        href = '#abs/' + bibcode + '/' + subPage;
+        href = '#abs/' + encodeURIComponent(bibcode) + '/' + subPage;
       }
       this.routerNavigate(navigateString, { href: href, bibcode: bibcode });
     },

--- a/src/js/mixins/link_generator_mixin.js
+++ b/src/js/mixins/link_generator_mixin.js
@@ -198,7 +198,7 @@ define(['underscore', 'js/mixins/openurl_generator'], function (_, OpenURLGenera
    */
   const _createGatewayUrl = function (bibcode, target) {
     if (_.isString(bibcode) && _.isString(target)) {
-      return GATEWAY_BASE_URL + bibcode + '/' + target;
+      return GATEWAY_BASE_URL + enc(bibcode) + '/' + target;
     }
     return '';
   };
@@ -362,7 +362,7 @@ define(['underscore', 'js/mixins/openurl_generator'], function (_, OpenURLGenera
           links.list.push({
             letter: 'C',
             name: 'Citations (' + citations.num_citations + ')',
-            url: '#abs/' + data.bibcode + '/citations'
+            url: '#abs/' + enc(data.bibcode) + '/citations'
           });
         }
 
@@ -371,7 +371,7 @@ define(['underscore', 'js/mixins/openurl_generator'], function (_, OpenURLGenera
           links.list.push({
             letter: 'R',
             name: 'References (' + citations.num_references + ')',
-            url: '#abs/' + data.bibcode + '/references'
+            url: '#abs/' + enc(data.bibcode) + '/references'
           });
         }
       }
@@ -382,7 +382,7 @@ define(['underscore', 'js/mixins/openurl_generator'], function (_, OpenURLGenera
           links.list.push({
             letter: 'T',
             name: 'Table of Contents',
-            url: '#abs/' + data.bibcode + '/tableofcontents'
+            url: '#abs/' + enc(data.bibcode) + '/tableofcontents'
           });
         }
       }
@@ -458,6 +458,10 @@ define(['underscore', 'js/mixins/openurl_generator'], function (_, OpenURLGenera
       return GATEWAY_BASE_URL + bibcode + '/' + type + ':' + id;
     }
     return '';
+  };
+
+  const enc = function (str) {
+    return encodeURIComponent(str);
   };
 
   return {

--- a/src/js/page_managers/toc_widget.js
+++ b/src/js/page_managers/toc_widget.js
@@ -203,11 +203,12 @@ define([
         return this.collection.selectOne('ShowAbstract');
       }
       var path = this.model.get('path') || 'abstract';
+      var encodedId = encodeURIComponent(this.model.get('bibcode'));
 
       var data = {
         idAttribute: this.model.get('idAttribute') || 'showAbstract',
         subView: this.model.get('subView') || '',
-        href: 'abs/' + (this.model.get('bibcode') || '') + '/' + path,
+        href: 'abs/' + (encodedId || '') + '/' + path,
         bibcode: this.model.get('bibcode')
       };
       this.trigger('page-manager-event', 'widget-selected', data);

--- a/src/js/widgets/graphics/widget.js
+++ b/src/js/widgets/graphics/widget.js
@@ -192,7 +192,7 @@ define([
 
     triggerShowGrid: function () {
       this.getPubSub().publish(this.getPubSub().NAVIGATE, 'ShowGraphics', {
-        href: '#abs/' + this._bibcode + '/graphics',
+        href: '#abs/' + encodeURIComponent(this._bibcode) + '/graphics',
         bibcode: this._bibcode
       });
     }


### PR DESCRIPTION
Make sure that we don't decode identifiers on abstract pages.  Also, update the url for the link generator stuff for the results page.