### PR TITLE
add metadata mixin

### DIFF
--- a/src/js/mixins/expose_metadata.js
+++ b/src/js/mixins/expose_metadata.js
@@ -1,0 +1,47 @@
+define([
+  'underscore',
+  'js/components/api_targets',
+  'js/components/api_query',
+  'js/components/api_request',
+], function(_, ApiTargets, ApiQuery, ApiRequest) {
+  const NAME = '__EXPORT_RESULTS_AS_BIBTEX__';
+
+  const mixin = {
+    /**
+     *
+     * Gets an array of documents and exposes a function on
+     * the global object which, when called, will make a request
+     * to `/export` to retrieve a bibtex string.
+     *
+     * This global method can't be called
+     * more than once per cycle.
+     *
+     * @param {object[]} docs - array of documents
+     */
+    __exposeMetadata: function(docs = []) {
+      window[NAME] = _.once(
+        () =>
+          new Promise((resolve, reject) => {
+            const ids = docs.map((d) =>
+              _.isArray(d.identifier) ? d.identifier[0] : d.identifier
+            );
+            const ps = this.getPubSub();
+            const request = new ApiRequest({
+              target: ApiTargets.EXPORT + 'bibtex',
+              query: new ApiQuery({ bibcode: ids }),
+              options: {
+                type: 'POST',
+                done: ({ export: bibtexString }) => {
+                  resolve({ identifiers: ids, bibtexString });
+                },
+                fail: (ev) => reject(ev),
+              },
+            });
+            ps.publish(ps.EXECUTE_REQUEST, request);
+          })
+      );
+    },
+  };
+
+  return mixin;
+});

--- a/src/js/widgets/results/widget.js
+++ b/src/js/widgets/results/widget.js
@@ -12,6 +12,7 @@ define([
   'js/mixins/formatter',
   'hbs!js/widgets/results/templates/container-template',
   'js/mixins/papers_utils',
+  'js/mixins/expose_metadata',
   'js/modules/orcid/extension',
   'js/mixins/dependon',
   'js/components/api_feedback'
@@ -25,6 +26,7 @@ function (
   Formatter,
   ContainerTemplate,
   PapersUtilsMixin,
+  MetadataMixin,
   OrcidExtension,
   Dependon,
   ApiFeedback
@@ -245,6 +247,7 @@ function (
       var self = this;
       var userData = this.getBeeHive().getObject('User').getUserData('USER_DATA');
       var link_server = userData.link_server;
+      this.__exposeMetadata(docs);
       this.updateMinAuthorsFromUserData();
 
       var appStorage = null;
@@ -395,6 +398,6 @@ function (
 
   _.extend(ResultsWidget.prototype, LinkGenerator);
   _.extend(ResultsWidget.prototype, Formatter);
-  _.extend(ResultsWidget.prototype, PapersUtilsMixin, Dependon.BeeHive);
+  _.extend(ResultsWidget.prototype, PapersUtilsMixin, MetadataMixin, Dependon.BeeHive);
   return OrcidExtension(ResultsWidget);
 });


### PR DESCRIPTION
Exposes a function after each search cycle that allows for reference managers or whatever to get the current results as a bulk export in bibtex