### PR TITLE
make start-new-search go back to correct page

### DIFF
--- a/src/js/apps/discovery/navigator.js
+++ b/src/js/apps/discovery/navigator.js
@@ -600,7 +600,8 @@ function (
         }
 
         var that = this;
-        showResultsPage(pages).then(function () {
+        var ctx = (data && data.context) || {};
+        showResultsPage(pages, ctx).then(function () {
           var handler = function () {
             // the current query should have been updated, use that instead
             var query = self.getBeeHive().getObject('AppStorage').getCurrentQuery();
@@ -935,9 +936,8 @@ function (
 
       this.set('visualization-closed', this.get('results-page'));
 
-      var showResultsPage = function (pages, toActivate) {
-        return app.getObject('MasterPageManager').show('SearchPage',
-          pages)
+      var showResultsPage = function (pages, ctx) {
+        return app.getObject('MasterPageManager').show('SearchPage', pages, ctx);
       };
 
       /*

--- a/src/js/page_managers/master.js
+++ b/src/js/page_managers/master.js
@@ -127,7 +127,7 @@ define([
       return PageManagerController.prototype.assemble.call(this, app);
     },
 
-    show: function (pageManagerName, options) {
+    show: function (pageManagerName, options, context) {
       var defer = $.Deferred();
       var app = this.getApp();
 
@@ -150,21 +150,25 @@ define([
           // it's already selected, trigger a change within the manager
           self.view.changeWithinManager();
         }
-  
+
+        if (context && pageManagerWidget.provideContext) {
+          pageManagerWidget.provideContext.call(pageManagerWidget, context);
+        }
+
         var previousPMName = self.currentChild;
         self.currentChild = pageManagerName;
-  
+
         // disassemble the old one (behind the scenes)
         if (previousPMName && previousPMName != pageManagerName) {
           var oldPM = self.collection.find({ id: previousPMName });
-  
+
           if (oldPM && oldPM.get('object')) {
             oldPM.set('numDetach', oldPM.get('numDetach') + 1);
             //XXX:rca - widgets are disappearing, probably must call incrCounter separately
             //oldPM.get('object').disAssemble(app);
           }
         }
-  
+
         self.getPubSub().publish(self.getPubSub().ARIA_ANNOUNCEMENT, pageManagerName);
         defer.resolve();
       }
@@ -175,8 +179,8 @@ define([
         activatePage(pageManagerModel.get('object'));
         return defer.promise();
       }
-      
-      
+
+
       app._getWidget(pageManagerName).done(function(pageManagerWidget) { // will throw error if not there
         pageManagerModel.set('object', pageManagerWidget);
         if (!pageManagerWidget) { console.error('unable to find page manager: ' + pageManagerName); }
@@ -190,11 +194,9 @@ define([
             console.error('eeeek, ' + pageManagerName + ' has no assemble() method!');
             defer.reject();
         }
-  
-        
-      }); 
+      });
       return defer.promise();
-      
+
     },
 
     // used by discovery mediator

--- a/src/js/widgets/classic_form/widget.js
+++ b/src/js/widgets/classic_form/widget.js
@@ -413,8 +413,8 @@ define([
       var ps = this.getPubSub();
       var options = {
         q: newQuery,
-        data: {
-          referrer: 'classic-form'
+        context: {
+          referrer: 'ClassicSearchForm'
         }
       };
       ps.publish(ps.NAVIGATE, 'search-page', options);

--- a/src/js/widgets/paper_search_form/widget.js
+++ b/src/js/widgets/paper_search_form/widget.js
@@ -169,7 +169,12 @@ define([
       });
 
       var ps = this.getPubSub();
-      ps.publish(ps.NAVIGATE, 'search-page', { q: newQuery });
+      ps.publish(ps.NAVIGATE, 'search-page', {
+        q: newQuery,
+        context: {
+          referrer: 'PaperSearchForm'
+        }
+      });
     },
 
     submitBigQuery: function (bibcodes) {
@@ -179,7 +184,12 @@ define([
       });
 
       var ps = this.getPubSub();
-      ps.publish(ps.NAVIGATE, 'search-page', { q: newQuery });
+      ps.publish(ps.NAVIGATE, 'search-page', {
+        q: newQuery,
+        context: {
+          referrer: 'PaperSearchForm'
+        }
+      });
     },
 
     onShow: function () {

--- a/src/js/wraps/results_page_manager.js
+++ b/src/js/wraps/results_page_manager.js
@@ -11,6 +11,11 @@ define([
 ) {
   var PageManager = PageManagerController.extend({
 
+    initialize: function () {
+      PageManagerController.prototype.initialize.apply(this, arguments);
+      this._referrer = null;
+    },
+
     persistentWidgets: [
       'PubtypeFacet', 'SearchWidget', 'BreadcrumbsWidget', 'Sort',
       'ExportDropdown', 'VisualizationDropdown', 'AffiliationFacet', 'AuthorFacet',
@@ -36,9 +41,23 @@ define([
 
     show: function () {
       var ret = PageManagerController.prototype.show.apply(this, arguments);
-      var button = '<a href="#" class="back-button btn btn-sm btn-default"> <i class="fa fa-arrow-left"></i> Start New Search</a>';
-      ret.$el.find('.s-back-button-container').empty().html(button);
+      var self = this;
+      var button = '<a href="javascript:void(0);" class="back-button btn btn-sm btn-default"> <i class="fa fa-arrow-left"></i> Start New Search</a>';
+      var $btn = ret.$el.find('.s-back-button-container');
+      $btn.empty().off('click').html(button);
+      $btn.click(function () {
+        var ps = self.getPubSub();
+        ps.publish(ps.NAVIGATE, self._referrer || 'index-page');
+        self._referrer = null;
+        return false;
+      });
       return ret;
+    },
+
+    provideContext: function (ctx) {
+      if (ctx.referrer) {
+        this._referrer = ctx.referrer;
+      }
     },
 
     assemble: function () {


### PR DESCRIPTION
Weird way to go about it, but since the page manager for the results page isn't always available when on the classic page we can't rely on messages directly.  This data has to be passed through the navigator.

Makes the "Start New Search" button go back to the correct page.