### PR TITLE
solve case of the missing numResults string

### DIFF
--- a/src/js/widgets/search_bar/templates/search_bar_template.html
+++ b/src/js/widgets/search_bar/templates/search_bar_template.html
@@ -126,17 +126,15 @@
 
   </div>
 
-  {{#unless loading}}
-    <div class="s-num-found">
-      <span class="s-light-font description">Your search returned</span>
-        <b><span class="num-found-container">{{numFound}}</span></b>
-        <span class="s-light-font"> results </span>
-      {{#if citationCount}}
-        <span class="search-bar__citation-count"> with <b><span class="citation-count-container">{{citationCount}}</span></b>
-          <span class="s-light-font description">total {{citationLabel}} </span>
-        </span>
-      {{/if}}
-    </div>
-  {{/unless}}
+  <div class="s-num-found">
+    <span class="s-light-font description">Your search returned</span>
+      <b><span class="num-found-container">{{numFound}}</span></b>
+      <span class="s-light-font"> results </span>
+    {{#if citationCount}}
+      <span class="search-bar__citation-count"> with <b><span class="citation-count-container">{{citationCount}}</span></b>
+        <span class="s-light-font description">total {{citationLabel}} </span>
+      </span>
+    {{/if}}
+  </div>
 </div>
 </div>


### PR DESCRIPTION
Not sure why, but sometimes the loading prop doesn't update properly and can cause the number of results string to not show.  Hiding it when loading is not necessary, so removing that extra criteria.