### PR TITLE
Remove unneccessary arXiv link fallback

### DIFF
--- a/src/js/mixins/link_generator_mixin.js
+++ b/src/js/mixins/link_generator_mixin.js
@@ -277,25 +277,6 @@ define(['underscore', 'js/mixins/openurl_generator'], function (_, OpenURLGenera
       }
     });
 
-    // if no arxiv link is present, check links_data as well to make sure
-    const hasEprint = _.find(fullTextSources, { name: LINK_TYPES.EPRINT_PDF.name });
-    if (!hasEprint && _.isArray(data.links_data)) {
-      _.forEach(data.links_data, function (linkData) {
-        const link = JSON.parse(linkData);
-        if (/preprint/i.test(link.type)) {
-          const info = LINK_TYPES.EPRINT_PDF;
-          fullTextSources.push({
-            url: link.url,
-            open: true,
-            shortName: (info && info.shortName) || link.type,
-            name: (info && info.name) || link.type,
-            type: (info && info.type) || 'HTML',
-            description: info && info.description
-          });
-        }
-      });
-    }
-
     // reorder the full text sources based on our default ordering
     fullTextSources = _.sortBy(fullTextSources, function (source) {
       const rank = DEFAULT_ORDERING.indexOf(source.name);

--- a/src/js/widgets/resources/widget.jsx.js
+++ b/src/js/widgets/resources/widget.jsx.js
@@ -47,7 +47,7 @@ define([
       this.view = new View({ store: this.store });
     },
     defaultQueryArguments: {
-      fl: 'bibcode,data,doctype,doi,esources,first_author,genre,isbn,issn,issue,page,property,pub,title,volume,year,links_data'
+      fl: 'bibcode,data,doctype,doi,esources,first_author,genre,isbn,issn,issue,page,property,pub,title,volume,year'
     },
     activate: function (beehive) {
       const { dispatch } = this.store;


### PR DESCRIPTION
Fallback was originally to address synchronization issues between solr and resolver, these are no longer a problem.
Removing so that we have a more accurate representation of the current data, not relying on old structure.