### PR TITLE
Fix up associated widget

### DIFF
--- a/src/js/widgets/associated/redux/modules/api.js
+++ b/src/js/widgets/associated/redux/modules/api.js
@@ -2,7 +2,6 @@ define([], function () {
   const actions = {
     CURRENT_QUERY_UPDATED: '[api] CURRENT_QUERY_UPDATED',
     FETCH_DATA: '[api] FETCH_DATA',
-    FETCHING_DATA: '[api] FETCHING_DATA',
     QUERY_PROVIDED: '[api] QUERY_PROVIDED',
     RECEIVED_RESPONSE: '[api] RECEIVED_RESPONSE',
     SEND_ANALYTICS: '[api] SEND_ANALYTICS',
@@ -21,6 +20,8 @@ define([], function () {
         return { ...state, bibcode: action.result };
       case actions.CURRENT_QUERY_UPDATED:
         return { ...state, query: action.result };
+      case actions.RESET:
+        return initialState;
       default:
         return state;
     }
@@ -29,7 +30,8 @@ define([], function () {
   // action creators
   const displayDocuments = result => ({ type: actions.QUERY_PROVIDED, result });
   const processResponse = result => ({ type: actions.RECEIVED_RESPONSE, result });
-  const fallbackOnError = result => ({ type: actions.FALLBACK_ON_ERROR });
+  const fallbackOnError = () => ({ type: actions.FALLBACK_ON_ERROR });
+  const setBibcode = result => ({ type: actions.SET_BIBCODE, result });
 
   return {
     reducer,
@@ -37,6 +39,7 @@ define([], function () {
     actions,
     displayDocuments,
     processResponse,
-    fallbackOnError
+    fallbackOnError,
+    setBibcode
   };
 });

--- a/src/js/widgets/associated/redux/modules/ui.js
+++ b/src/js/widgets/associated/redux/modules/ui.js
@@ -3,7 +3,8 @@ define([], function () {
     LINK_CLICKED: '[ui] LINK_CLICKED',
     SET_LOADING: '[ui] SET_LOADING',
     SET_ITEMS: '[ui] SET_ITEMS',
-    SET_HAS_ERROR: '[ui] SET_HAS_ERROR'
+    SET_HAS_ERROR: '[ui] SET_HAS_ERROR',
+    RESET: '[ui] RESET'
   };
 
   const initialState = {
@@ -20,6 +21,8 @@ define([], function () {
         return { ...state, items: action.result };
       case actions.SET_HAS_ERROR:
         return { ...state, hasError: action.result, loading: false };
+      case actions.RESET:
+        return initialState;
       default:
         return state;
     }
@@ -28,12 +31,14 @@ define([], function () {
   // action creators
   const handleLinkClick = result => ({ type: actions.LINK_CLICKED, result });
   const setError = result => ({ type: actions.SET_HAS_ERROR, result });
+  const reset = () => ({ type: actions.RESET });
 
   return {
     reducer,
     initialState,
     actions,
     handleLinkClick,
-    setError
+    setError,
+    reset
   };
 });

--- a/src/js/widgets/associated/widget.jsx.js
+++ b/src/js/widgets/associated/widget.jsx.js
@@ -46,6 +46,10 @@ define([
 
       // create the view, passing in store
       this.view = new View({ store: this.store });
+
+      if (!window.__BUMBLEBEE_TESTING_MODE__) {
+        this.processAbstractData = _.debounce(_.bind(this.processAbstractData, this), 300);
+      }
     },
     defaultQueryArguments: {},
     activate: function (beehive) {
@@ -59,8 +63,8 @@ define([
         if (event === 'latest-abstract-data') {
           const { bibcode: currentId } = this.store.getState().api;
           let id = data.bibcode || data.identifier;
-          id = typeof id === 'array' ? id[0] : id;
-          if (currentId === id) {
+          id = Array.isArray(id) ? id[0] : id;
+          if (!id || currentId === id) {
             return;
           }
 
@@ -77,14 +81,14 @@ define([
         }
       });
     },
-    processAbstractData: _.debounce(function (data) {
+    processAbstractData: function (data) {
       const { dispatch } = this.store;
       if (data && data.property && data.property.includes('ASSOCIATED')) {
         this.dispatchRequest(new ApiQuery());
       } else {
         dispatch(ui.setError('no associated property'));
       }
-    }, 300),
+    },
     composeRequest: function () {
       const { bibcode } = this.store.getState().api;
 


### PR DESCRIPTION
* Fixes issue with widget sending superfluous requests when the document
does not have the `ASSOCIATED` property.

* Widget also now waits for more important abstract widget to load before sending any request