### PR TITLE
change database -> collection in autocomplete

### DIFF
--- a/src/js/widgets/search_bar/autocomplete.js
+++ b/src/js/widgets/search_bar/autocomplete.js
@@ -39,8 +39,10 @@ define([
 
     { value: 'abs:""', label: 'Search abstract + title + keywords', match: 'abs:' },
 
-    { value: 'database:astronomy', label: 'Limit to papers in the astronomy database', match: 'database:astronomy' },
-    { value: 'database:physics', label: 'Limit to papers in the physics database', match: 'database:physics' },
+    { value: 'collection:astronomy', label: 'Limit to papers in the astronomy database', match: 'database:astronomy' },
+    { value: 'collection:physics', label: 'Limit to papers in the physics database', match: 'database:physics' },
+    { value: 'collection:astronomy', label: 'Limit to papers in the astronomy database', match: 'collection:astronomy' },
+    { value: 'collection:physics', label: 'Limit to papers in the physics database', match: 'collection:physics' },
 
     // hide this one
     //    {value: "abstract:\"\"" , label : "Abstract", match: "abstract:("},

--- a/src/js/widgets/search_bar/templates/option-dropdown.html
+++ b/src/js/widgets/search_bar/templates/option-dropdown.html
@@ -10,7 +10,7 @@
   <option value="bibstem">bib abbrev, e.g. ApJ</option>
   <option value="body">body of article</option>
   <option value="data">data archive</option>
-  <option value="database">database</option>
+  <option value="collection">collection</option>
   <option value="doctype">doctype</option>
   <option value="doi">doi</option>
   <option value="entdate" data-default-value="[2000-01-01 TO 2010-01-01]">entdate</option>


### PR DESCRIPTION
Changes the name in the quick-field dropdown
Autocomplete will work with database or collection, but always completes with "collection:..."