### PR TITLE
properly clear form on start search

### DIFF
--- a/src/js/widgets/classic_form/widget.js
+++ b/src/js/widgets/classic_form/widget.js
@@ -369,8 +369,15 @@ define([
     },
 
     onNewSearch: function () {
+      this.resetForm();
+    },
+
+    resetForm: function () {
       this.model.set(this.model.defaults);
-      this.view.$('input,textarea').val('');
+      const v = this.view;
+      v.$('input,textarea').val('');
+      v.$('input[type="checkbox"]').prop('checked', false);
+      v.$('input[name="astronomy"]').prop('checked', true);
     },
 
     /**


### PR DESCRIPTION
Currently the form doesn't properly clear the property checkboxes, this can mess up the state of the form later on. 

This should make sure it is properly cleared when performing a new search