### PR TITLE
update transpiling settings

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,10 @@
 {
 	"presets": [
-		"@babel/react"
-	]
+    "@babel/react",
+    ["@babel/preset-env", {
+      "targets": {
+        "browsers": ["last 2 versions"]
+      }
+    }]
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",
+    "@babel/preset-env": "^7.4.3",
     "@babel/preset-react": "^7.0.0",
     "async": "^2.5.0",
     "browserify": "^14.4.0",


### PR DESCRIPTION
Update the Babel settings to make sure that we transform properly during the build, without this older browsers are breaking.