### PR TITLE
Remove validation for non-field tokens with colons

### DIFF
--- a/src/js/components/query_validator.js
+++ b/src/js/components/query_validator.js
@@ -62,7 +62,7 @@ define([
      * @returns {boolean}
      */
     var completeValidation = function (res) {
-      return !!res;
+      return res !== null;
     };
 
     /**
@@ -100,7 +100,6 @@ define([
       // any confirmed match will make query invalid
       var validators = [
         completeValidation,
-        new Validator(/^$/), // matches -> ``
         new Validator(/^""$/), // matches -> `foo:""`
         new Validator(/^\(\)$/), // matches -> `foo:()`
         new Validator(/^\(\^\)$/), // matches -> `foo:(^)`

--- a/test/mocha/js/components/query_validator.spec.js
+++ b/test/mocha/js/components/query_validator.spec.js
@@ -156,5 +156,13 @@ define([
       expect(res).to.be.instanceOf(Object);
       expect(res.result).to.eql(true);
     });
+
+    it('correctly allows through non-fielded searches with colons', function () {
+      var q = getMockQuery('tests:  ', 'title: ', 'abs:');
+      var res = qv.validate(q);
+
+      expect(res).to.be.instanceOf(Object);
+      expect(res.result).to.eql(true);
+    });
   });
 });


### PR DESCRIPTION
Fixes an issue that caused searches with colons to incorrectly throw error

No longer throw error for searches like: 
`GW170817: Observation of Gravitational Waves from a Binary Neutron Star Inspiral`