### PR TITLE
Fix search url not updating issue

### DIFF
--- a/src/js/widgets/base/base_widget.js
+++ b/src/js/widgets/base/base_widget.js
@@ -110,7 +110,7 @@ define([
       // remove the arguments that are useful only to this widget
       _.each(this.defaultQueryArguments, function (v, k) { apiQuery.unset(k); });
       var pubsub = this.getPubSub();
-      pubsub.publish(pubsub.START_SEARCH, apiQuery);
+      pubsub.publish(pubsub.NAVIGATE, 'search-page', { q: apiQuery });
     },
 
     /**

--- a/src/js/widgets/facet/graph-facet/widget.js
+++ b/src/js/widgets/facet/graph-facet/widget.js
@@ -77,18 +77,28 @@ function (
       }
     },
 
+    removeAnyOldConditions: function (query, fieldName) {
+      var q = query.clone();
+      var oldField = q.get('__' + this.facetField + '_' + fieldName);
+
+      // check for field on current query
+      if (oldField && oldField.length > 0) {
+
+        // grab the last value and check to make sure it is actually in the query string
+        var oldVal = _.last(oldField);
+        if (q.get(fieldName)[0].indexOf(oldVal) > -1) {
+          this.queryUpdater.updateQuery(q, fieldName, 'remove', oldVal);
+        }
+      }
+      return q;
+    },
+
     handleConditionApplied: function (val) {
+      var fieldName = 'q';
       var q = this.getCurrentQuery();
       val = this.facetField + ':' + val;
-      // wrap the current query, if necessary
-      q.set('q', this.queryUpdater.quoteIfNecessary(q.get('q')[0]));
       q = q.clone();
-      var fieldName = 'q';
-      var oldVal = q.get('__' + this.facetField + '_' + fieldName);
-      if (oldVal && oldVal.length > 0) {
-        this.queryUpdater.updateQuery(q, fieldName, 'remove', _.last(oldVal));
-      }
-
+      q = this.removeAnyOldConditions(q, fieldName);
       this.queryUpdater.updateQuery(q, fieldName, 'limit', val);
       this.dispatchNewQuery(q);
     },

--- a/src/js/widgets/filter_visualizer/widget.js
+++ b/src/js/widgets/filter_visualizer/widget.js
@@ -501,7 +501,9 @@ function (
       var newQuery = this.createModifiedQuery(value);
 
       var ps = this.getBeeHive().getService('PubSub');
-      if (ps) ps.publish(ps.START_SEARCH, newQuery);
+      if (ps) {
+        ps.publish(ps.NAVIGATE, 'search-page', { q: newQuery });
+      }
     }
 
   });

--- a/src/js/widgets/sort/widget.jsx.js
+++ b/src/js/widgets/sort/widget.jsx.js
@@ -109,7 +109,7 @@ define([
       // don't do anything if we weren't able to find a query
       if (query) {
         query.sort = [newSort];
-        pubsub.publish(pubsub.START_SEARCH, new ApiQuery(query));
+        pubsub.publish(pubsub.NAVIGATE, 'search-page', { q: new ApiQuery(query) });
         analytics('send', 'event', 'interaction', 'sort-applied', newSort);
       }
     },

--- a/src/js/wraps/discovery_mediator.js
+++ b/src/js/wraps/discovery_mediator.js
@@ -142,7 +142,10 @@ function (
                 done: function () {
                 // we've recovered - restart the search cycle
                   app.getController('QueryMediator').resetFailures();
-                  self.getPubSub().publish(self.getPubSub().START_SEARCH, apiRequest.get('query'));
+                  var ps = self.getPubSub();
+                  if (ps) {
+                    ps.publish(ps.NAVIGATE, 'search-page', { q: apiRequest.get('query') });
+                  }
                 },
                 fail: function () {
                   analytics('send', 'event', 'error', 'unauthorized', 'request=' + apiRequest.url() + ' token=...' + getAccessTokenStump());

--- a/test/mocha/js/components/discovery_mediator.spec.js
+++ b/test/mocha/js/components/discovery_mediator.spec.js
@@ -116,8 +116,11 @@ define([
       minsub.publish(minsub.START_SEARCH, x.qError);
 
 
-      minsub.subscribeOnce(minsub.START_SEARCH, function() {
-        done()}); // if this fires, query was resurrected
+      minsub.subscribeOnce(minsub.NAVIGATE, function (route, data) {
+        expect(route).to.eql('search-page');
+        expect(data.q).to.be.instanceof(ApiQuery);
+        done();
+      }); // if this fires, query was resurrected
 
       x.app.getPluginOrWidgetName = sinon.stub().returns(null);
       x.app = _.extend(x.app, {


### PR DESCRIPTION
Since we removed the navigation event from START_SEARCH, the calls to it in the results page widgets no longer update the url.  Swapping it out for a navigation event (which also triggers search) works.

Added a little more robust solution for handling the replacement of query params updated via the graph facets.  I think this makes these widgets much more useful.  One issue is that they don't really like it if the the query changes (via manually updating in search bar).