### PR TITLE
add fix for hydration issue

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,14 +1,14 @@
 define(['jquery', 'underscore', 'analytics'], function($, _, analytics) {
   const qs = function(key, str, separator) {
-    const k = key.replace(/[*+?^$.\[\]{}()|\\\/]/g, '\\$&'); // escape RegEx meta chars
+    const k = key.replace(/[*+?^$.[\]{}()|\\/]/g, '\\$&'); // escape RegEx meta chars
     var pattern = '(^|[\\?&])' + k + '=[^&]*';
-    var match = (str || location.hash).match(new RegExp(pattern, 'g'));
+    var match = (str || window.location.hash).match(new RegExp(pattern, 'g'));
     if (!match) {
       return null;
     }
     var clean = [];
     // remove 'key=' from string, combine with optional separator and unquote spaces
-    for (var i = 0; i < match.length; i++) {
+    for (var i = 0; i < match.length; i += 1) {
       clean.push(match[i].replace(new RegExp('(^|[\\?&])' + k + '='), ''));
     }
     if (separator) {
@@ -20,11 +20,12 @@ define(['jquery', 'underscore', 'analytics'], function($, _, analytics) {
         return decodeURIComponent(msg.replace(/\+/g, ' '));
       });
     }
+    return null;
   };
 
   const updateHash = function(key, value, hash) {
-    const k = key.replace(/[*+?^$.\[\]{}()|\\\/]/g, '\\$&');
-    const h = _.isString(hash) ? hash : location.hash;
+    const k = key.replace(/[*+?^$.[\]{}()|\\/]/g, '\\$&');
+    const h = _.isString(hash) ? hash : window.location.hash;
     const match = h.match(new RegExp('&?' + k + '=([^&]+)(&|$)'));
     if (match) {
       const mat = match[0].replace(match[1], value);
@@ -53,12 +54,16 @@ define(['jquery', 'underscore', 'analytics'], function($, _, analytics) {
     const timeoutId = setTimeout(() => {
       $dd.reject();
     }, 3000);
-    require(['bowser'], (bowser) => {
-      window.clearTimeout(timeoutId);
-      $dd.resolve(bowser.parse(window.navigator.userAgent));
-    }, () => {
-      $dd.reject();
-    });
+    window.require(
+      ['bowser'],
+      (bowser) => {
+        window.clearTimeout(timeoutId);
+        $dd.resolve(bowser.parse(window.navigator.userAgent));
+      },
+      () => {
+        $dd.reject();
+      }
+    );
 
     return $dd.promise();
   };
@@ -110,8 +115,11 @@ define(['jquery', 'underscore', 'analytics'], function($, _, analytics) {
         return $dd.reject('timeout');
       }
       ref = setTimeout(() => {
-        window.requestAnimationFrame(() => check(++n));
+        window.requestAnimationFrame(() => {
+          check((n += 1));
+        });
       }, 100);
+      return null;
     })(0);
     $dd.promise.destroy = () => {
       window.clearTimeout(ref);
@@ -123,18 +131,22 @@ define(['jquery', 'underscore', 'analytics'], function($, _, analytics) {
   const withPrerenderedContent = (view) => {
     view.handlePrerenderedContent = (content, $el) => {
       // setup the elements so events are properly delegated
-      view.$el = $(view.tagName + '.' + view.className, $el);
+      const selector = view.tagName + '.' + view.className;
+      view.$el = $(selector, $el);
+
+      // stops mathjax from pre-rendering before we replace the content
+      $('>', view.$el).addClass('tex2jax_ignore');
       view.el = view.$el.get(0);
       view.delegateEvents();
 
-      // reset on first model change
-      view.model.once(
-        'change',
-        () => (view.getTemplate = () => view.getOption('template'))
-      );
+      // replace the current marionette template renderer for a moment
+      const _renderTmpl = view._renderTemplate;
+      view._renderTemplate = () => {};
 
-      // override the template to provide our pre-rendered content
-      view.getTemplate = () => content;
+      // reset template renderer on first model change
+      view.model.once('change', () => {
+        view._renderTemplate = _renderTmpl;
+      });
     };
     return view;
   };

--- a/src/js/widgets/abstract/widget.js
+++ b/src/js/widgets/abstract/widget.js
@@ -185,7 +185,7 @@ define([
       return false;
     },
 
-    toggleAffiliation: function(ev) {
+    toggleAffiliation: function() {
       this.$('fail-aff').hide();
       this.$('#pending-aff').show();
       this.trigger('fetchAffiliations', (err) => {
@@ -220,7 +220,18 @@ define([
         container: 'body',
       });
 
-      if (MathJax) MathJax.Hub.Queue(['Typeset', MathJax.Hub, this.el]);
+      if (MathJax) {
+        MathJax.Hub.Queue([
+          'Typeset',
+          MathJax.Hub,
+          this.$('.s-abstract-title', this.el).get(0),
+        ]);
+        MathJax.Hub.Queue([
+          'Typeset',
+          MathJax.Hub,
+          this.$('.s-abstract-text', this.el).get(0),
+        ]);
+      }
     },
   });
 
@@ -293,7 +304,7 @@ define([
         this.getCurrentQuery().toJSON(),
         _.keys(newQueryJSON)
       );
-      if (JSON.stringify(newQueryJSON) != JSON.stringify(currentStreamlined)) {
+      if (JSON.stringify(newQueryJSON) !== JSON.stringify(currentStreamlined)) {
         this._docs = {};
       }
     },
@@ -321,7 +332,7 @@ define([
         num_citations: 0,
         num_references: 0,
       };
-      var resolved_citations = c ? c.num_citations : 0;
+      var resolvedCitations = c ? c.num_citations : 0;
 
       this.trigger('page-manager-event', 'broadcast-payload', {
         title: this._docs[bibcode].title,
@@ -331,7 +342,7 @@ define([
 
         // used by citation list widget
         citation_discrepancy:
-          this._docs[bibcode].citation_count - resolved_citations,
+          this._docs[bibcode].citation_count - resolvedCitations,
         citation_count: this._docs[bibcode].citation_count,
         references_count: c.num_references,
         read_count: this._docs[bibcode].read_count,
@@ -361,11 +372,11 @@ define([
 
     onDisplayDocuments: function(apiQuery) {
       this.updateState(this.STATES.LOADING);
-
+      let stashedDocs = [];
       // check to see if a query is already in progress (the way bbb is set up, it will be)
       // if so, auto fill with docs initially requested by results widget
       try {
-        var stashedDocs = this.getBeeHive()
+        stashedDocs = this.getBeeHive()
           .getObject('DocStashController')
           .getDocs();
       } catch (e) {
@@ -396,12 +407,12 @@ define([
     },
 
     onAllInternalEvents: function(ev, arg1) {
-      if ((ev == 'next' || ev == 'prev') && this._current) {
+      if ((ev === 'next' || ev === 'prev') && this._current) {
         var keys = _.keys(this._docs);
         var pubsub = this.getPubSub();
         var curr = _.indexOf(keys, this._current);
         if (curr > -1) {
-          if (ev == 'next' && curr + 1 < keys.length) {
+          if (ev === 'next' && curr + 1 < keys.length) {
             pubsub.publish(pubsub.DISPLAY_DOCUMENTS, keys[curr + 1]);
           } else if (curr - 1 > 0) {
             pubsub.publish(pubsub.DISPLAY_DOCUMENTS, keys[curr - 1]);


### PR DESCRIPTION
fixes #2013
The problem came down to how the hydration works.  We had been passing the full raw html as the template string to the renderer, which works most of the time.  However, if there are any   MathML or any other template-specific strings it can break when parsing the template, and then never get to render the full dynamic page.
We now switch out the renderer fully until the first render has been called then swap it back in.  This makes sure we don't run anything through a template engine during that initial      phase.