### PR TITLE
Add arXiv link to abstract pages

### DIFF
--- a/src/js/widgets/abstract/templates/abstract_template.html
+++ b/src/js/widgets/abstract/templates/abstract_template.html
@@ -86,6 +86,16 @@
     </dd>
     {{/if}}
 
+    {{#if arxiv}}
+    <dt>arXiv:</dt>
+    <dd>
+        <span>
+            <a href="{{arxiv.href}}" target="_blank" rel="noopener">{{arxiv.id}}</a>
+            <i class="fa fa-external-link"></i>
+        </span>
+    </dd>
+    {{/if}}
+
     <dt>Bibcode:</dt>
     <dd>
       <a href="#abs/{{bibcode}}/abstract">

--- a/src/js/widgets/abstract/widget.js
+++ b/src/js/widgets/abstract/widget.js
@@ -147,6 +147,18 @@ function (
         doc.pubnoteList = _.first(doc.pubnote, MAX_COMMENTS);
       }
 
+      if (doc.identifier) {
+        var id = _.find(doc.identifier, function (d) {
+          return d.toLowerCase().startsWith('arxiv');
+        });
+        if (id) {
+          doc.arxiv = {
+            id: id,
+            href: LinkGeneratorMixin.createUrlByType(doc.bibcode, 'arxiv', id.split(':')[1])
+          }
+        }
+      }
+
       return doc;
     }
   });


### PR DESCRIPTION
arXiv links are now shown (if applicable) on abstract pages