### PR TITLE
Fix abstract navigation disabled bug

### DIFF
--- a/src/js/wraps/abstract_page_manager/abstract-nav.html
+++ b/src/js/wraps/abstract_page_manager/abstract-nav.html
@@ -4,7 +4,7 @@
 
     {{#each view}}
 
-    <a href="#abs/{{../bibcode}}/{{this.path}}" {{#unless this.isActive}} aria-disabled="true" {{/unless}} data-widget-id="{{this.id}}">
+    <a href="{{#if this.isActive}} #abs/{{../bibcode}}/{{this.path}} {{else}} javascript:void(0); {{/if}}" {{#unless this.isActive}} aria-disabled="true" {{/unless}} data-widget-id="{{this.id}}">
     <div class="abstract-nav s-nav {{#if this.isSelected}} s-nav-selected {{/if}} {{#unless this.isActive}} s-nav-inactive {{/unless}}">
             <span class="s-content">
             {{this.title}}
@@ -18,7 +18,7 @@
     {{/each}}
 
     {{#each export}}
-    <a href="#abs/{{../bibcode}}/{{this.path}}" data-widget-id="{{this.id}}">
+    <a href="{{#if this.isActive}} #abs/{{../bibcode}}/{{this.path}} {{else}} javascript:void(0); {{/if}}" data-widget-id="{{this.id}}" {{#unless this.isActive}} aria-disabled="true" {{/unless}}>
       <div class="abstract-nav s-nav {{#if this.isSelected}} s-nav-selected {{/if}} {{#unless this.isActive}} s-nav-inactive {{/unless}}">
         <span class="content">
           Export Citation


### PR DESCRIPTION
The templates now properly remove url from links on disabled TOC links
on the abstract page