### PR TITLE
fix ordering of export dropdown

### DIFF
--- a/src/js/wraps/export_dropdown.js
+++ b/src/js/wraps/export_dropdown.js
@@ -42,18 +42,22 @@ define([
               return false;
             }
           });
+          
+          if (match === 0) {
+            return links;
+          }
 
           var newVal = _.assign({}, links[0], {
             description: 'in ' + format,
             params: _.assign({}, links[0].params, { format: formatVal })
           });
+
           return match ?
             [newVal]
-              .concat(links.slice(1, match))
-              .concat(links[0])
+              .concat(links.slice(0, match))
               .concat(links.slice(match + 1)) :
             [newVal]
-              .concat(links.slice(1));
+              .concat(links.slice(0));
         }
         return links;
       }


### PR DESCRIPTION
Make sure that the default selected export format is at the top but does not replace any of the other menu options