### PR TITLE
make alt ids work again

### DIFF
--- a/src/js/apps/discovery/navigator.js
+++ b/src/js/apps/discovery/navigator.js
@@ -1002,7 +1002,7 @@ function (
         showDetail([id].concat(detailsPageAlwaysVisible), id).then(function (w) {
           // new search
           if (data.bibcode) {
-            self.getPubSub().publish(self.getPubSub().DISPLAY_DOCUMENTS, new ApiQuery({ q: 'bibcode:' + data.bibcode }));
+            self.getPubSub().publish(self.getPubSub().DISPLAY_DOCUMENTS, new ApiQuery({ q: 'identifier:' + data.bibcode }));
           }
           w.setActive(id);
 
@@ -1024,7 +1024,7 @@ function (
           that = this;
         showDetail([id].concat(detailsPageAlwaysVisible), id).then(function (w) {
           if (data.bibcode) {
-            self.getPubSub().publish(self.getPubSub().DISPLAY_DOCUMENTS, new ApiQuery({ q: 'bibcode:' + data.bibcode }));
+            self.getPubSub().publish(self.getPubSub().DISPLAY_DOCUMENTS, new ApiQuery({ q: 'identifier:' + data.bibcode }));
           }
           w.setActive(id);
 
@@ -1047,7 +1047,7 @@ function (
           that = this;
         showDetail([id].concat(detailsPageAlwaysVisible), id).then(function (w) {
           if (data.bibcode) {
-            self.getPubSub().publish(self.getPubSub().DISPLAY_DOCUMENTS, new ApiQuery({ q: 'bibcode:' + data.bibcode }));
+            self.getPubSub().publish(self.getPubSub().DISPLAY_DOCUMENTS, new ApiQuery({ q: 'identifier:' + data.bibcode }));
           }
           w.setActive(id);
 
@@ -1069,7 +1069,7 @@ function (
           that = this;
         showDetail([id].concat(detailsPageAlwaysVisible), id).then(function (w) {
           if (data.bibcode) {
-            self.getPubSub().publish(self.getPubSub().DISPLAY_DOCUMENTS, new ApiQuery({ q: 'bibcode:' + data.bibcode }));
+            self.getPubSub().publish(self.getPubSub().DISPLAY_DOCUMENTS, new ApiQuery({ q: 'identifier:' + data.bibcode }));
           }
           w.setActive(id);
 
@@ -1091,7 +1091,7 @@ function (
           that = this;
         showDetail([id].concat(detailsPageAlwaysVisible), id).then(function (w) {
           if (data.bibcode) {
-            self.getPubSub().publish(self.getPubSub().DISPLAY_DOCUMENTS, new ApiQuery({ q: 'bibcode:' + data.bibcode }));
+            self.getPubSub().publish(self.getPubSub().DISPLAY_DOCUMENTS, new ApiQuery({ q: 'identifier:' + data.bibcode }));
           }
           w.setActive(id);
 
@@ -1113,7 +1113,7 @@ function (
           that = this;
         showDetail([id].concat(detailsPageAlwaysVisible), id).then(function (w) {
           if (data.bibcode) {
-            self.getPubSub().publish(self.getPubSub().DISPLAY_DOCUMENTS, new ApiQuery({ q: 'bibcode:' + data.bibcode }));
+            self.getPubSub().publish(self.getPubSub().DISPLAY_DOCUMENTS, new ApiQuery({ q: 'identifier:' + data.bibcode }));
           }
           w.setActive(id);
 
@@ -1135,7 +1135,7 @@ function (
           that = this;
         showDetail([id].concat(detailsPageAlwaysVisible), id).then(function (w) {
           if (data.bibcode) {
-            self.getPubSub().publish(self.getPubSub().DISPLAY_DOCUMENTS, new ApiQuery({ q: 'bibcode:' + data.bibcode }));
+            self.getPubSub().publish(self.getPubSub().DISPLAY_DOCUMENTS, new ApiQuery({ q: 'identifier:' + data.bibcode }));
           }
           w.setActive(id);
 
@@ -1162,7 +1162,7 @@ function (
           [id].concat(detailsPageAlwaysVisible)).done(function() {
             app.getWidget('DetailsPage').done(function (w) {
               if (data.bibcode) {
-                self.getPubSub().publish(self.getPubSub().DISPLAY_DOCUMENTS, new ApiQuery({ q: 'bibcode:' + data.bibcode }));
+                self.getPubSub().publish(self.getPubSub().DISPLAY_DOCUMENTS, new ApiQuery({ q: 'identifier:' + data.bibcode }));
 
                 // guarantees the bibcode is set on the widget
                 w.widgets[id].ingestBroadcastedPayload(_.pick(data, 'bibcode'));
@@ -1181,7 +1181,7 @@ function (
           that = this;
         showDetail([id].concat(detailsPageAlwaysVisible), id).then(function (w) {
           if (data.bibcode) {
-            self.getPubSub().publish(self.getPubSub().DISPLAY_DOCUMENTS, new ApiQuery({ q: 'bibcode:' + data.bibcode }));
+            self.getPubSub().publish(self.getPubSub().DISPLAY_DOCUMENTS, new ApiQuery({ q: 'identifier:' + data.bibcode }));
             w.setActive(id);
           }
           that.route = data.href;

--- a/src/js/page_managers/toc_widget.js
+++ b/src/js/page_managers/toc_widget.js
@@ -214,6 +214,18 @@ define([
       this.trigger('page-manager-event', 'widget-selected', data);
     },
 
+    selectDefaultNavItem: function () {
+      var tocConfig = Marionette.getOption(this, 'navConfig');
+      var found = tocConfig[0];
+      _.each(tocConfig, function (v, k) {
+        if (v.isSelected) {
+          found = k;
+          return false;
+        }
+      });
+      this.collection.selectOne(found);
+    },
+
     onPageManagerMessage: function (event, data) {
       if (event == 'new-widget') {
         // building the toc collection
@@ -239,16 +251,22 @@ define([
           }, this);
         }
       } else if (event == 'widget-ready') {
+
+        // if there are no docs then go to the default view and exit here
+        if (data.noDocs) {
+          return this.selectDefaultNavItem();
+        }
+
         var model = this.collection.get(data.widgetId);
         _.defaults(data, { isActive: !!data.numFound });
         if (model) {
           model.set(_.pick(data, model.keys()));
         }
 
-        // if the widget should reset, switch to the abstract view
+        // if the widget should reset, switch to the default view
         if (data.shouldReset) {
           if (model && model.get('isSelected')) {
-            this.collection.selectOne('ShowAbstract');
+            this.selectDefaultNavItem();
           }
           model && model.set('isActive', false);
         }

--- a/src/js/widgets/abstract/widget.js
+++ b/src/js/widgets/abstract/widget.js
@@ -291,15 +291,12 @@ function (
 
       // there was an error
       if (feedback && feedback.error) {
-        this.model.set({
-          error: true,
-          loading: false
-        });
+        this.showError();
       }
     },
 
     defaultQueryArguments: {
-      fl: '[citations],abstract,aff,author,bibcode,citation_count,comment,doi,id,keyword,page,property,pub,pub_raw,pubdate,pubnote,read_count,title,volume',
+      fl: 'identifier,[citations],abstract,aff,author,bibcode,citation_count,comment,doi,id,keyword,page,property,pub,pub_raw,pubdate,pubnote,read_count,title,volume',
       rows: 1
     },
 
@@ -381,9 +378,9 @@ function (
       var bibcode = apiQuery.get('q'),
         q;
 
-      if (bibcode.length > 0 && bibcode[0].indexOf('bibcode:') > -1) {
+      if (bibcode.length > 0 && /(bibcode|identifier):/.test(bibcode[0])) {
         // redefine bibcode
-        var bibcode = bibcode[0].replace('bibcode:', '');
+        var bibcode = bibcode[0].replace(/(bibcode|identifier):/, '');
       }
       if (this._docs[bibcode]) { // we have already loaded it
         this.displayBibcode(bibcode);
@@ -413,22 +410,43 @@ function (
 
     processResponse: function (apiResponse) {
       var r = apiResponse.toJSON();
-      var d,
-        bibcode;
+      var self = this;
       if (r.response && r.response.docs) {
-        _.each(r.response.docs, function (doc) {
-          d = this.model.parse(doc, this.maxAuthors);
-          this._docs[d.bibcode] = d;
-        }, this);
+        var docs = r.response.docs;
+        var __show = apiResponse.get('responseHeader.params.__show', false, '');
+        _.each(docs, function (doc) {
+          var d = self.model.parse(doc, self.maxAuthors);
+          var ids = d.identifier;
 
-        if (apiResponse.has('responseHeader.params.__show')) {
-          bibcode = apiResponse.get('responseHeader.params.__show', false, '');
-          this.displayBibcode(bibcode);
+          // if __show is defined and it is found in the list of identifiers or only a single document
+          // was provided - then set the __show value to the bibcode of the document
+          if (__show && (
+            (ids.length > 0 && _.contains(ids, __show)) || docs.length === 1
+          )) {
+            __show = d.bibcode;
+          }
+          self._docs[d.bibcode] = d;
+        });
+
+        if (__show) {
+          this.displayBibcode(__show);
         }
       }
 
-      var numFound = apiResponse.get('response.numFound', false, 0);
-      this.trigger('page-manager-event', 'widget-ready', { numFound: numFound });
+      var msg = {};
+      msg.numFound = apiResponse.get('response.numFound', false, 0);
+      if (msg.numFound === 0) {
+        this.showError();
+        msg.noDocs = true;
+      }
+      this.trigger('page-manager-event', 'widget-ready', msg);
+    },
+
+    showError: function () {
+      this.model.set({
+        error: true,
+        loading: false
+      });
     }
 
   });

--- a/src/js/widgets/abstract/widget.js
+++ b/src/js/widgets/abstract/widget.js
@@ -421,7 +421,7 @@ function (
           // if __show is defined and it is found in the list of identifiers or only a single document
           // was provided - then set the __show value to the bibcode of the document
           if (__show && (
-            (ids.length > 0 && _.contains(ids, __show)) || docs.length === 1
+            (ids && ids.length > 0 && _.contains(ids, __show)) || docs.length === 1
           )) {
             __show = d.bibcode;
           }

--- a/src/js/widgets/resources/redux/middleware/api.js
+++ b/src/js/widgets/resources/redux/middleware/api.js
@@ -29,7 +29,7 @@ define([
     next(action);
     if (action.type === FETCH_DATA) {
       const query = {
-        q: `bibcode:${action.result}`
+        q: `identifier:${action.result}`
       };
       dispatch({ type: FETCHING_DATA, result: query });
       dispatch({ type: SET_LOADING, result: true });
@@ -50,11 +50,11 @@ define([
 
       // check the query
       if (_.isPlainObject(query)) {
-        let bibcode = query.q;
-        if (_.isArray(bibcode) && bibcode.length > 0) {
-          if (/^bibcode:/.test(bibcode[0])) {
-            bibcode = bibcode[0].split(':')[1];
-            dispatch({ type: FETCH_DATA, result: bibcode });
+        let identifier = query.q;
+        if (_.isArray(identifier) && identifier.length > 0) {
+          if (/^(identifier|bibcode):/.test(identifier[0])) {
+            identifier = identifier[0].replace(/^(identifier|bibcode):/, '');
+            dispatch({ type: FETCH_DATA, result: identifier });
             ctx.trigger('page-manager-event', 'widget-ready', { isActive: true });
           } else {
             dispatch({ type: SET_HAS_ERROR, result: 'unable to parse bibcode from query' });

--- a/test/mocha/js/widgets/abstract_widget.spec.js
+++ b/test/mocha/js/widgets/abstract_widget.spec.js
@@ -32,7 +32,8 @@ define(['backbone', 'marionette', 'jquery', 'js/widgets/abstract/widget',
                 "aff": ["Heidelberg, Universität, Heidelberg, Germany", "California Institute of Technology, Jet Propulsion Laboratory, Pasadena, CA"],
                 "citation_count" : 5,
                 "[citations]" : { num_citations : 3, num_references: 34 },
-                read_count: 30
+                read_count: 30,
+                identifier: ["foo"]
               }
             ]}};
 

--- a/test/mocha/js/widgets/resources_widget.spec.js
+++ b/test/mocha/js/widgets/resources_widget.spec.js
@@ -55,7 +55,7 @@ define([
       it('fires off request for sources after display docs', function (done) {
         const w = new Widget();
         w.activate(this.pubsub.beehive);
-        const mockQuery = { toJSON: _.constant({ q: ['bibcode:foo'] })};
+        const mockQuery = { toJSON: _.constant({ q: ['identifier:foo'] })};
         this.pubsub.publish(this.pubsub.DISPLAY_DOCUMENTS, mockQuery);
         const rSpy = this.pubsub.request;
         expect(rSpy.calledOnce).to.eql(true);
@@ -90,7 +90,7 @@ define([
       it('fully updates state after getting bibcode/query', function (done) {
         const w = new Widget();
         w.activate(this.pubsub.beehive);
-        const mockQuery = { toJSON: _.constant({ q: ['bibcode:foo'] })};
+        const mockQuery = { toJSON: _.constant({ q: ['identifier:foo'] })};
         this.pubsub.publish(this.pubsub.DISPLAY_DOCUMENTS, mockQuery);
         expect(this.state(w).ui.loading).to.eql(true);
         expect(this.state(w).ui.noResults).to.eql(false);

--- a/test/mocha/js/widgets/results_render_widget.spec.js
+++ b/test/mocha/js/widgets/results_render_widget.spec.js
@@ -101,25 +101,7 @@ define([
         expect(widget.getCurrentQuery().toJSON()).to.eql({});
         minsub.publish(minsub.START_SEARCH, new ApiQuery({q: "star isbn:* *:*"}));
         setTimeout(function() {
-
-          expect(widget.model.get('currentQuery').toJSON()).to.eql({
-            "q": [
-              "star isbn:* *:*"
-            ],
-            "sort": [
-              "date desc, bibcode desc"
-            ],
-            "fl": [
-              "[citations],abstract,aff,author,bibcode,citation_count,comment,doi,id,keyword,page,property,pub,pub_raw,pubdate,pubnote,read_count,title,volume,links_data,esources,data,email,doctype,identifier"
-            ],
-            "rows": [
-              25
-            ],
-            "start": [
-              0
-            ]
-          });
-          expect(widget.model.get('currentQuery').url()).to.eql('fl=%5Bcitations%5D%2Cabstract%2Caff%2Cauthor%2Cbibcode%2Ccitation_count%2Ccomment%2Cdoi%2Cid%2Ckeyword%2Cpage%2Cproperty%2Cpub%2Cpub_raw%2Cpubdate%2Cpubnote%2Cread_count%2Ctitle%2Cvolume%2Clinks_data%2Cesources%2Cdata%2Cemail%2Cdoctype%2Cidentifier&q=star%20isbn%3A*%20*%3A*&rows=25&sort=date%20desc%2C%20bibcode%20desc&start=0');
+          expect(widget.model.get('currentQuery').get('q')).to.eql(['star isbn:* *:*']);
           expect(widget.collection.length).to.eql(10);
           done();
         }, 50);
@@ -138,25 +120,7 @@ define([
         expect(widget.getCurrentQuery().toJSON()).to.eql({});
         minsub.publish(minsub.START_SEARCH, new ApiQuery({q: "star"}));
         setTimeout(function() {
-
-          expect(widget.model.get('currentQuery').toJSON()).to.eql({
-            "q": [
-              "star"
-            ],
-            "sort": [
-              "date desc, bibcode desc"
-            ],
-            "fl": [
-              "[citations],abstract,aff,author,bibcode,citation_count,comment,doi,id,keyword,page,property,pub,pub_raw,pubdate,pubnote,read_count,title,volume,links_data,esources,data,email,doctype,identifier"
-            ],
-            "rows": [
-              25
-            ],
-            "start": [
-              0
-            ]
-          });
-          expect(widget.model.get('currentQuery').url()).to.eql('fl=%5Bcitations%5D%2Cabstract%2Caff%2Cauthor%2Cbibcode%2Ccitation_count%2Ccomment%2Cdoi%2Cid%2Ckeyword%2Cpage%2Cproperty%2Cpub%2Cpub_raw%2Cpubdate%2Cpubnote%2Cread_count%2Ctitle%2Cvolume%2Clinks_data%2Cesources%2Cdata%2Cemail%2Cdoctype%2Cidentifier&q=star&rows=25&sort=date%20desc%2C%20bibcode%20desc&start=0');
+          expect(widget.model.get('currentQuery').get('q')).to.eql(['star']);
           expect(widget.collection.length).to.eql(10);
           done();
         }, 50);


### PR DESCRIPTION
Swap out `bibcode:` style queries for using `identifier:` for all abstract pages, replaces alternate ids in the url with bibcode.  Not positive if this is a definitive fix, are there cases that this will point the wrong document? we will need to test this out more thoroughly.

for example:
`/abs/doi%3A10.1117%2F12.2314185/abstract` -> `/abs/2018SPIE10699E..02H/abstract`

Also abstract page should show a proper error if the id is missing now.
Also updated the resources widget to match the way ids are handled in the other widgets.