### PR TITLE
add npm caching to speed up travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
-node_js:
-  - "6.11.2"
+node_js: "6.11.2"
+cache: npm
 before_install: npm install -g grunt-cli
 install: npm install
 deployg: grunt release


### PR DESCRIPTION
Cache npm as per (https://docs.travis-ci.com/user/caching/#npm-cache)
Trying this out to see if it helps to speed up travis builds.