### PR TITLE
Adds the current query to introspection event

### DIFF
--- a/src/js/components/query_mediator.js
+++ b/src/js/components/query_mediator.js
@@ -733,7 +733,7 @@ function (
             break;
 
           default:
-            analytics('send', 'event', 'introspection', 'not-retrying', status);
+            analytics('send', 'event', 'introspection', 'not-retrying', status, JSON.stringify(qm.mostRecentQuery.toJSON()));
         }
       }
     },


### PR DESCRIPTION
You'll be able to find it by looking for
behavior > events > introspection > (status) > not-retrying

Should help with #1903 