### PR TITLE
 Make sure reCAPTCHA loads asynchronously

### DIFF
--- a/src/common.config.js
+++ b/src/common.config.js
@@ -199,19 +199,4 @@ define([], function () {
       }
     })();
   });
-
-  // recaptcha stuff
-  require(['jquery'], function ($) {
-
-    // make a global deferred that will be used by the recaptcha_manager
-    window.__grecaptcha__ = $.Deferred();
-
-    // add the global handler which will be called by the recaptcha script
-    window.onRecaptchaLoad = function () {
-      window.__grecaptcha__.resolve();
-    };
-
-    // finally make the request for recaptcha
-    require(['google-recaptcha']);
-  });
 });

--- a/src/discovery.config.js
+++ b/src/discovery.config.js
@@ -53,7 +53,7 @@ require.config({
           DynamicConfig: 'discovery.vars',
           MasterPageManager: 'js/page_managers/master',
           AppStorage: 'js/components/app_storage',
-          RecaptchaManager: 'js/components/recaptcha_manager',
+          RecaptchaManager: 'recaptcha!js/components/recaptcha_manager',
           CSRFManager: "js/components/csrf_manager",
           LibraryController: 'js/components/library_controller',
           DocStashController: 'js/components/doc_stash_controller',
@@ -233,11 +233,6 @@ require.config({
       'libs/g',
       'data:application/javascript,'
     ],
-    'google-recaptcha': [
-      '//google.com/recaptcha/api.js?&render=explicit&onload=onRecaptchaLoad',
-      '//recaptcha.net/recaptcha/api.js?&render=explicit&onload=onRecaptchaLoad',
-      'data:application/javascript,'
-    ],
     'hbs': 'libs/require-handlebars-plugin/hbs',
     'immutable': 'libs/immutable/index',
     'jquery': [
@@ -290,6 +285,7 @@ require.config({
       '//cdnjs.cloudflare.com/ajax/libs/react-redux/4.4.5/react-redux.min',
       'libs/react-redux/index'
     ],
+    'recaptcha': 'js/plugins/recaptcha',
     'redux': [
       '//cdnjs.cloudflare.com/ajax/libs/redux/3.5.2/redux.min',
       'libs/redux/index'

--- a/src/js/apps/discovery/navigator.js
+++ b/src/js/apps/discovery/navigator.js
@@ -634,7 +634,6 @@ function (
         if (widgetName && possibleSearchSubPages.indexOf(widgetName) > -1) {
           pages = [widgetName].concat(searchPageAlwaysVisible.slice(1));
         } else {
-          console.error('Results page subpage not recognized:', widgetName);
           pages = searchPageAlwaysVisible;
         }
 

--- a/src/js/plugins/recaptcha.js
+++ b/src/js/plugins/recaptcha.js
@@ -1,0 +1,28 @@
+define([], function () {
+
+  const URLS = [
+    '//google.com/recaptcha/api.js?&render=explicit&onload=onRecaptchaLoad',
+    '//recaptcha.net/recaptcha/api.js?&render=explicit&onload=onRecaptchaLoad'
+  ];
+
+  const recaptcha = {
+    load: function (name, req, onload, config) {
+
+      // make a global deferred that will be used by the recaptcha_manager
+      window.__grecaptcha__ = $.Deferred();
+
+      // add the global handler which will be called by the recaptcha script
+      window.onRecaptchaLoad = function () {
+        window.__grecaptcha__.resolve();
+      };
+
+      // load each url, we don't care if they take a while or fail
+      URLS.forEach((url) => req([url]));
+
+      // load our resource right away, don't wait for recaptcha to be ready
+      req([name], (value) => onload(value));
+    }
+  };
+
+  return recaptcha;
+});

--- a/test/mocha/js/components/recaptcha_manager.spec.js
+++ b/test/mocha/js/components/recaptcha_manager.spec.js
@@ -1,5 +1,5 @@
 define([
-  "js/components/recaptcha_manager",
+  "recaptcha!js/components/recaptcha_manager",
   'js/bugutils/minimal_pubsub'
 ], function(
   RecaptchaManager,
@@ -15,7 +15,7 @@ define([
       var r = new RecaptchaManager();
 
       r.renderRecaptcha = sinon.spy();
-      
+
       var testView = new Backbone.View();
 
       r.activateRecaptcha(testView);


### PR DESCRIPTION
Moves recaptcha from normal loading path and into a custom loader

This now makes parallel requests for recaptcha resources rather than
relying on fallback urls.  Also it should be non-blocking now, since the
loader replies right away