### PR TITLE
IE11 fixes

### DIFF
--- a/grunt/concurrent.js
+++ b/grunt/concurrent.js
@@ -13,7 +13,6 @@ module.exports = {
   convert: [
     'exec:convert_enzyme',
     'exec:convert_dsjslib',
-    'exec:convert_redux_immutable',
     'exec:convert_requirejs'
   ],
   hash_require: [

--- a/grunt/copy.js
+++ b/grunt/copy.js
@@ -189,15 +189,6 @@ module.exports = function (grunt) {
           }
         },
         {
-          cwd: 'node_modules/immutable/dist',
-          src: 'immutable.js',
-          dest: 'src/libs/immutable/',
-          expand: true,
-          rename: function (dest, src) {
-            return dest + src.replace('immutable', 'index');
-          }
-        },
-        {
           cwd: 'node_modules/reselect/dist',
           src: 'reselect.js',
           dest: 'src/libs/reselect/',

--- a/grunt/exec.js
+++ b/grunt/exec.js
@@ -9,9 +9,6 @@ module.exports = {
   convert_dsjslib: {
     cmd: 'node node_modules/requirejs/bin/r.js -convert src/libs/dsjslib src/libs/dsjslib'
   },
-  convert_redux_immutable: {
-    cmd: 'mkdir src/libs/redux-immutable && node_modules/.bin/browserify --standalone combineReducers node_modules/redux-immutable/dist/index.js > src/libs/redux-immutable/index.js'
-  },
   convert_requirejs: {
     cmd: 'node_modules/.bin/uglifyjs src/libs/requirejs/require.js -c -m -o src/libs/requirejs/require.js'
   },

--- a/grunt/optimize-build.js
+++ b/grunt/optimize-build.js
@@ -233,7 +233,6 @@ module.exports = function (grunt) {
           "hbs/handlebars",
           "hbs/json2",
           "hbs/underscore",
-          "immutable",
           "js/apps/discovery/main",
           "js/apps/discovery/navigator",
           "js/bugutils/diagnostics",
@@ -356,7 +355,6 @@ module.exports = function (grunt) {
           "js/wraps/visualization_dropdown",
           "js/wraps/vizier_facet",
           "libs/select2/matcher",
-          "redux-immutable",
           "router",
           "utils"
         ]

--- a/grunt/requirejs.js
+++ b/grunt/requirejs.js
@@ -241,7 +241,6 @@
         "hbs/handlebars",
         "hbs/json2",
         "hbs/underscore",
-        "immutable",
         "js/apps/discovery/main",
         "js/apps/discovery/navigator",
         "js/bugutils/diagnostics",
@@ -364,7 +363,6 @@
         "js/wraps/visualization_dropdown",
         "js/wraps/vizier_facet",
         "libs/select2/matcher",
-        "redux-immutable",
         "router",
         "utils"
       ]

--- a/src/discovery.config.js
+++ b/src/discovery.config.js
@@ -197,7 +197,7 @@ require.config({
       '//ajax.aspnetcdn.com/ajax/bootstrap/3.3.5/bootstrap.min',
       'libs/bootstrap/bootstrap'
     ],
-    'bowser': '//cdn.jsdelivr.net/npm/bowser@2.4.0/bundled',  
+    'bowser': '//cdn.jsdelivr.net/npm/bowser@2.4.0/bundled',
     'cache': 'libs/dsjslib/lib/Cache',
     'chai': '../bower_components/chai/chai',
     'classnames': [
@@ -235,7 +235,6 @@ require.config({
       'data:application/javascript,'
     ],
     'hbs': 'libs/require-handlebars-plugin/hbs',
-    'immutable': 'libs/immutable/index',
     'jquery': [
       '//ajax.aspnetcdn.com/ajax/jQuery/jquery-2.0.3.min',
       'libs/jquery/jquery'
@@ -291,7 +290,6 @@ require.config({
       '//cdnjs.cloudflare.com/ajax/libs/redux/3.5.2/redux.min',
       'libs/redux/index'
     ],
-    'redux-immutable': 'libs/redux-immutable/index',
     'redux-thunk': [
       '//cdnjs.cloudflare.com/ajax/libs/redux-thunk/2.1.0/redux-thunk.min',
       'libs/redux-thunk/index'
@@ -381,10 +379,6 @@ require.config({
 
     'persist-js': {
       exports: 'Persist'
-    },
-
-    'redux-immutable': {
-      deps: ['immutable']
     }
   }
 });

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,4 +1,5 @@
 define([
+  'jquery',
   'underscore'
 ], function (_) {
 
@@ -47,16 +48,17 @@ define([
 
   // get the current browser information
   const getBrowserInfo = function () {
-
     // do this inline, so we only request when necessary
-    return new Promise((resolve, reject) => {
-      // reject after 3 seconds
-      const timeoutId = setTimeout(() => { reject(); }, 3000);
-      require(['bowser'], (bowser) => {
-        window.clearTimeout(timeoutId);
-        resolve(bowser.parse(window.navigator.userAgent));
-      }, () => { reject(); });
-    });
+    const $dd = $.Deferred();
+
+    // reject after 3 seconds
+    const timeoutId = setTimeout(() => { $dd.reject(); }, 3000);
+    require(['bowser'], (bowser) => {
+      window.clearTimeout(timeoutId);
+      $dd.resolve(bowser.parse(window.navigator.userAgent));
+    }, () => { $dd.reject(); });
+
+    return $dd.promise();
   };
 
   return {

--- a/src/js/widgets/navbar/widget.js
+++ b/src/js/widgets/navbar/widget.js
@@ -231,7 +231,7 @@ define([
       // get the current browser information
       utils.getBrowserInfo().then((data) => {
         this.model.set('browser', data);
-      }).catch(() => {
+      }).fail(() => {
         this.model.set('browser', null);
       });
     },

--- a/src/js/widgets/orcid-selector/components/orcid-selector-app.jsx.js
+++ b/src/js/widgets/orcid-selector/components/orcid-selector-app.jsx.js
@@ -48,15 +48,16 @@ define([
 
     componentWillReceiveProps(next) {
       // if nothing incoming, just reset
-      if (next.app.get('selected').length === 0) {
+      if (next.app.selected.length === 0) {
         this.setState(initialState);
       }
     }
 
     render() {
-      const len = this.props.app.get('selected').length;
+      const { app } = this.props;
+      const len = app.selected.length;
 
-      if (this.props.app.get('mode')) {
+      if (app.mode) {
         return (
           <div className="s-right-col-widget-container container-fluid">
             <div className="row">

--- a/src/js/widgets/orcid-selector/containers/orcid-selector-container.js
+++ b/src/js/widgets/orcid-selector/containers/orcid-selector-container.js
@@ -1,12 +1,9 @@
 
 define([
-  'underscore',
-  'react',
-  'redux',
   'react-redux',
   'es6!../redux/modules/orcid-selector-app',
   'es6!../components/orcid-selector-app.jsx'
-], function (_, React, Redux, ReactRedux, actions, OrcidSelectorApp) {
+], function (ReactRedux, actions, OrcidSelectorApp) {
   // actions
   const {
     sendEvent
@@ -14,7 +11,7 @@ define([
 
   // mapping state to props
   const mapStateToProps = state => ({
-    app: state.get('OrcidSelectorApp') // state is available on sub-components as 'app'
+    app: state // state is available on sub-components as 'app'
   });
 
   // dispatch to props

--- a/src/js/widgets/orcid-selector/redux/configure-store.js
+++ b/src/js/widgets/orcid-selector/redux/configure-store.js
@@ -2,18 +2,13 @@
 define([
   'redux',
   'redux-thunk',
-  'es6!./modules/orcid-selector-app',
-  'redux-immutable'
-], function (Redux, ReduxThunk, OrcidSelectorApp, ReduxImmutable) {
+  'es6!./modules/orcid-selector-app'
+], function (Redux, ReduxThunk, OrcidSelectorApp) {
   const { createStore, applyMiddleware } = Redux;
-  const { combineReducers } = ReduxImmutable;
 
   return function configureStore(context) {
     const middleware = applyMiddleware(ReduxThunk.default.withExtraArgument(context));
     const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || Redux.compose;
-    const reducer = combineReducers({
-      OrcidSelectorApp: OrcidSelectorApp.reducer
-    });
-    return createStore(reducer, composeEnhancers(middleware));
+    return createStore(OrcidSelectorApp.reducer, composeEnhancers(middleware));
   };
 });

--- a/src/js/widgets/orcid-selector/redux/modules/orcid-selector-app.js
+++ b/src/js/widgets/orcid-selector/redux/modules/orcid-selector-app.js
@@ -1,7 +1,6 @@
 
 define([
-  'immutable'
-], function (Immutable) {
+], function () {
   // Action Constants
   const UPDATE_SELECTED = 'UPDATE_SELECTED';
   const UPDATE_MODE = 'UPDATE_MODE';
@@ -10,23 +9,23 @@ define([
   const updateSelected = value => ({ type: UPDATE_SELECTED, value });
   const updateMode = value => ({ type: UPDATE_MODE, value });
   const sendEvent = event => (dispatch, getState, widget) => {
-    const selected = getState().get('OrcidSelectorApp').get('selected');
+    const { selected } = getState();
     widget.fireOrcidEvent(event, selected);
   };
 
   // initial state
-  const initialState = Immutable.fromJS({
+  const initialState = {
     selected: [],
     mode: false
-  });
+  };
 
   // reducer
   const reducer = (state = initialState, action) => {
     switch (action.type) {
       case UPDATE_SELECTED:
-        return state.set('selected', action.value);
+        return { ...state, selected: action.value };
       case UPDATE_MODE:
-        return state.set('mode', action.value);
+        return { ...state, mode: action.value };
       default: return initialState;
     }
   };

--- a/src/js/widgets/orcid-selector/widget.jsx.js
+++ b/src/js/widgets/orcid-selector/widget.jsx.js
@@ -5,15 +5,13 @@ define([
   'react',
   'react-redux',
   'react-dom',
-  'redux',
   'es6!./redux/configure-store',
   'es6!./redux/modules/orcid-selector-app',
-  'js/components/api_query',
   'js/widgets/base/base_widget',
   'es6!./containers/orcid-selector-container'
 ], function (
-  _, Backbone, React, ReactRedux, ReactDOM, Redux, configureStore,
-  OrcidSelectorApp, ApiQuery, BaseWidget, OrcidSelectorContainer
+  _, Backbone, React, ReactRedux, ReactDOM, configureStore,
+  OrcidSelectorApp, BaseWidget, OrcidSelectorContainer
 ) {
   /**
    * Main App View

--- a/src/js/widgets/sort/components/sort-app.jsx.js
+++ b/src/js/widgets/sort/components/sort-app.jsx.js
@@ -4,9 +4,7 @@ define([
   'react-prop-types'
 ], function (React, PropTypes) {
   const SortApp = ({ setSort, setDirection, app }) => {
-    const options = app.get('options');
-    const sort = app.get('sort');
-    const direction = app.get('direction');
+    const { options, sort, direction } = app;
 
     /**
      * Call the handler after a selection is made from the dropdown
@@ -40,17 +38,17 @@ define([
           data-toggle="dropdown"
           title="Select a sort option"
           >
-          {sort.get('text')} <span className="caret" aria-hidden="true"/>
+          {sort.text} <span className="caret" aria-hidden="true"/>
         </button>
         <ul className="dropdown-menu" role="menu">
           {
             options.map(o => (
-              <li key={o.get('id')}>
+              <li key={o.id}>
                 <a
                   href="javascript:void(0)"
-                  title={o.get('desc')}
+                  title={o.desc}
                   onClick={e => onSelect(o, e)}
-                >{o.get('text')}</a>
+                >{o.text}</a>
               </li>
             ))
           }

--- a/src/js/widgets/sort/containers/sort-container.js
+++ b/src/js/widgets/sort/containers/sort-container.js
@@ -1,12 +1,9 @@
 
 define([
-  'underscore',
-  'react',
-  'redux',
   'react-redux',
   'es6!../redux/modules/sort-app',
   'es6!../components/sort-app.jsx'
-], function (_, React, Redux, ReactRedux, actions, SortApp) {
+], function (ReactRedux, actions, SortApp) {
   // actions
   const {
     setSort,
@@ -15,7 +12,7 @@ define([
 
   // mapping state to props
   const mapStateToProps = state => ({
-    app: state.get('SortApp') // state is available on sub-components as 'app'
+    app: state // state is available on sub-components as 'app'
   });
 
   // dispatch to props

--- a/src/js/widgets/sort/redux/configure-store.js
+++ b/src/js/widgets/sort/redux/configure-store.js
@@ -2,18 +2,13 @@
 define([
   'redux',
   'redux-thunk',
-  'es6!./modules/sort-app',
-  'redux-immutable'
-], function (Redux, ReduxThunk, SortApp, ReduxImmutable) {
+  'es6!./modules/sort-app'
+], function (Redux, ReduxThunk, SortApp) {
   const { createStore, applyMiddleware } = Redux;
-  const { combineReducers } = ReduxImmutable;
 
   return function configureStore(context) {
     const middleware = applyMiddleware(ReduxThunk.default.withExtraArgument(context));
     const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || Redux.compose;
-    const reducer = combineReducers({
-      SortApp: SortApp.reducer
-    });
-    return createStore(reducer, composeEnhancers(middleware));
+    return createStore(SortApp.reducer, composeEnhancers(middleware));
   };
 });

--- a/src/js/widgets/sort/redux/modules/sort-app.js
+++ b/src/js/widgets/sort/redux/modules/sort-app.js
@@ -1,8 +1,7 @@
 
 define([
-  'underscore',
-  'immutable'
-], function (_, Immutable) {
+  'underscore'
+], function (_) {
   // Action Constants
   const SET_DIRECTION = 'SET_DIRECTION';
   const SET_SORT = 'SET_SORT';
@@ -22,10 +21,10 @@ define([
   const setSort = (value, silent) => (dispatch, getState, widget) => {
     // if passed a string, convert it to one of our pre-defined options
     if (_.isString(value)) {
-      const options = getState().get('SortApp').get('options');
+      const { options } = getState();
 
       // attempt to find something, if not just provide the first option
-      value = options.find(i => i.get('id') === value) || options[0];
+      value = options.find(({ id }) => id === value) || options[0];
     }
 
     dispatch({ type: SET_SORT, value });
@@ -45,7 +44,7 @@ define([
   const setDirection = (value, silent) => (dispatch, getState, widget) => {
     // if a direction isn't passed, then just toggle
     if (_.isUndefined(value)) {
-      const direction = getState().get('SortApp').get('direction');
+      const { direction } = getState();
       value = (direction === 'asc') ? 'desc' : 'asc';
     }
     dispatch({ type: SET_DIRECTION, value });
@@ -68,9 +67,9 @@ define([
    */
   const setLocked = value => (dispatch, getState) => {
     // grab the current timer (if exists)
-    const timeout = getState().get('SortApp').get('lockTimer');
-    if (timeout) {
-      clearTimeout(timeout);
+    const { lockTimer } = getState();
+    if (lockTimer) {
+      clearTimeout(lockTimer);
     }
 
     // create a new timer, which resets the locked state after a period of time
@@ -81,7 +80,7 @@ define([
   };
 
   // initial state
-  const initialState = Immutable.fromJS({
+  const initialState = {
     options: [
       { id: 'author_count', text: 'Author Count', desc: 'sort by number of authors' },
       { id: 'bibcode', text: 'Bibcode', desc: 'sort by bibcode' },
@@ -99,22 +98,23 @@ define([
     query: null,
     locked: false,
     lockTimer: null
-  });
+  };
 
   // reducer
   const reducer = (state = initialState, action) => {
     switch (action.type) {
       case SET_SORT:
-        return state.set('sort', action.value);
+          return { ...state, sort: action.value };
       case SET_DIRECTION:
-        return state.set('direction', action.value);
+          return { ...state, direction: action.value };
       case SET_QUERY:
-        return state.set('query', action.value);
+        return { ...state, query: action.value };
       case SET_LOCKED:
-        return state.merge({
+        return {
+          ...state,
           locked: action.value,
           lockTimer: action.timer
-        });
+        };
       default: return initialState;
     }
   };

--- a/src/js/widgets/sort/widget.jsx.js
+++ b/src/js/widgets/sort/widget.jsx.js
@@ -6,7 +6,6 @@ define([
   'react',
   'react-redux',
   'react-dom',
-  'redux',
   'es6!./redux/configure-store',
   'es6!./redux/modules/sort-app',
   'js/components/api_query',
@@ -14,7 +13,7 @@ define([
   'js/components/api_feedback',
   'es6!./containers/sort-container'
 ], function (
-  _, Backbone, analytics, React, ReactRedux, ReactDOM, Redux, configureStore,
+  _, Backbone, analytics, React, ReactRedux, ReactDOM, configureStore,
   SortApp, ApiQuery, BaseWidget, ApiFeedback, SortContainer
 ) {
   /**
@@ -86,10 +85,10 @@ define([
      */
     onSortChange: function () {
       const pubsub = this.getPubSub();
-      const app = this.store.getState().get('SortApp');
-      const sort = app.get('sort').get('id');
-      const dir = app.get('direction');
-      let query = app.get('query');
+      const app = this.store.getState();
+      const sort = app.sort.id;
+      const dir = app.direction;
+      let query = app.query;
       let newSort = sort + ' ' + dir;
 
       // try local app storage if we don't have one stored

--- a/src/styles/sass/ads-sass/landing-page.scss
+++ b/src/styles/sass/ads-sass/landing-page.scss
@@ -26,6 +26,7 @@ $landing-page-hero-background : desaturate(lighten($brand-info, 20%), 15%);
     max-width: 75px;
     position: relative;
     top: -5px;
+    max-height: 66;
   }
 
   >div {

--- a/src/styles/sass/ads-sass/landing-page.scss
+++ b/src/styles/sass/ads-sass/landing-page.scss
@@ -26,7 +26,7 @@ $landing-page-hero-background : desaturate(lighten($brand-info, 20%), 15%);
     max-width: 75px;
     position: relative;
     top: -5px;
-    max-height: 66;
+    max-height: 66px;
   }
 
   >div {

--- a/test/mocha/js/widgets/library_list_widget.spec.js
+++ b/test/mocha/js/widgets/library_list_widget.spec.js
@@ -1,14 +1,12 @@
 define([
   "js/widgets/library_list/widget",
   "js/bugutils/minimal_pubsub",
-  "js/widgets/list_of_things/widget",
-  "immutable"
+  "js/widgets/list_of_things/widget"
 
 ], function(
     LibraryWidget,
     MinSub,
-    ListOfThingsWidget,
-    Immutable
+    ListOfThingsWidget
 ) {
 
   describe("Library List Widget (library_list_widget.spec.js)", function () {
@@ -484,16 +482,16 @@ define([
       expect(l.reset.callCount).to.eql(0);
 
       var state = function () {
-        return l.view.sortWidget.store.getState().get('SortApp').toJS();
+        return l.view.sortWidget.store.getState();
       }
       var st = state();
       expect(st.direction).to.eql('desc');
       expect(st.sort.id).to.eql('date');
 
       var updateSort = function (sort, direction) {
-        var values = Immutable.fromJS({ sort: sort, direction: direction });
-        l.view.sortWidget.store.dispatch({ type: 'SET_SORT', value: values.get('sort') });
-        l.view.sortWidget.store.dispatch({ type: 'SET_DIRECTION', value: values.get('direction') });
+        var values = { sort: sort, direction: direction };
+        l.view.sortWidget.store.dispatch({ type: 'SET_SORT', value: values.sort });
+        l.view.sortWidget.store.dispatch({ type: 'SET_DIRECTION', value: values.direction });
         l.view.onSortChange();
       }
 
@@ -503,7 +501,7 @@ define([
       expect(st.direction).to.eql('desc');
       expect(st.sort.id).to.eql('author_count');
       expect(l.reset.callCount).to.eql(1);
-      expect(fakeApi.request.args[2][0].get("query").toJSON().sort[0]).to.eql("author_count desc, bibcode desc");
+      expect(fakeApi.request.args[2][0].query.toJSON().sort[0]).to.eql("author_count desc, bibcode desc");
 
       // change the direction
       updateSort({ id: 'author_count', text: 'Author Count' }, 'asc');
@@ -511,7 +509,7 @@ define([
       expect(st.direction).to.eql('asc');
       expect(st.sort.id).to.eql('author_count');
       expect(l.reset.callCount).to.eql(2);
-      expect(fakeApi.request.args[3][0].get("query").toJSON().sort[0]).to.eql("author_count asc, bibcode asc");
+      expect(fakeApi.request.args[3][0].query.toJSON().sort[0]).to.eql("author_count asc, bibcode asc");
     });
   });
 });

--- a/test/mocha/js/widgets/orcid_selector_widget.spec.js
+++ b/test/mocha/js/widgets/orcid_selector_widget.spec.js
@@ -10,7 +10,7 @@ define([
       request: _.identity
     }))({ verbose: false });
     this.state = function (w) {
-      return w.store.getState().get('OrcidSelectorApp');
+      return w.store.getState();
     };
   };
 
@@ -29,7 +29,7 @@ define([
       w.activate(this.pubsub.beehive);
 
       // check to make sure mode is off
-      expect(this.state(w).get('mode')).to.equal(false);
+      expect(this.state(w).mode).to.equal(false);
 
       // render and see that it's empty
       expect(w.view.render().$el.children().length).to.equal(0);
@@ -42,7 +42,7 @@ define([
       w.activate(beehive);
 
       // check to make sure mode is on
-      expect(this.state(w).get('mode')).to.equal(true);
+      expect(this.state(w).mode).to.equal(true);
 
       // render and see that it's empty
       expect(w.view.render().$el.children().length).to.be.gt(0);
@@ -52,7 +52,7 @@ define([
       const w = new Widget();
       w.activate(this.pubsub.beehive);
       // should be off initially
-      expect(this.state(w).get('mode')).to.equal(false);
+      expect(this.state(w).mode).to.equal(false);
 
       // trigger a user event
       this.pubsub.publish(this.pubsub.USER_ANNOUNCEMENT, '', {
@@ -60,7 +60,7 @@ define([
       });
 
       // should now be on
-      expect(this.state(w).get('mode')).to.equal(true);
+      expect(this.state(w).mode).to.equal(true);
     });
 
     it('State is update correctly when number of papers is changed', function () {
@@ -71,11 +71,11 @@ define([
       });
       w.activate(beehive);
 
-      expect(this.state(w).get('selected').toJS().length).to.equal(0);
+      expect(this.state(w).selected.length).to.equal(0);
 
       this.pubsub.publish(this.pubsub.STORAGE_PAPER_UPDATE);
 
-      expect(this.state(w).get('selected').length).to.equal(2);
+      expect(this.state(w).selected.length).to.equal(2);
     });
 
     it('Clicking claim button publishes the proper claim event', function () {
@@ -103,7 +103,7 @@ define([
       $('button:contains("Apply")', $el).click();
 
       expect(spy.args[0][0]).is.equal('orcid-bulk-claim');
-      expect(spy.args[0][1]).is.equal(this.state(w).get('selected'));
+      expect(spy.args[0][1]).is.equal(this.state(w).selected);
     });
 
     it('Clicking delete button publishes the proper delete event', function () {
@@ -131,7 +131,7 @@ define([
       $('button:contains("Apply")', $el).click();
 
       expect(spy.args[0][0]).is.equal('orcid-bulk-delete');
-      expect(spy.args[0][1]).is.equal(this.state(w).get('selected'));
+      expect(spy.args[0][1]).is.equal(this.state(w).selected);
     });
   });
 });

--- a/test/mocha/js/widgets/sort_widget.spec.js
+++ b/test/mocha/js/widgets/sort_widget.spec.js
@@ -1,16 +1,13 @@
 
 define([
     'jquery',
-    'underscore',
-    'js/components/api_response',
-    'js/components/api_request',
     'js/components/api_query',
     'js/bugutils/minimal_pubsub',
     'js/widgets/sort/widget.jsx',
     'js/widgets/sort/redux/modules/sort-app',
     'js/components/api_feedback'
     ],
-  function($, _, ApiResponse, ApiRequest, ApiQuery, MinimalPubSub, SortWidget, SortApp, ApiFeedback) {
+  function($, ApiQuery, MinimalPubSub, SortWidget, SortApp, ApiFeedback) {
 
     var init = function () {
       var minsub = new (MinimalPubSub.extend({
@@ -21,7 +18,7 @@ define([
       this.w = new SortWidget();
       this.w.activate(minsub.beehive.getHardenedInstance());
       this.getState = _.bind(function () {
-        return this.w.store.getState().get('SortApp');
+        return this.w.store.getState();
       }, this);
     };
 
@@ -51,7 +48,7 @@ define([
         }));
 
         _.defer(function () {
-          var actual = self.getState().toJS();
+          var actual = self.getState();
           var expected = {
             "sort": {
               "id": "citation_count",
@@ -85,7 +82,7 @@ define([
         }));
 
         _.defer(function () {
-          var actual = self.getState().toJS();
+          var actual = self.getState();
           var expected = {
             "locked": true
           };
@@ -106,7 +103,7 @@ define([
         }));
 
         _.defer(function () {
-          var actual = self.getState().toJS();
+          var actual = self.getState();
           var expected = {
             "locked": false
           };
@@ -127,7 +124,7 @@ define([
         }));
 
         _.defer(function () {
-          var actual = self.getState().toJS();
+          var actual = self.getState();
           var expected = {
             "locked": false
           };


### PR DESCRIPTION
Fixes issue where main logo image was stretched in IE11, due to height not being explicitly set
Removes `immutable` and `immutable-redux` libraries which were causing issues when used in some widgets.

Also converts a `Promise` into equivalent jquery promise, since the polyfills do not work for IE11 afaict.