### PR TITLE
Detect ctrl+click on links to help with Windows users

### DIFF
--- a/src/js/mixins/discovery_bootstrap.js
+++ b/src/js/mixins/discovery_bootstrap.js
@@ -76,7 +76,7 @@ function (
         $el.attr('href', url);
 
         // handle metakey presses
-        if (event.metaKey) {
+        if (event.metaKey || event.ctrlKey) {
           metaKey = true;
           return;
         } else if (metaKey && event.type === 'focusin') {


### PR DESCRIPTION
The metaKey prop maps to the Windows (meta) key instead of control, this should make sure that either combination will work