### PR TITLE
Make Abstract Routes Handle Slashes Properly

### DIFF
--- a/src/js/apps/discovery/router.js
+++ b/src/js/apps/discovery/router.js
@@ -1,244 +1,291 @@
 define([
-  'underscore',
-  'jquery',
-  'backbone',
-  'js/components/api_query',
-  'js/mixins/dependon',
-  'js/components/api_feedback',
-  'js/components/api_request',
-  'js/components/api_targets',
-  'js/mixins/api_access',
-  'js/components/api_query_updater'
+    'underscore',
+    'jquery',
+    'backbone',
+    'js/components/api_query',
+    'js/mixins/dependon',
+    'js/components/api_feedback',
+    'js/components/api_request',
+    'js/components/api_targets',
+    'js/mixins/api_access',
+    'js/components/api_query_updater'
 
-],
-function (
-  _,
-  $,
-  Backbone,
-  ApiQuery,
-  Dependon,
-  ApiFeedback,
-  ApiRequest,
-  ApiTargets,
-  ApiAccessMixin,
-  ApiQueryUpdater
-) {
-  var Router = Backbone.Router.extend({
+  ],
+  function (
+    _,
+    $,
+    Backbone,
+    ApiQuery,
+    Dependon,
+    ApiFeedback,
+    ApiRequest,
+    ApiTargets,
+    ApiAccessMixin,
+    ApiQueryUpdater
+  ) {
+    var Router = Backbone.Router.extend({
 
-    initialize: function (options) {
-      options = options || {};
-      this.queryUpdater = new ApiQueryUpdater('Router');
-    },
+      initialize: function (options) {
+        options = options || {};
+        this.queryUpdater = new ApiQueryUpdater('Router');
+      },
 
-    execute: function (callback, args) {
-      // only perform actions if history has started
-      if (Backbone.History.started) {
-        var route = Backbone.history.getFragment();
-        route = route === '' ? 'index' : route;
+      execute: function (callback, args) {
+        // only perform actions if history has started
+        if (Backbone.History.started) {
+          var route = Backbone.history.getFragment();
+          route = route === '' ? 'index' : route;
 
-        // Workaround for issue where hitting back button from the index page
-        // goes to an empty `search/` route, so capture that here and go back 2
-        if (route === 'search/' && _.isEmpty(_.reject(args, _.isUndefined))) {
-          return Backbone.history.history.go(-2);
+          // Workaround for issue where hitting back button from the index page
+          // goes to an empty `search/` route, so capture that here and go back 2
+          if (route === 'search/' && _.isEmpty(_.reject(args, _.isUndefined))) {
+            return Backbone.history.history.go(-2);
+          }
         }
-      }
 
-      if (_.isFunction(callback)) {
-        callback.apply(this, args);
-      }
-    },
+        if (_.isFunction(callback)) {
+          callback.apply(this, args);
+        }
+      },
 
-    activate: function (beehive) {
-      this.setBeeHive(beehive);
-      if (!this.hasPubSub()) {
-        throw new Error('Ooops! Who configured this #@$%! There is no PubSub service!');
-      }
-    },
+      activate: function (beehive) {
+        this.setBeeHive(beehive);
+        if (!this.hasPubSub()) {
+          throw new Error('Ooops! Who configured this #@$%! There is no PubSub service!');
+        }
+      },
 
-    /*
-      * if you don't want the navigator to duplicate the route in history,
-      * use this function instead of pubsub.publish(pubsub.NAVIGATE ...)
-      * */
-
-    routerNavigate: function (route, options) {
-      var options = options || {};
-      this.getPubSub().publish(this.getPubSub().NAVIGATE, route, options);
-    },
-
-    routes: {
-      '/': 'index',
-      '': 'index',
-      'classic-form(/)': 'classicForm',
-      'paper-form(/)': 'paperForm',
-      'index/(:query)': 'index',
-      'search/(:query)(/)(:widgetName)': 'search',
-      'execute-query/(:query)': 'executeQuery',
-      'abs/:bibcode(/)(:subView)': 'view',
       /*
-        * user endpoints require user to be logged in, either
-        * to orcid or to ads
-        * */
-      'user/orcid*(:subView)': 'orcidPage',
-      'user/account(/)(:subView)': 'authenticationPage',
-      'user/account/verify/(:subView)/(:token)': 'routeToVerifyPage',
-      'user/settings(/)(:subView)(/)': 'settingsPage',
-      'user/libraries(/)(:id)(/)(:subView)(/)(:subData)(/)': 'librariesPage',
-      'user/home(/)': 'homePage',
-      /* end user routes */
+       * if you don't want the navigator to duplicate the route in history,
+       * use this function instead of pubsub.publish(pubsub.NAVIGATE ...)
+       * */
 
-      'orcid-instructions(/)': 'orcidInstructions',
+      routerNavigate: function (route, options) {
+        var options = options || {};
+        this.getPubSub().publish(this.getPubSub().NAVIGATE, route, options);
+      },
 
-      'public-libraries/(:id)(/)': 'publicLibraryPage',
-      '*invalidRoute': 'noPageFound'
-    },
+      routes: {
+        '/': 'index',
+        '': 'index',
+        'classic-form(/)': 'classicForm',
+        'paper-form(/)': 'paperForm',
+        'index/(:query)': 'index',
+        'search/(:query)(/)(:widgetName)': 'search',
+        'execute-query/(:query)': 'executeQuery',
+        'abs/*path': 'view',
+        /*
+         * user endpoints require user to be logged in, either
+         * to orcid or to ads
+         * */
+        'user/orcid*(:subView)': 'orcidPage',
+        'user/account(/)(:subView)': 'authenticationPage',
+        'user/account/verify/(:subView)/(:token)': 'routeToVerifyPage',
+        'user/settings(/)(:subView)(/)': 'settingsPage',
+        'user/libraries(/)(:id)(/)(:subView)(/)(:subData)(/)': 'librariesPage',
+        'user/home(/)': 'homePage',
+        /* end user routes */
 
-    index: function (query) {
-      this.routerNavigate('index-page');
-    },
+        'orcid-instructions(/)': 'orcidInstructions',
 
-    classicForm: function () {
-      this.routerNavigate('ClassicSearchForm');
-    },
+        'public-libraries/(:id)(/)': 'publicLibraryPage',
+        '*invalidRoute': 'noPageFound'
+      },
 
-    paperForm: function () {
-      this.routerNavigate('PaperSearchForm');
-    },
+      index: function (query) {
+        this.routerNavigate('index-page');
+      },
 
-    search: function (query, widgetName) {
+      classicForm: function () {
+        this.routerNavigate('ClassicSearchForm');
+      },
 
-      if (query) {
-        try {
-          var q = new ApiQuery().load(query);
-          this.routerNavigate('search-page', {
-            q: q,
-            page: widgetName && 'show-' + widgetName,
-            replace: true
-          });
-        } catch (e) {
-          console.error('Error parsing query from a string: ', query, e);
-          this.getPubSub().publish(this.getPubSub().NAVIGATE, 'index-page');
-          this.getPubSub().publish(this.getPubSub().BIG_FIRE, new ApiFeedback({
-            code: ApiFeedback.CODES.CANNOT_ROUTE,
-            reason: 'Cannot parse query',
-            query: query
-          }));
-          return this.getPubSub().publish(this.getPubSub().ALERT, new ApiFeedback({
-            code: ApiFeedback.CODES.ALERT,
-            msg: 'unable parse query',
-            type: 'danger',
-            modal : true
-          }));
-        }
-      } else {
-        this.getPubSub().publish(this.getPubSub().NAVIGATE, 'index-page');
-      }
-    },
+      paperForm: function () {
+        this.routerNavigate('PaperSearchForm');
+      },
 
+      search: function (query, widgetName) {
 
-    executeQuery: function (queryId) {
-      this.getPubSub().publish(this.getPubSub().NAVIGATE, 'execute-query', queryId);
-    },
-
-    view: function (bibcode, subPage) {
-      var navigateString, href;
-      if (!subPage) {
-        navigateString = 'ShowAbstract';
-        href = '#abs/' + encodeURIComponent(bibcode) + '/abstract';
-      } else {
-        navigateString = 'Show' + subPage[0].toUpperCase() + subPage.slice(1);
-        href = '#abs/' + encodeURIComponent(bibcode) + '/' + subPage;
-      }
-      this.routerNavigate(navigateString, { href: href, bibcode: bibcode });
-    },
-
-
-    routeToVerifyPage: function (subView, token) {
-      this.getPubSub().publish(this.getPubSub().NAVIGATE, 'user-action', {subView: subView, token: token});
-    },
-
-    orcidPage: function () {
-      this.getPubSub().publish(this.getPubSub().NAVIGATE, 'orcid-page');
-    },
-
-    orcidInstructions: function () {
-      this.getPubSub().publish(this.getPubSub().NAVIGATE, 'orcid-instructions');
-    },
-
-    authenticationPage: function (subView) {
-      // possible subViews: "login", "register", "reset-password"
-      if (subView && !_.contains(['login', 'register', 'reset-password-1', 'reset-password-2'], subView)) {
-        throw new Error('that isn\'t a subview that the authentication page knows about');
-      }
-      this.routerNavigate('authentication-page', { subView: subView });
-    },
-
-    settingsPage: function (subView) {
-      // possible subViews: "token", "password", "email", "preferences"
-      if (_.contains(['token', 'password', 'email', 'delete'], subView)) {
-        this.routerNavigate('UserSettings', { subView: subView });
-      } else if (_.contains(['librarylink', 'orcid', 'application'], subView)) {
-        // show preferences if no subview provided
-        this.routerNavigate('UserPreferences', { subView: subView });
-      } else if (_.contains(['libraryimport'], subView)) {
-        this.routerNavigate('LibraryImport');
-      } else {
-        // just default to showing the library link page for now
-        this.routerNavigate('UserPreferences', { subView: undefined });
-      }
-    },
-
-    librariesPage: function (id, subView, subData) {
-      if (id) {
-        if (id === 'actions') {
-          return this.routerNavigate('LibraryActionsWidget', 'libraries');
-        }
-
-        // individual libraries view
-        var subView = subView || 'library';
-        if (_.contains(['library', 'admin'], subView)) {
-          this.routerNavigate('IndividualLibraryWidget', { subView: subView, id: id });
-        } else if (_.contains(['export', 'metrics', 'visualization'], subView)) {
-          subView = 'library-' + subView;
-
-          if (subView == 'library-export') {
-            this.routerNavigate(subView, { subView: subData || 'bibtex', id: id });
-          } else if (subView == 'library-metrics') {
-            this.routerNavigate(subView, { id: id });
+        if (query) {
+          try {
+            var q = new ApiQuery().load(query);
+            this.routerNavigate('search-page', {
+              q: q,
+              page: widgetName && 'show-' + widgetName,
+              replace: true
+            });
+          } catch (e) {
+            console.error('Error parsing query from a string: ', query, e);
+            this.getPubSub().publish(this.getPubSub().NAVIGATE, 'index-page');
+            this.getPubSub().publish(this.getPubSub().BIG_FIRE, new ApiFeedback({
+              code: ApiFeedback.CODES.CANNOT_ROUTE,
+              reason: 'Cannot parse query',
+              query: query
+            }));
+            return this.getPubSub().publish(this.getPubSub().ALERT, new ApiFeedback({
+              code: ApiFeedback.CODES.ALERT,
+              msg: 'unable parse query',
+              type: 'danger',
+              modal: true
+            }));
           }
         } else {
-          throw new Error('did not recognize subview for library view');
+          this.getPubSub().publish(this.getPubSub().NAVIGATE, 'index-page');
         }
-      } else {
+      },
+
+
+      executeQuery: function (queryId) {
+        this.getPubSub().publish(this.getPubSub().NAVIGATE, 'execute-query', queryId);
+      },
+
+      view: function (path) {
+        if (!path) {
+          return this.routerNavigate('404');
+        }
+
+        // break apart the path
+        const parts = path.split('/');
+
+        // check for a subpage
+        let subPage;
+        const subPageRegex = /^(abstract|citations|references|coreads|similar|toc|graphics|metrics|exportcitation)$/
+        if (parts[parts.length - 1].match(subPageRegex)) {
+          subPage = parts.pop();
+        }
+
+        // take the rest and combine into the identifier
+        const id = parts.join('/');
+
+        var navigateString, href;
+        if (!subPage) {
+          navigateString = 'ShowAbstract';
+          href = '#abs/' + encodeURIComponent(id) + '/abstract';
+        } else {
+          navigateString = 'Show' + subPage[0].toUpperCase() + subPage.slice(1);
+          href = '#abs/' + encodeURIComponent(id) + '/' + subPage;
+        }
+        this.routerNavigate(navigateString, {
+          href: href,
+          bibcode: id
+        });
+      },
+
+
+      routeToVerifyPage: function (subView, token) {
+        this.getPubSub().publish(this.getPubSub().NAVIGATE, 'user-action', {
+          subView: subView,
+          token: token
+        });
+      },
+
+      orcidPage: function () {
+        this.getPubSub().publish(this.getPubSub().NAVIGATE, 'orcid-page');
+      },
+
+      orcidInstructions: function () {
+        this.getPubSub().publish(this.getPubSub().NAVIGATE, 'orcid-instructions');
+      },
+
+      authenticationPage: function (subView) {
+        // possible subViews: "login", "register", "reset-password"
+        if (subView && !_.contains(['login', 'register', 'reset-password-1', 'reset-password-2'], subView)) {
+          throw new Error('that isn\'t a subview that the authentication page knows about');
+        }
+        this.routerNavigate('authentication-page', {
+          subView: subView
+        });
+      },
+
+      settingsPage: function (subView) {
+        // possible subViews: "token", "password", "email", "preferences"
+        if (_.contains(['token', 'password', 'email', 'delete'], subView)) {
+          this.routerNavigate('UserSettings', {
+            subView: subView
+          });
+        } else if (_.contains(['librarylink', 'orcid', 'application'], subView)) {
+          // show preferences if no subview provided
+          this.routerNavigate('UserPreferences', {
+            subView: subView
+          });
+        } else if (_.contains(['libraryimport'], subView)) {
+          this.routerNavigate('LibraryImport');
+        } else {
+          // just default to showing the library link page for now
+          this.routerNavigate('UserPreferences', {
+            subView: undefined
+          });
+        }
+      },
+
+      librariesPage: function (id, subView, subData) {
+        if (id) {
+          if (id === 'actions') {
+            return this.routerNavigate('LibraryActionsWidget', 'libraries');
+          }
+
+          // individual libraries view
+          var subView = subView || 'library';
+          if (_.contains(['library', 'admin'], subView)) {
+            this.routerNavigate('IndividualLibraryWidget', {
+              subView: subView,
+              id: id
+            });
+          } else if (_.contains(['export', 'metrics', 'visualization'], subView)) {
+            subView = 'library-' + subView;
+
+            if (subView == 'library-export') {
+              this.routerNavigate(subView, {
+                subView: subData || 'bibtex',
+                id: id
+              });
+            } else if (subView == 'library-metrics') {
+              this.routerNavigate(subView, {
+                id: id
+              });
+            }
+          } else {
+            throw new Error('did not recognize subview for library view');
+          }
+        } else {
+          // main libraries view
+          this.routerNavigate('AllLibrariesWidget', 'libraries');
+        }
+      },
+
+      publicLibraryPage: function (id) {
         // main libraries view
-        this.routerNavigate('AllLibrariesWidget', 'libraries');
+        this.getPubSub().publish(this.getPubSub().NAVIGATE, 'IndividualLibraryWidget', {
+          id: id,
+          publicView: true,
+          subView: 'library'
+        });
+      },
+
+      homePage: function (subView) {
+        this.routerNavigate('home-page', {
+          subView: subView
+        });
+      },
+
+      noPageFound: function () {
+        this.routerNavigate('404');
+      },
+
+
+      _extractParameters: function (route, fragment) {
+        return _.map(route.exec(fragment).slice(1), function (param) {
+          // do not decode api queries
+          if (/q\=/.test(param)) {
+            return param;
+          }
+
+          return param ? decodeURIComponent(param) : param;
+        });
       }
-    },
+    });
 
-    publicLibraryPage: function (id) {
-      // main libraries view
-      this.getPubSub().publish(this.getPubSub().NAVIGATE, 'IndividualLibraryWidget', { id: id, publicView: true, subView: 'library' });
-    },
+    _.extend(Router.prototype, Dependon.BeeHive, ApiAccessMixin);
 
-    homePage: function (subView) {
-      this.routerNavigate('home-page', { subView: subView });
-    },
-
-    noPageFound: function () {
-      this.routerNavigate('404');
-    },
-
-
-    _extractParameters: function (route, fragment) {
-      return _.map(route.exec(fragment).slice(1), function (param) {
-        // do not decode api queries
-        if (/q\=/.test(param)) { return param; }
-
-        return param ? decodeURIComponent(param) : param;
-      });
-    }
+    return Router;
   });
-
-  _.extend(Router.prototype, Dependon.BeeHive, ApiAccessMixin);
-
-  return Router;
-});

--- a/src/js/components/navigator.js
+++ b/src/js/components/navigator.js
@@ -13,189 +13,194 @@
  */
 
 define(['underscore',
-  'jquery',
-  'cache',
-  'js/components/generic_module',
-  'js/mixins/dependon',
-  'js/components/transition',
-  'js/components/transition_catalog',
-  'analytics'
-],
-function (
-  _,
-  $,
-  Cache,
-  GenericModule,
-  Mixins,
-  Transition,
-  TransitionCatalog,
-  analytics
-) {
+    'jquery',
+    'cache',
+    'js/components/generic_module',
+    'js/mixins/dependon',
+    'js/components/transition',
+    'js/components/transition_catalog',
+    'analytics'
+  ],
+  function (
+    _,
+    $,
+    Cache,
+    GenericModule,
+    Mixins,
+    Transition,
+    TransitionCatalog,
+    analytics
+  ) {
 
-  // Document Title Constants
-  var APP_TITLE = 'NASA/ADS';
-  var TITLE_SEP = ' - ';
+    // Document Title Constants
+    var APP_TITLE = 'NASA/ADS';
+    var TITLE_SEP = ' - ';
 
-  var Navigator = GenericModule.extend({
+    var Navigator = GenericModule.extend({
 
-    initialize: function (options) {
-      options = options || {};
-      this.router = options.router;
-      this.catalog = new TransitionCatalog(); // catalog of nagivation points (later we can build FST)
-    },
+      initialize: function (options) {
+        options = options || {};
+        this.router = options.router;
+        this.catalog = new TransitionCatalog(); // catalog of nagivation points (later we can build FST)
+      },
 
-    /**
+      /**
        * Starts listening on the PubSub
        *
        * @param beehive - the full access instance; we excpect PubSub to be
        *    present
        */
-    activate: function (beehive) {
-      this.setBeeHive(beehive);
-      this.storage = beehive.getObject('AppStorage');
-      var pubsub = this.getPubSub();
-      pubsub.subscribe(pubsub.NAVIGATE, _.bind(this.navigate, this));
-      pubsub.subscribe(pubsub.CUSTOM_EVENT, _.bind(this._onCustomEvent, this));
-    },
+      activate: function (beehive) {
+        this.setBeeHive(beehive);
+        this.storage = beehive.getObject('AppStorage');
+        var pubsub = this.getPubSub();
+        pubsub.subscribe(pubsub.NAVIGATE, _.bind(this.navigate, this));
+        pubsub.subscribe(pubsub.CUSTOM_EVENT, _.bind(this._onCustomEvent, this));
+      },
 
-    _onCustomEvent: function (ev, data) {
-      if (ev === 'update-document-title') {
-        this._updateDocumentTitle(data);
-      }
-    },
+      _onCustomEvent: function (ev, data) {
+        if (ev === 'update-document-title') {
+          this._updateDocumentTitle(data);
+        }
+      },
 
-    _cleanRoute: function (route) {
-      const r = route.match(/[#\/]?([^\/]*)\//);
-      if (r.length > 1) {
-        return '/' + r[1];
-      }
-      return route;
-    },
+      _cleanRoute: function (route) {
+        const r = route.match(/[#\/]?([^\/]*)\//);
+        if (r && r.length > 1) {
+          return '/' + r[1];
+        }
+        return route;
+      },
 
-    _setPageAndEmitEvent: _.debounce(function (route, pageName) {
-      analytics('set', 'page', this._cleanRoute(route));
-      analytics('send', 'pageview', {
-        'dimension1': pageName
-      });
-    }, 300),
+      _setPageAndEmitEvent: _.debounce(function (route, pageName) {
+        analytics('set', 'page', this._cleanRoute(route));
+        analytics('send', 'pageview', {
+          'dimension1': pageName
+        });
+      }, 300),
 
-    /**
+      /**
        * Responds to PubSubEvents.NAVIGATE signal
        */
-    navigate: function (ev, arg1, arg2) {
-      var defer = $.Deferred();
-      var self = this;
+      navigate: function (ev, arg1, arg2) {
+        var defer = $.Deferred();
+        var self = this;
 
-      if (!this.router || !(this.router instanceof Backbone.Router)) {
-        defer.reject(new Error('Navigator must be given \'router\' instance'));
-        return defer.promise();
-      }
-
-      var transition = this.catalog.get(ev);
-      if (!transition) {
-        this.handleMissingTransition(arguments);
-        defer.reject(new Error('Missing route; going to 404'));
-        return defer.promise();
-      }
-
-      if (!transition.execute) {
-
-        // do nothing
-        return defer.resolve().promise();
-      }
-
-      var afterNavigation = _.bind(function() {
-
-        // router can communicate directly with navigator to replace url
-        var replace = !!((transition.replace || arg1 && arg1.replace));
-
-        if (transition.route === '' || transition.route) {
-          var route = transition.route === '' ? '/' : transition.route;
-          this._setPageAndEmitEvent(route, ev);
-          this.router.navigate(route, { trigger: false, replace: replace });
+        if (!this.router || !(this.router instanceof Backbone.Router)) {
+          defer.reject(new Error('Navigator must be given \'router\' instance'));
+          return defer.promise();
         }
 
-        // clear any metadata added to head on the previous page
-        $('head').find('meta[data-highwire]').remove();
-        this._updateDocumentTitle(transition.title);
-        defer.resolve();
-      }, this);
+        var transition = this.catalog.get(ev);
+        if (!transition) {
+          this.handleMissingTransition(arguments);
+          defer.reject(new Error('Missing route; going to 404'));
+          return defer.promise();
+        }
 
-      var p;
-      try {
-        p = transition.execute.apply(transition, arguments);
-        (p && _.isFunction(p.then)) ? p.then(afterNavigation) : afterNavigation();
-      } catch (e) {
-        this.handleTransitionError(transition, e, arguments);
-        var err = new Error('Error transitioning to route; going to 404');
-        return defer.reject(err).promise();
-      }
+        if (!transition.execute) {
 
-      return defer.promise();
-    },
+          // do nothing
+          return defer.resolve().promise();
+        }
 
-    _updateDocumentTitle: function (title) {
-      if (_.isUndefined(title) || title === false) return;
-      var currTitle = this.storage.getDocumentTitle();
-      var setDocTitle = _.bind(function (t) {
-        document.title = t === '' ? APP_TITLE : t + TITLE_SEP + APP_TITLE;
-        this.storage.setDocumentTitle(t);
-      }, this);
+        var afterNavigation = _.bind(function () {
 
-      // title is defined and it is different from the current one, it should be updated
-      if (title !== currTitle) {
-        setDocTitle(title);
-      }
-    },
+          // router can communicate directly with navigator to replace url
+          var replace = !!((transition.replace || arg1 && arg1.replace));
 
-    handleMissingTransition: function (transition) {
-      console.error('Cannot handle \'navigate\' event: ' + JSON.stringify(arguments));
-      var ps = this.getPubSub();
-      ps.publish(ps.BIG_FIRE, 'navigation-error', arguments);
-      if (this.catalog.get('404'))
-        ps.publish(ps.NAVIGATE, '404');
-    },
+          if (transition.route === '' || transition.route) {
+            var route = transition.route === '' ? '/' : transition.route;
+            this._setPageAndEmitEvent(route, ev);
+            this.router.navigate(route, {
+              trigger: false,
+              replace: replace
+            });
+          }
 
-    handleTransitionError: function (transition, error, args) {
-      console.error('Error while executing transition', transition, args);
-      console.error(error.stack);
-      var ps = this.getPubSub();
-      ps.publish(ps.CITY_BURNING, 'navigation-error', arguments);
-      if (this.catalog.get('404'))
-        ps.publish(ps.NAVIGATE, '404');
-    },
+          // clear any metadata added to head on the previous page
+          $('head').find('meta[data-highwire]').remove();
+          this._updateDocumentTitle(transition.title);
+          defer.resolve();
+        }, this);
 
-    /**
+        var p;
+        try {
+          p = transition.execute.apply(transition, arguments);
+          (p && _.isFunction(p.then)) ? p.then(afterNavigation): afterNavigation();
+        } catch (e) {
+          this.handleTransitionError(transition, e, arguments);
+          var err = new Error('Error transitioning to route; going to 404');
+          return defer.reject(err).promise();
+        }
+
+        return defer.promise();
+      },
+
+      _updateDocumentTitle: function (title) {
+        if (_.isUndefined(title) || title === false) return;
+        var currTitle = this.storage.getDocumentTitle();
+        var setDocTitle = _.bind(function (t) {
+          document.title = t === '' ? APP_TITLE : t + TITLE_SEP + APP_TITLE;
+          this.storage.setDocumentTitle(t);
+        }, this);
+
+        // title is defined and it is different from the current one, it should be updated
+        if (title !== currTitle) {
+          setDocTitle(title);
+        }
+      },
+
+      handleMissingTransition: function (transition) {
+        console.error('Cannot handle \'navigate\' event: ' + JSON.stringify(arguments));
+        var ps = this.getPubSub();
+        ps.publish(ps.BIG_FIRE, 'navigation-error', arguments);
+        if (this.catalog.get('404'))
+          ps.publish(ps.NAVIGATE, '404');
+      },
+
+      handleTransitionError: function (transition, error, args) {
+        console.error('Error while executing transition', transition, args);
+        console.error(error.stack);
+        var ps = this.getPubSub();
+        ps.publish(ps.CITY_BURNING, 'navigation-error', arguments);
+        if (this.catalog.get('404'))
+          ps.publish(ps.NAVIGATE, '404');
+      },
+
+      /**
        * Sets the transition inside the catalog; you can pass simplified
        * list of options or the Transition instance
        */
-    set: function () {
-      if (arguments.length == 1) {
-        if (arguments[1] instanceof Transition) {
-          return this.catalog.add(arguments[1]);
-        }
-        throw new Error('You must be kiddin\' sir!');
-      } else if (arguments.length == 2) {
-        var endpoint = arguments[0];
-        if (_.isFunction(arguments[1])) {
-          return this.catalog.add(new Transition(endpoint, { execute: arguments[1] }));
-        }
-        if (_.isObject(arguments[1]) && arguments[1].execute) {
-          return this.catalog.add(new Transition(endpoint, arguments[1]));
-        }
+      set: function () {
+        if (arguments.length == 1) {
+          if (arguments[1] instanceof Transition) {
+            return this.catalog.add(arguments[1]);
+          }
+          throw new Error('You must be kiddin\' sir!');
+        } else if (arguments.length == 2) {
+          var endpoint = arguments[0];
+          if (_.isFunction(arguments[1])) {
+            return this.catalog.add(new Transition(endpoint, {
+              execute: arguments[1]
+            }));
+          }
+          if (_.isObject(arguments[1]) && arguments[1].execute) {
+            return this.catalog.add(new Transition(endpoint, arguments[1]));
+          }
 
-        throw new Error('Himmm, I dont know how to create a catalog rule with this input:', arguments);
-      } else {
-        // var args = array.slice.call(arguments, 1);
-        throw new Error('Himmm, I dont know how to create a catalog rule with this input:', arguments);
+          throw new Error('Himmm, I dont know how to create a catalog rule with this input:', arguments);
+        } else {
+          // var args = array.slice.call(arguments, 1);
+          throw new Error('Himmm, I dont know how to create a catalog rule with this input:', arguments);
+        }
+      },
+
+      get: function (endpoint) {
+        return this.catalog.get(endpoint);
       }
-    },
+    });
 
-    get: function (endpoint) {
-      return this.catalog.get(endpoint);
-    }
+    _.extend(Navigator.prototype, Mixins.BeeHive);
+    return Navigator;
   });
-
-  _.extend(Navigator.prototype, Mixins.BeeHive);
-  return Navigator;
-});

--- a/test/mocha/js/apps/discovery/router.spec.js
+++ b/test/mocha/js/apps/discovery/router.spec.js
@@ -5,19 +5,19 @@ define([
   'js/services/api',
   'js/services/pubsub',
   'js/components/session'
-], function(
-    _,
-    Router,
-    Beehive,
-    Api,
-    PubSub,
-    Session
-  ){
+], function (
+  _,
+  Router,
+  Beehive,
+  Api,
+  PubSub,
+  Session
+) {
 
 
-  describe("Router", function(){
+  describe("Router", function () {
 
-    it("all endpoints", function(){
+    it("all endpoints", function () {
 
       var r = new Router();
 
@@ -59,14 +59,21 @@ define([
       expect(fakePubSub.publish.lastCall.args[2]).to.eql("execute-query");
       expect(fakePubSub.publish.lastCall.args[3]).to.eql('queryid');
 
-      r.view('bibcooode', 'metrics')
+      r.view('bibcooode/metrics')
       expect(fakePubSub.publish.lastCall.args[1]).to.eql(fakePubSub.NAVIGATE);
       expect(fakePubSub.publish.lastCall.args[2]).to.eql("ShowMetrics");
       expect(fakePubSub.publish.lastCall.args[3]).to.eql({
         href: "#abs/bibcooode/metrics",
         bibcode: "bibcooode",
-      })
+      });
 
+      r.view('test/test/test/test/test/metrics')
+      expect(fakePubSub.publish.lastCall.args[1]).to.eql(fakePubSub.NAVIGATE);
+      expect(fakePubSub.publish.lastCall.args[2]).to.eql("ShowMetrics");
+      expect(fakePubSub.publish.lastCall.args[3]).to.eql({
+        href: "#abs/test%2Ftest%2Ftest%2Ftest%2Ftest/metrics",
+        bibcode: "test/test/test/test/test",
+      });
 
       r.routeToVerifyPage('subview', 'token')
       expect(fakePubSub.publish.lastCall.args[1]).to.eql(fakePubSub.NAVIGATE);


### PR DESCRIPTION
`abs/*` links should now properly handle identifiers with slashes