### PR TITLE
Fix bug causing author network to keep loading after close

### DIFF
--- a/src/js/widgets/network_vis/network_widget.js
+++ b/src/js/widgets/network_vis/network_widget.js
@@ -1302,7 +1302,7 @@ function (Marionette,
       }
       this.filterCollection.reset(null, { silent: true });
       // reset model
-      this.model.set(_.result(this.model, 'defaults'));
+      this.model.set(_.result(this.model, 'defaults'), { silent: true });
     },
 
     // for now, called to show vis for library


### PR DESCRIPTION
If user selects all papers and then exits, the widget will be in loading state, but was actually in an error state and should be closed.