### PR TITLE
Fix library metrics and data fetching

### DIFF
--- a/src/js/apps/discovery/navigator.js
+++ b/src/js/apps/discovery/navigator.js
@@ -433,17 +433,26 @@ define([
 
         function renderLibrarySub(id) {
           var defer = $.Deferred();
-          app
-            .getObject('LibraryController')
-            .getLibraryBibcodes(id)
-            .done(function(bibcodes) {
-              // XXX - this was async in the original version; likely wrong
-              // one block should be main...
-              app.getWidget('LibraryListWidget').then(function(listWidget) {
-                var sort = listWidget.model.get('sort');
-                app.getWidget(widgetName).then(function(subWidget) {
-                  additional = _.extend({}, additional, { sort: sort });
-                  subWidget.renderWidgetForListOfBibcodes(bibcodes, additional);
+
+          app.getWidget('LibraryListWidget').then(function(listWidget) {
+            var sort = listWidget.model.get('sort');
+            app.getWidget(widgetName).then(function(subWidget) {
+              app
+                .getObject('LibraryController')
+                .fetchLibraryMetadata(id)
+                .then(({ num_documents: numFound }) => {
+                  // use second order operator and library id to set query
+                  const currentQuery = new ApiQuery({
+                    q: `docs(library/${id})`,
+                    fl: 'bibcode',
+                    sort,
+                  });
+                  subWidget.setCurrentQuery(currentQuery);
+                  subWidget.renderWidgetForCurrentQuery({
+                    currentQuery,
+                    format,
+                    numFound,
+                  });
                   app
                     .getWidget('IndividualLibraryWidget')
                     .then(function(indWidget) {
@@ -455,8 +464,8 @@ define([
                       defer.resolve();
                     });
                 });
-              });
             });
+          });
           return defer.promise();
         }
 

--- a/src/js/components/library_controller.js
+++ b/src/js/components/library_controller.js
@@ -177,7 +177,7 @@ define([
       var deferred = $.Deferred();
       var that = this;
 
-      if (options.bibcodes == 'all') {
+      if (options.bibcodes === 'all') {
         var limit = options.limit || 2000;
         var start = 0;
         var rows = 100;
@@ -192,9 +192,10 @@ define([
           q.set('start', start);
 
           this._executeApiRequest(q).done(function(apiResponse) {
-            var bibs = _.map(apiResponse.get('response.docs'), function(d) {
-              return d.bibcode;
-            });
+            var bibs = _.map(
+              apiResponse.get('response.docs'),
+              (d) => d.bibcode
+            );
 
             [].push.apply(bibcodes, bibs);
             start += rows;
@@ -326,10 +327,9 @@ define([
       var limit = maxReturned;
       // start gets incremented
       var start = 0;
-      var rows = 100;
+      var rows = 1000;
       var bibcodes = [];
       var endpoint = ApiTargets.LIBRARIES + '/' + id;
-      var that = this;
 
       // this function gets called repeatedly
       function done(data) {
@@ -350,7 +350,7 @@ define([
 
       function makeRequest() {
         var q = new ApiQuery();
-        q.set('rows', 100);
+        q.set('rows', 1000);
         q.set('fl', 'bibcode');
 
         q.set('start', start);

--- a/src/js/widgets/metrics/widget.js
+++ b/src/js/widgets/metrics/widget.js
@@ -892,7 +892,8 @@ define([
         pubsub.ALERT,
         new ApiFeedback({
           code: 0,
-          msg: 'Sorry Metrics are unavailable at this time, try again later',
+          msg:
+            'Metrics did not manage to complete your request in time, probably your dataset is too large',
           type: 'danger',
         })
       );
@@ -1597,7 +1598,7 @@ define([
        If this changed in the future, the checkIfSimpleRequired function would need to
        be refactored to create a bigquery, then send the qid to execute_query
        */
-      this.getMetrics(bibcodes, { simple: false });
+      this.getMetrics(bibcodes);
     },
   });
 

--- a/test/mocha/js/apps/discovery/navigator.spec.js
+++ b/test/mocha/js/apps/discovery/navigator.spec.js
@@ -4,17 +4,17 @@ define([
   'js/components/api_feedback',
   'js/components/session'
 
-], function(
-    Navigator,
-    MinPubSub,
-    ApiFeedback,
-    Session
+], function (
+  Navigator,
+  MinPubSub,
+  ApiFeedback,
+  Session
 
-){
+) {
 
-  describe("Navigator", function(){
+  describe("Navigator", function () {
 
-    it("should handle the orcid endpoint and authenticating if code is provided", function(){
+    it("should handle the orcid endpoint and authenticating if code is provided", function () {
 
       var n = new Navigator();
 
@@ -22,10 +22,10 @@ define([
 
       var orcidApi = {
         //only testing after orcid access has been provided
-        hasAccess : function(){
+        hasAccess: function () {
           return true
         },
-        getADSUserData : function(){
+        getADSUserData: function () {
           var d = $.Deferred();
           //pretending user hasnt filled in data yet
           d.resolve({});
@@ -33,27 +33,28 @@ define([
         }
       };
       var storage = {
-        get : function(val){
-          if (val == "orcidAuthenticating"){
+        get: function (val) {
+          if (val == "orcidAuthenticating") {
             return true;
           }
         },
-        remove : sinon.spy(function(val){
-        })
+        remove: sinon.spy(function (val) {})
       };
 
       var appStorage = {
-        executeStashedNav : sinon.spy(function(){
+        executeStashedNav: sinon.spy(function () {
           return true;
         }),
 
-        get : function(a){
-          if (a == "stashedNav") return ["UserPreferences", {"subView":"orcid"}];
+        get: function (a) {
+          if (a == "stashedNav") return ["UserPreferences", {
+            "subView": "orcid"
+          }];
         }
       };
 
       var AlertsController = {
-        alert : sinon.spy()
+        alert: sinon.spy()
       };
 
       var MasterPageManager = {
@@ -67,28 +68,24 @@ define([
         getService: function (obj) {
           if (obj == "OrcidApi") {
             return orcidApi
-          }
-          else if (obj == "PersistentStorage") {
+          } else if (obj == "PersistentStorage") {
             return storage
           }
         },
         getObject: function (obj) {
           if (obj == "AppStorage") {
             return appStorage;
-          }
-          else if (obj == "User") {
+          } else if (obj == "User") {
             return {
               isLoggedIn: function () {
                 return true
               }
             }
-          }
-          else if (obj === "MasterPageManager") {
+          } else if (obj === "MasterPageManager") {
             return MasterPageManager;
-          }
-          else if (obj === "LibraryController"){
+          } else if (obj === "LibraryController") {
             return {
-              getLibraryBibcodes : function(){
+              getLibraryBibcodes: function () {
                 return ["1", "2", "3"]
               }
             }
@@ -101,9 +98,9 @@ define([
           }
         },
 
-        getWidget : function(obj){
-          if (obj === "OrcidBigWidget"){
-            return sinon.spy(function(){
+        getWidget: function (obj) {
+          if (obj === "OrcidBigWidget") {
+            return sinon.spy(function () {
               var d = $.Deferred();
               d.resolve();
               return d;
@@ -126,11 +123,11 @@ define([
       //2. show the modal and redirect to orcidbigwidget
 
       var appStorage = {
-        executeStashedNav : sinon.spy(function(){
+        executeStashedNav: sinon.spy(function () {
           return false;
         }),
 
-        get : function(a){
+        get: function (a) {
           if (a == "stashedNav") return undefined;
         }
       };
@@ -148,27 +145,30 @@ define([
       expect(MasterPageManager.show.args[0][0]).to.eql("OrcidPage");
 
 
-  });
+    });
 
-    it("should have endpoints for library-export, library-metrics, and library-visualization", function(done){
+    it("should have endpoints for library-export, library-metrics, and library-visualization", function (done) {
 
       var n = new Navigator();
 
-      n.getPubSub = function(){
+      n.getPubSub = function () {
         return {
-          publish : sinon.spy()
+          publish: sinon.spy()
         }
       }
 
       var Export = {
-        renderWidgetForListOfBibcodes : sinon.spy()
+        renderWidgetForCurrentQuery: sinon.spy(),
+        setCurrentQuery: sinon.spy()
       };
       var Library = {
-        setSubView : sinon.spy()
+        setSubView: sinon.spy()
       };
 
       var MasterPageManager = {
-        show : sinon.spy(function() { return $.Deferred().resolve().promise()})
+        show: sinon.spy(function () {
+          return $.Deferred().resolve().promise()
+        })
       };
 
       var app = {
@@ -177,28 +177,36 @@ define([
 
           if (obj === "MasterPageManager") {
             return MasterPageManager;
-          }
-          else if (obj === "LibraryController"){
+          } else if (obj === "LibraryController") {
             return {
-              getLibraryBibcodes : function(){
+              getLibraryBibcodes: function () {
                 return $.Deferred().resolve(["1", "2", "3"]);
+              },
+              fetchLibraryMetadata: () => {
+                return $.Deferred().resolve({
+                  num_documents: 3
+                });
               }
             }
           }
         },
 
-        getWidget : function(obj){
+        getWidget: function (obj) {
           var d = $.Deferred();
-          if (obj === "ExportWidget"){
+          if (obj === "ExportWidget") {
             d.resolve(Export);
           }
-          if (obj === "IndividualLibraryWidget"){
+          if (obj === "IndividualLibraryWidget") {
             d.resolve(Library);
           }
 
           // we only grab this for the sort prop on the model
           if (obj === 'LibraryListWidget') {
-            d.resolve({ model: { get: _.constant('date desc') }});
+            d.resolve({
+              model: {
+                get: _.constant('date desc')
+              }
+            });
           }
           return d;
         }
@@ -207,7 +215,7 @@ define([
       n.start(app);
 
 
-      n.catalog.get("library-export").execute("library-export",    {
+      n.catalog.get("library-export").execute("library-export", {
         "id": "1",
         "publicView": false,
         "subView": "export",
@@ -215,29 +223,31 @@ define([
         "additional": {
           "format": "bibtex"
         }
-      }).done(function() {
+      }).done(function () {
 
-        expect(Export.renderWidgetForListOfBibcodes.callCount).to.eql(1);
-        expect(Export.renderWidgetForListOfBibcodes.args[0]).to.eql([
-          [
-            "1",
-            "2",
-            "3"
+        expect(Export.renderWidgetForCurrentQuery.callCount).to.eql(1);
+        expect(Export.renderWidgetForCurrentQuery.args[0][0]).to.exist;
+        const args = Export.renderWidgetForCurrentQuery.args[0][0];
+        expect(args.currentQuery.toJSON()).to.eql({
+          "q": [
+            "docs(library/1)"
           ],
-          {
-            "format": "bibtex",
-            "sort": "date desc"
-          }
-        ]);
+          "fl": [
+            "bibcode"
+          ],
+          "sort": [
+            "date desc"
+          ]
+        });
+        expect(args.format).to.eql('bibtex');
+        expect(args.numFound).to.eql(3)
 
         expect(Library.setSubView.callCount).to.eql(1);
-        expect(Library.setSubView.args[0]).to.eql([
-          {
-            "subView": "export",
-            "publicView": false,
-            "id": "1"
-          }
-        ]);
+        expect(Library.setSubView.args[0]).to.eql([{
+          "subView": "export",
+          "publicView": false,
+          "id": "1"
+        }]);
 
         expect(MasterPageManager.show.callCount).to.eql(1)
         expect(MasterPageManager.show.args[0]).to.eql([
@@ -252,17 +262,19 @@ define([
       })
     });
 
-    it("should handle the three verify routes which are contained in email links, passing verify token to servers ", function(done){
+    it("should handle the three verify routes which are contained in email links, passing verify token to servers ", function (done) {
 
-      var minsub = new MinPubSub({verbose: true});
+      var minsub = new MinPubSub({
+        verbose: true
+      });
       minsub.initialize({
-                      Api: {
-                        request: function() {
-                            return $.Deferred().promise();
-                          }
+        Api: {
+          request: function () {
+            return $.Deferred().promise();
+          }
 
-                      }
-                    });
+        }
+      });
 
       var navigator = new Navigator();
       var fakeSession = new Session();
@@ -273,7 +285,10 @@ define([
       sinon.spy(fakePubSub, 'publish');
 
       var getAccess = null;
-      navigator.getApiAccess = sinon.spy(function(){getAccess = $.Deferred(); return getAccess.promise()});
+      navigator.getApiAccess = sinon.spy(function () {
+        getAccess = $.Deferred();
+        return getAccess.promise()
+      });
       fakePubSub.publish = sinon.spy()
       fakeSession.setChangeToken = sinon.spy();
       beehive.addObject("Session", fakeSession);
@@ -283,13 +298,18 @@ define([
 
       //1. account verification email link
 
-      navigator.set('index-page', sinon.spy(function() {
+      navigator.set('index-page', sinon.spy(function () {
         return $.Deferred().resolve().promise();
       }))
 
-      var p = navigator.get('user-action').execute('user-action', {subView: "register", token: "fakeToken"});
+      var p = navigator.get('user-action').execute('user-action', {
+        subView: "register",
+        token: "fakeToken"
+      });
       expect(fakeApi.request.args[0][0].toJSON().target).to.eql("accounts/verify/fakeToken");
-      fakeApi.request.args[0][0].get("options").done.call(navigator, {email:"foo"});
+      fakeApi.request.args[0][0].get("options").done.call(navigator, {
+        email: "foo"
+      });
       expect(navigator.getApiAccess.callCount).to.eql(1);
       expect(navigator.get('index-page').execute.callCount).to.eql(0);
       expect(p.state()).to.eql('pending');
@@ -303,7 +323,11 @@ define([
 
 
       // pretend verification failed
-      fakeApi.request.args[0][0].get("options").fail.call(navigator, {responseJSON : {error : "fakeError"}});
+      fakeApi.request.args[0][0].get("options").fail.call(navigator, {
+        responseJSON: {
+          error: "fakeError"
+        }
+      });
       expect(navigator.get('index-page').execute.callCount).to.eql(2);
       expect(fakePubSub.publish.args[1][2].toJSON()).to.eql({
         "code": 0,
@@ -317,9 +341,14 @@ define([
 
       //2. change email link
 
-      p = navigator.get('user-action').execute('user-action', {subView: "change-email", token: "fakeToken2"});
+      p = navigator.get('user-action').execute('user-action', {
+        subView: "change-email",
+        token: "fakeToken2"
+      });
       expect(fakeApi.request.args[0][0].toJSON().target).to.eql("accounts/verify/fakeToken2");
-      fakeApi.request.args[0][0].get("options").done.call(navigator, {email:"foo2"});
+      fakeApi.request.args[0][0].get("options").done.call(navigator, {
+        email: "foo2"
+      });
       expect(navigator.getApiAccess.callCount).to.eql(1);
       expect(navigator.get('index-page').execute.callCount).to.eql(0);
       expect(p.state()).to.eql('pending');
@@ -333,7 +362,11 @@ define([
 
 
 
-      fakeApi.request.args[0][0].get("options").fail.call(navigator, {responseJSON : {error : "fakeError2"}});
+      fakeApi.request.args[0][0].get("options").fail.call(navigator, {
+        responseJSON: {
+          error: "fakeError2"
+        }
+      });
       expect(navigator.get('index-page').execute.callCount).to.eql(2);
       expect(fakePubSub.publish.args[1][2].toJSON()).to.eql({
         "code": 0,
@@ -349,7 +382,10 @@ define([
 
 
       //3. reset password is slightly more complicated, should redirect to part 2 of the form in authentication widget
-      p = navigator.get('user-action').execute('user-action', {subView: "reset-password", token: "fakeToken3"});
+      p = navigator.get('user-action').execute('user-action', {
+        subView: "reset-password",
+        token: "fakeToken3"
+      });
       expect(fakeApi.request.args[0][0].toJSON().target).to.eql("accounts/reset-password/fakeToken3");
       fakeApi.request.args[0][0].get("options").done.call(navigator);
 
@@ -363,7 +399,11 @@ define([
         }
       ]);
 
-      fakeApi.request.args[0][0].get("options").fail.call(navigator, {responseJSON : {error : "fakeErrorX"}});
+      fakeApi.request.args[0][0].get("options").fail.call(navigator, {
+        responseJSON: {
+          error: "fakeErrorX"
+        }
+      });
       expect(navigator.get('index-page').execute.callCount).to.eql(1);
       expect(fakePubSub.publish.args[1][2].toJSON()).to.eql({
         "code": 0,
@@ -371,7 +411,7 @@ define([
       })
 
       done();
-      })
+    })
 
 
 

--- a/test/mocha/js/components/library_controller.spec.js
+++ b/test/mocha/js/components/library_controller.spec.js
@@ -3,37 +3,68 @@ define([
   "js/bugutils/minimal_pubsub",
   "js/components/json_response"
 
-], function(
+], function (
   LibraryController,
   MinSub,
   JSONResponse
 
-  ){
+) {
 
 
-  describe("Library Controller", function(){
+  describe("Library Controller", function () {
 
 
-    var stubMetadata  = {
+    var stubMetadata = {
 
-      libraries : [
-        {name: "Aliens Among Us", id: "1", description: "Are you one of them?", permission : "owner", num_documents : 300, date_created: '2015-04-03 04:30:04', date_last_modified: '2015-04-09 06:30:04'},
-        {name: "Everything Sun", id: "2", description: "Where would we be without the sun?", num_documents : 0, permission : "admin", date_created: '2014-01-03 04:30:04', date_last_modified: '2015-01-09 06:30:04'},
-        {name: "Space Travel and You", id: "7", description: "", permission : "write", num_documents : 4000, date_created: '2013-06-03 04:30:04', date_last_modified: '2015-06-09 06:30:04'},
-        {name: "Space Travel and Me", id: "3", description: "interesting", permission : "read", num_documents : 400, date_created: '2012-06-03 05:30:04', date_last_modified: '2015-07-09 06:30:04'}
+      libraries: [{
+          name: "Aliens Among Us",
+          id: "1",
+          description: "Are you one of them?",
+          permission: "owner",
+          num_documents: 300,
+          date_created: '2015-04-03 04:30:04',
+          date_last_modified: '2015-04-09 06:30:04'
+        },
+        {
+          name: "Everything Sun",
+          id: "2",
+          description: "Where would we be without the sun?",
+          num_documents: 0,
+          permission: "admin",
+          date_created: '2014-01-03 04:30:04',
+          date_last_modified: '2015-01-09 06:30:04'
+        },
+        {
+          name: "Space Travel and You",
+          id: "7",
+          description: "",
+          permission: "write",
+          num_documents: 4000,
+          date_created: '2013-06-03 04:30:04',
+          date_last_modified: '2015-06-09 06:30:04'
+        },
+        {
+          name: "Space Travel and Me",
+          id: "3",
+          description: "interesting",
+          permission: "read",
+          num_documents: 400,
+          date_created: '2012-06-03 05:30:04',
+          date_last_modified: '2015-07-09 06:30:04'
+        }
 
       ]
     };
 
 
     // stub of what will be returned from a GET to /libraries/[library ID]
-    var stubLibraryData  = {
-      documents : ["bibcode1", "bibcode2", "bibcode3"]
+    var stubLibraryData = {
+      documents: ["bibcode1", "bibcode2", "bibcode3"]
     }
 
 
 
-    it("should offer a hardened interface to widgets with the relevant library CRUD operations", function(){
+    it("should offer a hardened interface to widgets with the relevant library CRUD operations", function () {
 
       var l = new LibraryController();
 
@@ -55,39 +86,61 @@ define([
 
     });
 
-    it("should automatically keep the libraries metadata collection in sync throughout different CRUD operations", function(){
+    it("should automatically keep the libraries metadata collection in sync throughout different CRUD operations", function () {
 
       var l = new LibraryController();
 
       var fetchLibraryMetadataSpy = sinon.spy(l, "fetchLibraryMetadata");
 
-      var minsub = new (MinSub.extend({
-        request: function() {
-          return {some: 'foo'}
+      var minsub = new(MinSub.extend({
+        request: function () {
+          return {
+            some: 'foo'
+          }
         }
-      }))({verbose: false});
+      }))({
+        verbose: false
+      });
 
 
       l.activate(minsub.beehive);
 
 
       //all calls to compose request will resolve w/done
-      l.composeRequest = sinon.spy(function(target, method){
+      l.composeRequest = sinon.spy(function (target, method) {
         var d = $.Deferred();
         //update metadata
-        if (target ==  "biblib/documents/2" && method == "PUT"){
-          d.resolve({name: "nothing sun", id: "2", description: "Where would we be without the sun?", num_documents : 0, permission : "admin", date_created: '2014-01-03 04:30:04', date_last_modified: '2015-01-09 06:30:04'})
+        if (target == "biblib/documents/2" && method == "PUT") {
+          d.resolve({
+            name: "nothing sun",
+            id: "2",
+            description: "Where would we be without the sun?",
+            num_documents: 0,
+            permission: "admin",
+            date_created: '2014-01-03 04:30:04',
+            date_last_modified: '2015-01-09 06:30:04'
+          })
         }
         //add records
-        else if ( target == "biblib/documents/7" && method == "POST"){
-          d.resolve({ number_added : 4 });
+        else if (target == "biblib/documents/7" && method == "POST") {
+          d.resolve({
+            number_added: 4
+          });
         }
-       //update after a request
-        else if ( target == "biblib/libraries/7"){
-          d.resolve({ metadata : {name: "Space Travel and You", id: "7", description: "", permission : "write", num_documents : 4004, date_created: '2013-06-03 04:30:04', date_last_modified: '2015-06-09 06:30:04'} });
-        }
-
-        else {
+        //update after a request
+        else if (target == "biblib/libraries/7") {
+          d.resolve({
+            metadata: {
+              name: "Space Travel and You",
+              id: "7",
+              description: "",
+              permission: "write",
+              num_documents: 4004,
+              date_created: '2013-06-03 04:30:04',
+              date_last_modified: '2015-06-09 06:30:04'
+            }
+          });
+        } else {
           d.resolve(stubMetadata);
         }
         return d.promise();
@@ -102,7 +155,10 @@ define([
       // add lib, delete lib, update metadata,
       // change permissions (not implemented yet), add/remove items
 
-      l.createLibrary({name: "fake", bibcodes : ["fake"]});
+      l.createLibrary({
+        name: "fake",
+        bibcodes: ["fake"]
+      });
 
       //second request to endpoint is POST to de
       expect(l.composeRequest.args[1]).to.eql(["biblib/libraries", "POST", {
@@ -127,7 +183,9 @@ define([
       //record was removed
       expect(l.collection.get(1)).to.be.undefined;
 
-      l.updateLibraryMetadata(2, {name: "nothing sun"});
+      l.updateLibraryMetadata(2, {
+        name: "nothing sun"
+      });
 
       expect(l.composeRequest.args[4]).to.eql([
         "biblib/documents/2",
@@ -144,7 +202,9 @@ define([
 
       expect(fetchLibraryMetadataSpy.callCount).to.eql(0);
 
-      l.updateLibraryContents(7, {bibcode : [1,2,3,4]});
+      l.updateLibraryContents(7, {
+        bibcode: [1, 2, 3, 4]
+      });
 
       expect(fetchLibraryMetadataSpy.args[0][0]).to.eql(7);
 
@@ -154,15 +214,19 @@ define([
 
     });
 
-    it("should notify widgets of the status of the collection", function() {
+    it("should notify widgets of the status of the collection", function () {
 
       var l = new LibraryController();
 
-      var minsub = new (MinSub.extend({
+      var minsub = new(MinSub.extend({
         request: function () {
-          return {some: 'foo'}
+          return {
+            some: 'foo'
+          }
         }
-      }))({verbose: false});
+      }))({
+        verbose: false
+      });
 
       l.activate(minsub.beehive);
 
@@ -186,9 +250,11 @@ define([
 
     it('should perform library actions properly', function (done) {
       var lc = new LibraryController();
-      var minsub = new (MinSub.extend({
+      var minsub = new(MinSub.extend({
         request: _.constant({})
-      }))({ verbose: false });
+      }))({
+        verbose: false
+      });
       lc.activate(minsub.beehive.getHardenedInstance());
       var ctx = {
         composeRequest: sinon.stub()
@@ -201,7 +267,9 @@ define([
           lc.performLibraryOperation.apply(ctx, args);
         }
       }
-      var ep = function (t) { return 'biblib/libraries/operations/' + t; };
+      var ep = function (t) {
+        return 'biblib/libraries/operations/' + t;
+      };
       var method = 'POST';
 
       expect(test()).to.throw();
@@ -209,14 +277,27 @@ define([
       expect(test(false, {})).to.throw();
       expect(test(3, 2)).to.throw();
       expect(test('test', {})).to.throw();
-      expect(test('test', { action: 'none' })).to.throw();
-      expect(test('test', { action: 'union', libraries: 'foo' })).to.throw();
-      expect(test('test', { action: 'copy', libraries: [] })).to.throw();
-      expect(test('test', { action: 'copy', libraries: ['foo', 'bar'] })).to.throw();
+      expect(test('test', {
+        action: 'none'
+      })).to.throw();
+      expect(test('test', {
+        action: 'union',
+        libraries: 'foo'
+      })).to.throw();
+      expect(test('test', {
+        action: 'copy',
+        libraries: []
+      })).to.throw();
+      expect(test('test', {
+        action: 'copy',
+        libraries: ['foo', 'bar']
+      })).to.throw();
 
       var check = function (data, cb) {
         ctx.composeRequest.reset();
-        var args = [ep('test'), method, { data: data }];
+        var args = [ep('test'), method, {
+          data: data
+        }];
         test('test', data)();
         if (cb) {
           return cb(args);
@@ -224,35 +305,69 @@ define([
         expect(ctx.composeRequest.args[0]).to.eql(args);
       }
 
-      check({ action: 'union', libraries: [], name: undefined });
-      check({ action: 'union', libraries: ['foo'], name: undefined  });
-      check({ action: 'intersection', libraries: ['foo'], name: undefined  });
-      check({ action: 'difference', libraries: ['foo'], name: undefined  });
-      check({ action: 'copy', libraries: ['foo'] });
-      check({ action: 'empty' });
-      check({ action: 'difference', libraries: ['foo', 'foo', 'foo', 'bar'], name: undefined }, function (args) {
-        args[2].data = _.extend(args[2].data, { libraries: ['foo', 'bar'] })
+      check({
+        action: 'union',
+        libraries: [],
+        name: undefined
+      });
+      check({
+        action: 'union',
+        libraries: ['foo'],
+        name: undefined
+      });
+      check({
+        action: 'intersection',
+        libraries: ['foo'],
+        name: undefined
+      });
+      check({
+        action: 'difference',
+        libraries: ['foo'],
+        name: undefined
+      });
+      check({
+        action: 'copy',
+        libraries: ['foo']
+      });
+      check({
+        action: 'empty'
+      });
+      check({
+        action: 'difference',
+        libraries: ['foo', 'foo', 'foo', 'bar'],
+        name: undefined
+      }, function (args) {
+        args[2].data = _.extend(args[2].data, {
+          libraries: ['foo', 'bar']
+        })
         expect(ctx.composeRequest.args[0]).to.eql(args);
       });
 
       done();
     });
 
-    it("should allow widgets to get a list of bibcodes from a library", function(){
+    it("should allow widgets to get a list of bibcodes from a library", function () {
 
       var l = new LibraryController();
 
-      var minsub = new (MinSub.extend({
+      var minsub = new(MinSub.extend({
         request: function () {
-          return {some: 'foo'}
+          return {
+            some: 'foo'
+          }
         }
-      }))({verbose: false});
+      }))({
+        verbose: false
+      });
 
+      const COUNT = 2000;
       var fakeApi = {
-        getHardenedInstance : function(){return this},
-        request : sinon.spy(function(apiRequest) {
+        getHardenedInstance: function () {
+          return this
+        },
+        request: sinon.spy(function (apiRequest) {
 
-          var libJSON = {
+          const libJSON = {
             "solr": {
               "responseHeader": {
                 "status": 0,
@@ -260,7 +375,7 @@ define([
                 "params": {
                   "sort": "date desc",
                   "fq": "{!bitset}",
-                  "rows": "100",
+                  "rows": "1000",
                   "q": "*:*",
                   "start": "0",
                   "wt": "json",
@@ -269,315 +384,15 @@ define([
               },
               "response": {
                 "start": 0,
-                "numFound": 179,
-                "docs": [
-                  {
-                    "bibcode": "2015ASPC..495..401C"
-                  },
-                  {
-                    "bibcode": "2015IAUGA..2257982A"
-                  },
-                  {
-                    "bibcode": "2015IAUGA..2257768A"
-                  },
-                  {
-                    "bibcode": "2015IAUGA..2257639R"
-                  },
-                  {
-                    "bibcode": "2015ASPC..492..204F"
-                  },
-                  {
-                    "bibcode": "2015ASPC..492...85E"
-                  },
-                  {
-                    "bibcode": "2015ASPC..492..150T"
-                  },
-                  {
-                    "bibcode": "2015ASPC..492..189A"
-                  },
-                  {
-                    "bibcode": "2015ASPC..492..208G"
-                  },
-                  {
-                    "bibcode": "2015ASPC..492...80H"
-                  },
-                  {
-                    "bibcode": "2015AAS...22533656H"
-                  },
-                  {
-                    "bibcode": "2015AAS...22533655A"
-                  },
-                  {
-                    "bibcode": "2014ASPC..485..461A"
-                  },
-                  {
-                    "bibcode": "2014AAS...22325503A"
-                  },
-                  {
-                    "bibcode": "2014AAS...22325525A"
-                  },
-                  {
-                    "bibcode": "2013ASPC..475....7M"
-                  },
-                  {
-                    "bibcode": "2013A&C.....1....1A"
-                  },
-                  {
-                    "bibcode": "2013AAS...22124028G"
-                  },
-                  {
-                    "bibcode": "2013AAS...22124030A"
-                  },
-                  {
-                    "bibcode": "2012AGUFMED21A0703H"
-                  },
-                  {
-                    "bibcode": "2012ASPC..461..867A"
-                  },
-                  {
-                    "bibcode": "2012SPIE.8448E..0KA"
-                  },
-                  {
-                    "bibcode": "2012ASPC..461..763H"
-                  },
-                  {
-                    "bibcode": "2012opsa.book..253H"
-                  },
-                  {
-                    "bibcode": "2012LPI....43.1022H"
-                  },
-                  {
-                    "bibcode": "2011ASPC..442.....E"
-                  },
-                  {
-                    "bibcode": "2011AAS...21813102E"
-                  },
-                  {
-                    "bibcode": "2011AAS...21813105A"
-                  },
-                  {
-                    "bibcode": "2011ASSP...24.....A"
-                  },
-                  {
-                    "bibcode": "2011AAS...21711608H"
-                  },
-                  {
-                    "bibcode": "2011AAS...21714501C"
-                  },
-                  {
-                    "bibcode": "2011ASSP...24..125H"
-                  },
-                  {
-                    "bibcode": "2011ASSP...24..135A"
-                  },
-                  {
-                    "bibcode": "2010ASPC..434..155K"
-                  },
-                  {
-                    "bibcode": "2010ASPC..433..273A"
-                  },
-                  {
-                    "bibcode": "2010ASSP...20..141H"
-                  },
-                  {
-                    "bibcode": "2009AGUFM.P43B1437H"
-                  },
-                  {
-                    "bibcode": "2009ASPC..411..384H"
-                  },
-                  {
-                    "bibcode": "2009ASPC..410..160O"
-                  },
-                  {
-                    "bibcode": "2009LPI....40.1873H"
-                  },
-                  {
-                    "bibcode": "2009AAS...21347301A"
-                  },
-                  {
-                    "bibcode": "2009astro2010P..64W"
-                  },
-                  {
-                    "bibcode": "2009astro2010P..44O"
-                  },
-                  {
-                    "bibcode": "2009astro2010P..34L"
-                  },
-                  {
-                    "bibcode": "2009AAS...21347302H"
-                  },
-                  {
-                    "bibcode": "2009arad.workE..32A"
-                  },
-                  {
-                    "bibcode": "2009JInfo...3....1H"
-                  },
-                  {
-                    "bibcode": "2009astro2010P...6B"
-                  },
-                  {
-                    "bibcode": "2009astro2010P..28K"
-                  },
-                  {
-                    "bibcode": "2007BASI...35..717E"
-                  },
-                  {
-                    "bibcode": "2007AAS...211.4731G"
-                  },
-                  {
-                    "bibcode": "2007AAS...211.4732A"
-                  },
-                  {
-                    "bibcode": "2007AAS...211.4730K"
-                  },
-                  {
-                    "bibcode": "2007ASPC..377...97G"
-                  },
-                  {
-                    "bibcode": "2007DPS....39.2708H"
-                  },
-                  {
-                    "bibcode": "2007ASPC..377...23K"
-                  },
-                  {
-                    "bibcode": "2007ASPC..377...93E"
-                  },
-                  {
-                    "bibcode": "2007ASPC..376..467A"
-                  },
-                  {
-                    "bibcode": "2007ASPC..377...69A"
-                  },
-                  {
-                    "bibcode": "2007ASPC..377..102T"
-                  },
-                  {
-                    "bibcode": "2007ASPC..377...36E"
-                  },
-                  {
-                    "bibcode": "2007ASPC..377..106H"
-                  },
-                  {
-                    "bibcode": "2007HiA....14..605E"
-                  },
-                  {
-                    "bibcode": "2007APS..MARU20009K"
-                  },
-                  {
-                    "bibcode": "2007LPI....38.1240E"
-                  },
-                  {
-                    "bibcode": "2007LePub..20...16H"
-                  },
-                  {
-                    "bibcode": "2006AAS...20921809K"
-                  },
-                  {
-                    "bibcode": "2006AAS...20917302H"
-                  },
-                  {
-                    "bibcode": "2006AAS...20921808E"
-                  },
-                  {
-                    "bibcode": "2006DPS....38.4605E"
-                  },
-                  {
-                    "bibcode": "2006JEPub...9....2H"
-                  },
-                  {
-                    "bibcode": "2006ASPC..351..715A"
-                  },
-                  {
-                    "bibcode": "2006ASPC..351..653K"
-                  },
-                  {
-                    "bibcode": "2006LPI....37.1691E"
-                  },
-                  {
-                    "bibcode": "2005AAS...207.3405K"
-                  },
-                  {
-                    "bibcode": "2005AAS...207.3404E"
-                  },
-                  {
-                    "bibcode": "2005AGUFMIN33A1162E"
-                  },
-                  {
-                    "bibcode": "2005DPS....37.1302E"
-                  },
-                  {
-                    "bibcode": "2005LPI....36.1207E"
-                  },
-                  {
-                    "bibcode": "2005Msngr.119...50D"
-                  },
-                  {
-                    "bibcode": "2005coas.conf...80E"
-                  },
-                  {
-                    "bibcode": "2005JASIS..56..111K"
-                  },
-                  {
-                    "bibcode": "2005JASIS..56...36K"
-                  },
-                  {
-                    "bibcode": "2004AGUFMED13D0746E"
-                  },
-                  {
-                    "bibcode": "2004DPS....36.1314E"
-                  },
-                  {
-                    "bibcode": "2004ASPC..314..181A"
-                  },
-                  {
-                    "bibcode": "2004LPI....35.1602T"
-                  },
-                  {
-                    "bibcode": "2004LPI....35.1267E"
-                  },
-                  {
-                    "bibcode": "2004tivo.conf..294M"
-                  },
-                  {
-                    "bibcode": "2004tivo.conf..267E"
-                  },
-                  {
-                    "bibcode": "2004ccdm.conf..521D"
-                  },
-                  {
-                    "bibcode": "2003AGUFMED32C1207E"
-                  },
-                  {
-                    "bibcode": "2003AAS...203.2006H"
-                  },
-                  {
-                    "bibcode": "2003AAS...203.2004E"
-                  },
-                  {
-                    "bibcode": "2003AAS...203.2005K"
-                  },
-                  {
-                    "bibcode": "2003AfrSk...8....7E"
-                  },
-                  {
-                    "bibcode": "2003DPS....35.3302E"
-                  },
-                  {
-                    "bibcode": "2003EAEJA....12295E"
-                  },
-                  {
-                    "bibcode": "2003LPI....34.1949E"
-                  },
-                  {
-                    "bibcode": "2003APS..MARX31001E"
-                  }
-                ]
+                "numFound": COUNT,
+                "docs": _.map(new Array(1000), () => ({
+                  "bibcode": "2003APS..MARX31001E"
+                }))
               }
             }
           };
 
-          arguments[0].toJSON().options.done(libJSON);
-
+          apiRequest.toJSON().options.done(libJSON);
         })
 
       };
@@ -589,22 +404,18 @@ define([
 
       //it should paginate through and collect all bibcodes up to 3000
 
-      var data;
-
-      l.getLibraryBibcodes("2").done(function(d){
-        data= d;
+      let data = [];
+      l.getLibraryBibcodes("2").done(function (d) {
+        data = d;
       });
-
-      expect(data.length).to.eql(200);
-
+      expect(data.length).to.eql(COUNT);
       expect(fakeApi.request.callCount).to.eql(2);
 
-      var req = fakeApi.request.args[0][0];
-
+      const req = fakeApi.request.args[0][0];
       expect(req.get('target')).to.eql("biblib/libraries/2");
       expect(req.get("query").toJSON()).to.eql({
         "rows": [
-          100
+          1000
         ],
         "fl": [
           "bibcode"
@@ -617,44 +428,43 @@ define([
 
       expect(fakeApi.request.args[1][0].get("query").toJSON()).to.eql({
         "rows": [
-          100
+          1000
         ],
         "fl": [
           "bibcode"
         ],
         "start": [
-          100
+          1000
         ]
       });
-
-      //it should cache the bibcodes
-
       expect(l._libraryBibcodeCache["2"]).to.be.instanceof(Array);
-      expect(l._libraryBibcodeCache["2"].length).to.eql(200);
-
-      //it should empty the cache for that bibcode if it changes
-
-      l.collection.trigger("change", new Backbone.Model({id : "2"}));
+      expect(l._libraryBibcodeCache["2"].length).to.eql(COUNT);
+      l.collection.trigger("change", new Backbone.Model({
+        id: "2"
+      }));
       expect(l._libraryBibcodeCache["2"]).to.be.undefined;
-
     });
 
 
-    it("should offer widgets a method to get library metadata", function(done){
+    it("should offer widgets a method to get library metadata", function (done) {
 
       var l = new LibraryController();
 
       var fetchMetadataSpy = sinon.spy(l, "fetchLibraryMetadata");
 
-      l.composeRequest = sinon.spy(function(){
-        if (arguments[0] === "biblib/libraries"){
+      l.composeRequest = sinon.spy(function () {
+        if (arguments[0] === "biblib/libraries") {
           var d = $.Deferred();
           d.resolve(stubMetadata);
           return d.promise();
-        }
-       else if (arguments[0] === "biblib/libraries/17") {
+        } else if (arguments[0] === "biblib/libraries/17") {
           var d = $.Deferred();
-          d.resolve({ metadata : {id : '17', title : "Public Lib 2"} });
+          d.resolve({
+            metadata: {
+              id: '17',
+              title: "Public Lib 2"
+            }
+          });
           return d.promise();
         }
       });
@@ -674,7 +484,7 @@ define([
 
       //should just return collection (or model json if lib id is provided) if _metadataLoaded
 
-      l.getLibraryMetadata("3").done(function(data){
+      l.getLibraryMetadata("3").done(function (data) {
         expect(data.id).to.eql("3");
       });
 
@@ -683,7 +493,7 @@ define([
       //public library or a lbirary that isnt in general collection for some reason
       expect(fetchMetadataSpy.callCount).to.eql(0);
 
-      l.getLibraryMetadata("17").done(function(data){
+      l.getLibraryMetadata("17").done(function (data) {
         expect(data.id).to.eql("17")
         done();
       });
@@ -693,20 +503,28 @@ define([
     });
 
 
-    it("should have an internal method, composeRequest, that actually composes API request and returns and resolves a promise (so public functions can return the promise)", function(){
+    it("should have an internal method, composeRequest, that actually composes API request and returns and resolves a promise (so public functions can return the promise)", function () {
 
       var l = new LibraryController();
 
-      var minsub = new (MinSub.extend({
-        request: function() {
-          return {some: 'foo'}
+      var minsub = new(MinSub.extend({
+        request: function () {
+          return {
+            some: 'foo'
+          }
         }
-      }))({verbose: false});
+      }))({
+        verbose: false
+      });
 
       var fakeApi = {
-        getHardenedInstance : function(){return this}, request : function(){
-        arguments[0].toJSON().options.done();
-      }};
+        getHardenedInstance: function () {
+          return this
+        },
+        request: function () {
+          arguments[0].toJSON().options.done();
+        }
+      };
 
       minsub.beehive.removeService("Api");
       minsub.beehive.addService("Api", fakeApi);
@@ -724,24 +542,34 @@ define([
     });
 
 
-    it("should allow widgets to create + delete libraries", function(){
+    it("should allow widgets to create + delete libraries", function () {
 
       var l = new LibraryController();
 
-      var minsub = new (MinSub.extend({
-        request: function() {
-          return {some: 'foo'}
+      var minsub = new(MinSub.extend({
+        request: function () {
+          return {
+            some: 'foo'
+          }
         }
-      }))({verbose: false});
+      }))({
+        verbose: false
+      });
 
       l.activate(minsub.beehive.getHardenedInstance());
 
-      l.composeRequest = sinon.spy(function(){ var d = $.Deferred();d.resolve(stubMetadata.libraries);return d.promise()});
+      l.composeRequest = sinon.spy(function () {
+        var d = $.Deferred();
+        d.resolve(stubMetadata.libraries);
+        return d.promise()
+      });
       l.fetchAllLibraryData = sinon.spy();
 
       l.getBeeHive().getService("PubSub").publish = sinon.spy();
 
-      l.createLibrary( {name : "fake library name" });
+      l.createLibrary({
+        name: "fake library name"
+      });
 
       expect(l.composeRequest.args[0]).to.eql([
         "biblib/libraries",
@@ -753,13 +581,13 @@ define([
         }
       ]);
 
-      var getBibcodesStub = sinon.stub(l, "_getBibcodes", function(){
+      var getBibcodesStub = sinon.stub(l, "_getBibcodes", function () {
         var d = new $.Deferred();
         d.resolve({
-          bibcodes : [
-              "bib1",
-              "bib2",
-              "bib3"
+          bibcodes: [
+            "bib1",
+            "bib2",
+            "bib3"
           ]
         });
         return d.promise();
@@ -791,24 +619,32 @@ define([
 
     });
 
-    it("should allow widgets to add bibcodes to libraries", function(){
+    it("should allow widgets to add bibcodes to libraries", function () {
 
       var l = new LibraryController();
 
-      var minsub = new (MinSub.extend({
-        request: function() {
-          return {some: 'foo'}
+      var minsub = new(MinSub.extend({
+        request: function () {
+          return {
+            some: 'foo'
+          }
         }
-      }))({verbose: false});
+      }))({
+        verbose: false
+      });
 
       l.activate(minsub.beehive.getHardenedInstance());
 
-      l.composeRequest = sinon.spy(function(){ var d = $.Deferred();d.resolve(stubMetadata.libraries);return d.promise()});
+      l.composeRequest = sinon.spy(function () {
+        var d = $.Deferred();
+        d.resolve(stubMetadata.libraries);
+        return d.promise()
+      });
 
-      var getBibcodesStub = sinon.stub(l, "_getBibcodes", function(){
+      var getBibcodesStub = sinon.stub(l, "_getBibcodes", function () {
         var d = new $.Deferred();
         d.resolve({
-          bibcodes : [
+          bibcodes: [
             "bib1",
             "bib2",
             "bib3"
@@ -821,7 +657,9 @@ define([
 
       l.collection.reset(stubMetadata.libraries);
 
-      l.addBibcodesToLib({ library : "7" });
+      l.addBibcodesToLib({
+        library: "7"
+      });
 
       expect(JSON.stringify(updateLibraryContentsSpy.args[0])).to.eql('["7",{"bibcode":{"bibcodes":["bib1","bib2","bib3"]},"action":"add"}]')
 
@@ -832,54 +670,84 @@ define([
 
 
 
-    it("should offer convenience methods for interfacing with current query/ app storage, getting relevant bibcodes, and adding those bibcodes to libraries", function(){
+    it("should offer convenience methods for interfacing with current query/ app storage, getting relevant bibcodes, and adding those bibcodes to libraries", function () {
 
       var l = new LibraryController();
 
       l._currentQuery = new MinSub.prototype.T.QUERY();
 
-      l._executeApiRequest = sinon.spy(function(){
+      l._executeApiRequest = sinon.spy(function () {
         var d = $.Deferred();
-        d.resolve( new JSONResponse({response : {docs : [{bibcode : "1", bibcode : "2", bibcode : "3"}]}}));
+        d.resolve(new JSONResponse({
+          response: {
+            docs: [{
+              bibcode: "1",
+              bibcode: "2",
+              bibcode: "3"
+            }]
+          }
+        }));
         return d;
       });
 
-      l.getBeeHive = function(){return {getObject : function(){ return {getSelectedPapers : function(){return ["1", "2", "3"]}}}}};
+      l.getBeeHive = function () {
+        return {
+          getObject: function () {
+            return {
+              getSelectedPapers: function () {
+                return ["1", "2", "3"]
+              }
+            }
+          }
+        }
+      };
 
       //get bibcodes from current  query
-      var deferred1 =  l._getBibcodes({bibcodes : "all"});
+      var deferred1 = l._getBibcodes({
+        bibcodes: "all"
+      });
 
       //get bibcodes from app storage
-      var deferred2 = l._getBibcodes({bibcodes : "selected"});
+      var deferred2 = l._getBibcodes({
+        bibcodes: "selected"
+      });
 
       var bibs;
 
-      deferred2.done(function(b){bibs = b});
+      deferred2.done(function (b) {
+        bibs = b
+      });
 
-      expect(bibs).to.eql( ["1", "2", "3"] );
+      expect(bibs).to.eql(["1", "2", "3"]);
 
     });
 
 
-    it("should have an importLibraries function to import from classic or 2.0", function(){
+    it("should have an importLibraries function to import from classic or 2.0", function () {
 
       var l = new LibraryController();
 
-      var minsub = new (MinSub.extend({
-        request: function() {
-          return {some: 'foo'}
+      var minsub = new(MinSub.extend({
+        request: function () {
+          return {
+            some: 'foo'
+          }
         }
-      }))({verbose: false});
+      }))({
+        verbose: false
+      });
 
       var requestSpy = sinon.spy(
-          function(){
-            arguments[0].toJSON().options.done();
-          }
+        function () {
+          arguments[0].toJSON().options.done();
+        }
       )
 
       var fakeApi = {
-        getHardenedInstance : function(){return this},
-        request : requestSpy
+        getHardenedInstance: function () {
+          return this
+        },
+        request: requestSpy
       };
 
       minsub.beehive.removeService("Api");
@@ -891,7 +759,7 @@ define([
 
       var test;
 
-      l.importLibraries("classic").done(function(){
+      l.importLibraries("classic").done(function () {
         test = "foo"
       });
 


### PR DESCRIPTION
Changes library metrics to use `docs(library/<id>)` instead of fetching
bibcodes

Updates metrics error message

Changes library fetch size from 100 to 1000

### DO NOT MERGE
Don't merge until backend is ready