### PR TITLE
Fix second order menu

### DIFF
--- a/src/js/components/second_order_controller.js
+++ b/src/js/components/second_order_controller.js
@@ -194,7 +194,7 @@ function (
 
       const newQuery = new ApiQuery({
         q: `${ field }(${ q.join(' AND ') })`,
-        sort: query.get('sort') || 'score desc'
+        sort: 'score desc'
       });
       ps.publish(ps.NAVIGATE, 'search-page', { q: newQuery });
     },

--- a/src/js/wraps/visualization_dropdown.js
+++ b/src/js/wraps/visualization_dropdown.js
@@ -18,8 +18,8 @@ define([
     { divider: true },
     { section: 'Operations', icon: {
         class: 'icon-help',
-        href: 'https://adsabs.github.io/img/operators.png',
-        description: 'What are second-order operations?'
+        href: '//adsabs.github.io/help/search/second-order',
+        description: 'Discover more about second-order operators'
       }
     },
     { description: 'Co-reads', pubsubEvent: 'second-order-search/trending' },


### PR DESCRIPTION
Updates the second-order operator menu question mark link
and also makes sure that `score desc` is used as the sort when no selection was made