### PR TITLE
fix toc links

### DIFF
--- a/src/discovery.config.js
+++ b/src/discovery.config.js
@@ -130,7 +130,7 @@ require.config({
         ShowSimilar: 'js/wraps/similar',
         MetaTagsWidget: 'js/widgets/meta_tags/widget',
         //can't camel case because router only capitalizes first letter
-        ShowTableofcontents: 'js/wraps/table_of_contents',
+        ShowToc: 'js/wraps/table_of_contents',
         ShowResources: 'es6!js/widgets/resources/widget.jsx',
         ShowAssociated: 'es6!js/widgets/associated/widget.jsx',
         ShowRecommender: 'js/widgets/recommender/widget',

--- a/src/js/apps/discovery/navigator.js
+++ b/src/js/apps/discovery/navigator.js
@@ -1223,9 +1223,7 @@ function (
         return defer.promise();
       });
 
-      // proxy to ShowTableofcontents
-      this.set('ShowToc', makeProxyHandler('ShowTableofcontents'));
-      this.set('ShowTableofcontents', function (id, data) {
+      this.set('ShowToc', function (id, data) {
         var defer = $.Deferred()
         showDetail([id].concat(detailsPageAlwaysVisible), id).then((page) => {
           if (!data.bibcode) {

--- a/src/js/components/analytics.js
+++ b/src/js/components/analytics.js
@@ -19,7 +19,7 @@ define([
       types: [
         'abstract', 'citations', 'references',
         'metrics', 'coreads', 'similar', 'graphics', 'associated',
-        [ 'tableofcontents', { redirectTo: 'toc' }]
+        'toc'
       ],
       url: _.template('link_gateway/<%= bibcode %>/<%= target %>')
     }

--- a/src/js/mixins/link_generator_mixin.js
+++ b/src/js/mixins/link_generator_mixin.js
@@ -382,7 +382,7 @@ define(['underscore', 'js/mixins/openurl_generator'], function (_, OpenURLGenera
           links.list.push({
             letter: 'T',
             name: 'Table of Contents',
-            url: '#abs/' + enc(data.bibcode) + '/tableofcontents'
+            url: '#abs/' + enc(data.bibcode) + '/toc'
           });
         }
       }

--- a/src/js/wraps/abstract_page_manager/abstract-page-layout.html
+++ b/src/js/wraps/abstract_page_manager/abstract-page-layout.html
@@ -26,7 +26,7 @@
                         <div data-widget="ShowReferences"/>
                         <div data-widget="ShowCoreads"/>
                         <div data-widget="ShowSimilar"/>
-                        <div data-widget="ShowTableofcontents"/>
+                        <div data-widget="ShowToc"/>
                         <div data-widget="ShowGraphics" />
                         <div data-widget="ShowExportcitation" data-origin="abstract"/>
                         <div data-widget="ShowMetrics" data-allow-redirect="false"/>

--- a/src/js/wraps/abstract_page_manager/abstract_page_manager.js
+++ b/src/js/wraps/abstract_page_manager/abstract_page_manager.js
@@ -12,7 +12,7 @@ define([
 ) {
   var PageManager = PageManagerController.extend({
 
-    persistentWidgets: ['SearchWidget', 'ShowAbstract', 'ShowCitations', 'ShowTableofcontents', 'ShowReferences', 'tocWidget'],
+    persistentWidgets: ['SearchWidget', 'ShowAbstract', 'ShowCitations', 'ShowToc', 'ShowReferences', 'tocWidget'],
 
     TOCTemplate: TOCTemplate,
 
@@ -102,9 +102,9 @@ define([
         showCount: false,
         order: 4
       },
-      ShowTableofcontents: {
+      ShowToc: {
         title: 'Volume Content',
-        path: 'tableofcontents',
+        path: 'toc',
         category: 'view',
         showCount: false,
         order: 5

--- a/src/js/wraps/table_of_contents.js
+++ b/src/js/wraps/table_of_contents.js
@@ -9,18 +9,16 @@ function (
 ) {
   var Widget = DetailsWidget.extend({
     initialize: function () {
-      this.name = 'ShowTableofcontents';
+      this.name = 'ShowToc';
       return DetailsWidget.prototype.initialize.apply(this, arguments);
     },
     ingestBroadcastedPayload: function (data) {
       var hasTOC = data.property && data.property.indexOf('TOC') > -1;
-      if (hasTOC) {
-        this.trigger('page-manager-event', 'widget-ready', {
-          numFound: 1,
-          isActive: true
-        });
-        DetailsWidget.prototype.ingestBroadcastedPayload.apply(this, arguments);
-      }
+      this.trigger('page-manager-event', 'widget-ready', {
+        numFound: +hasTOC,
+        isActive: hasTOC
+      });
+      DetailsWidget.prototype.ingestBroadcastedPayload.apply(this, arguments);
     },
     customizeQuery: function (apiQuery) {
       var bibcode = this.parseIdentifierFromQuery(apiQuery);

--- a/test/mocha/js/components/analytics.spec.js
+++ b/test/mocha/js/components/analytics.spec.js
@@ -102,7 +102,7 @@ define([
         expect(expected).to.eql(actual);
       });
       analytics('send', 'event', 'interaction', 'toc-link-followed', {
-        target: 'tableofcontents',
+        target: 'toc',
         bibcode: 'foo'
       });
       server.respond();

--- a/test/mocha/js/mixins/link_generator_mixin.spec.js
+++ b/test/mocha/js/mixins/link_generator_mixin.spec.js
@@ -327,7 +327,7 @@ define([
               {
                 letter: 'T',
                 name: 'Table of Contents',
-                url: '#abs/foo/tableofcontents'
+                url: '#abs/foo/toc'
               }
             ],
           }

--- a/test/mocha/js/widgets/lot_derivates.spec.js
+++ b/test/mocha/js/widgets/lot_derivates.spec.js
@@ -203,7 +203,7 @@ define([
       expect($w.find(".s-list-description").text()).to.eql("Papers in the same volume as");
 
       widget.trigger("page-manager-message", "broadcast-payload", {title: "foo"});
-      widget.trigger("page-manager-message", "widget-selected", { idAttribute: "ShowTableofcontents" });
+      widget.trigger("page-manager-message", "widget-selected", { idAttribute: "ShowToc" });
 
       setTimeout(function(){
         expect($w.find(".s-article-title").text()).to.eql("foo");


### PR DESCRIPTION
Rename `tableofcontents` links to `toc`
Fix issue with erroneous active toc link on abstract pages