### PR TITLE
Rename "papers which cite" to "papers that cite"

### DIFF
--- a/src/js/wraps/citations.js
+++ b/src/js/wraps/citations.js
@@ -24,7 +24,7 @@ function (
     var options = {
       queryOperator: 'citations',
       sortOrder: 'date desc',
-      description: 'Papers which cite',
+      description: 'Papers that cite',
       operator: true
     };
     return new Widget(options);


### PR DESCRIPTION
Make citations title in abstract page clearer

resolves: #1769