### PR TITLE
Make sidebar showhide better

### DIFF
--- a/src/js/mixins/side_bar_manager.js
+++ b/src/js/mixins/side_bar_manager.js
@@ -8,9 +8,10 @@ define([
 
   var state = new (Backbone.Model.extend({
     defaults: {
+      recent: true,
       show: true
     }
-  }));
+  }))();
 
   var SideBarManager = {
 
@@ -70,9 +71,31 @@ define([
      */
     _onFeedback: function (feedback) {
       switch(feedback.code) {
-        case ApiFeedback.CODES.MAKE_SPACE: this.setSidebarState(false); break;
-        case ApiFeedback.CODES.UNMAKE_SPACE: this.setSidebarState(true);
+        case ApiFeedback.CODES.MAKE_SPACE: return this.onMakeSpace();
+        case ApiFeedback.CODES.UNMAKE_SPACE: return this.onUnMakeSpace();
       };
+    },
+
+    /**
+     * Save the current state and
+     * set the sidebar state to `false`
+     */
+    onMakeSpace: function () {
+      state.set('recent', this.getSidebarState());
+      this.setSidebarState(false);
+    },
+
+    /**
+     * if the saved state is set, then update the side bar to that value
+     * and unset the saved state.
+     *
+     * only "unmake space" if "make space" was called previously
+     */
+    onUnMakeSpace: function () {
+      if (state.has('recent')) {
+        this.setSidebarState(state.get('recent'));
+        state.unset('recent');
+      }
     },
 
     /**

--- a/src/js/wraps/results_page_manager.js
+++ b/src/js/wraps/results_page_manager.js
@@ -47,6 +47,8 @@ define([
         _.each(_.keys(self.widgets), function (w) {
           self.listenTo(self.widgets[w], 'page-manager-event', _.bind(self.onPageManagerEvent, self, self.widgets[w]));
         }, self);
+
+        self.setSidebarState(self._getUpdateFromUserData());
       });
     },
 

--- a/src/styles/sass/ads-sass/page-managers.scss
+++ b/src/styles/sass/ads-sass/page-managers.scss
@@ -144,9 +144,6 @@ s-search-bar-motion is applied */
 
 .s-results-page-layout {
 
-  .s-results-column {
-    transition : width .5s ease-out, padding .5s ease-out;
-  }
   .s-left-col-container {
     @extend .s-ads-card;
     padding: 5px;


### PR DESCRIPTION
This makes sure that user data is checked after the results page has been assembled so the listeners have been attached first.

Also, this fixes the issue where the state wasn't being respected when transitioning from a results page subpage (export, metrics, etc).

Controversial change: I removed that weird transition that happens when moving from normal to full screen and back.