### PR TITLE
Stop prepending utf-8 BOM to export output

### DIFF
--- a/src/js/widgets/export/actions/index.js
+++ b/src/js/widgets/export/actions/index.js
@@ -273,7 +273,9 @@ define([
     const blob = new Blob([state.exports.output], {
       type: 'text/plain;charset=utf-8'
     });
-    saveAs(blob, `export-${state.format.value}.${state.format.ext}`);
+
+    // save Blob to file, passing true to not automatically add BOM
+    saveAs(blob, `export-${state.format.value}.${state.format.ext}`, true);
   };
 
   return actions;


### PR DESCRIPTION
By default, saveAs will prepend the BOM to the export output which may mess with some user scripts if they are expecting plain text.