### PR TITLE
Fix years graph facet updater

### DIFF
--- a/src/js/widgets/facet/graph-facet/widget.js
+++ b/src/js/widgets/facet/graph-facet/widget.js
@@ -84,6 +84,11 @@ function (
       q.set('q', this.queryUpdater.quoteIfNecessary(q.get('q')[0]));
       q = q.clone();
       var fieldName = 'q';
+      var oldVal = q.get('__' + this.facetField + '_' + fieldName);
+      if (oldVal && oldVal.length > 0) {
+        this.queryUpdater.updateQuery(q, fieldName, 'remove', _.last(oldVal));
+      }
+
       this.queryUpdater.updateQuery(q, fieldName, 'limit', val);
       this.dispatchNewQuery(q);
     },


### PR DESCRIPTION
Adding a simple way of updating the query for the years graph facet using Roman's changes to queryUpdater.  That PR (#1778) should get merged first.