### PR TITLE
Small fixes

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -52,7 +52,7 @@
 
     <div id="app-container">
      <!--this is where bbb discovery gets inserted -->
-      <div id="body-template-container">
+      <div id="body-template-container" role="main">
         <article class="loading-screen" style="display: none">
           <h1 id="loading-screen-title">
             <span class="logo__astrophysics">astrophysics</span>

--- a/src/js/apps/discovery/navigator.js
+++ b/src/js/apps/discovery/navigator.js
@@ -279,8 +279,8 @@ define([
         'UserPreferences',
         settingsPreferencesView(
           'UserPreferences',
-          'librarylink',
-          'Library Link Server'
+          'application',
+          'Application Settings'
         )
       );
 

--- a/src/js/mixins/side_bar_manager.js
+++ b/src/js/mixins/side_bar_manager.js
@@ -82,6 +82,8 @@ define(['backbone', 'js/components/api_feedback'], function(
           return this.onMakeSpace();
         case ApiFeedback.CODES.UNMAKE_SPACE:
           return this.onUnMakeSpace();
+        default:
+          return null;
       }
     },
 
@@ -90,7 +92,9 @@ define(['backbone', 'js/components/api_feedback'], function(
      * set the sidebar state to `false`
      */
     onMakeSpace: function() {
-      state.set('recent', this.getSidebarState());
+      if (!state.has('recent')) {
+        state.set('recent', this.getSidebarState());
+      }
       this.setSidebarState(false);
     },
 

--- a/src/js/page_managers/templates/aria-announcement.html
+++ b/src/js/page_managers/templates/aria-announcement.html
@@ -1,8 +1,8 @@
 {{#compare page "SearchPage" }}
-<a href="#main-content" id="skip-to-main-content" class="sr-only sr-only-focusable">Skip to main content</a>
+<a href="#main-content" id="skip-to-main-content" class="sr-only sr-only-focusable" data-dont-handle="true">Skip to main content</a>
 {{/compare}}
 {{#compare page "DetailsPage" }}
-<a href="#main-content"  id="skip-to-main-content" class="sr-only sr-only-focusable">Skip to main content</a>
+<a href="#main-content"  id="skip-to-main-content" class="sr-only sr-only-focusable" data-dont-handle="true">Skip to main content</a>
 {{/compare}}
 
 <div id="aria-announcement-container">

--- a/src/js/page_managers/templates/results-page-layout.html
+++ b/src/js/page_managers/templates/results-page-layout.html
@@ -1,6 +1,6 @@
 <div id="results-page-layout" class="s-results-page-layout">
   <div class="row s-stable-search-bar-height">
-    <div class="s-search-bar-full-width-container">
+    <div class="s-search-bar-full-width-container" role="search">
       <div class="col-xs-0 col-sm-12 col-md-2 s-back-button-container">
         <a href="/" class="back-button btn btn-sm btn-default">
           <i class="fa fa-arrow-left" aria-hidden="true"></i> Start New

--- a/src/js/widgets/facet/facet-container.jsx.js
+++ b/src/js/widgets/facet/facet-container.jsx.js
@@ -3,69 +3,16 @@ define([
   'react-redux',
   'react-prop-types',
   'es6!./toggle_list.jsx',
+  'es6!./facet-dropdown.jsx',
   './reducers',
 ], function(
   React,
-  { connect, useSelector },
+  { connect },
   PropTypes,
   ToggleList,
+  Dropdown,
   { getActiveFacets }
 ) {
-  const Dropdown = React.memo(({ activeFacets, onSubmitFilter }) => {
-    const { logicOptions, facetTitle } = useSelector((state) => ({
-      logicOptions: state.config.logicOptions,
-      facetTitle: state.config.facetTitle,
-    }));
-
-    // no dropdown if no selected facets!
-    if (activeFacets.length === 0) {
-      return <div />;
-    }
-
-    if (activeFacets.length > 25) {
-      return (
-        <div className="facet__dropdown">
-          select no more than 25 facets at a time
-        </div>
-      );
-    }
-
-    const arr = logicOptions[activeFacets.length === 1 ? 'single' : 'multiple'];
-
-    if (arr[0] === 'invalid choice') {
-      return <div className="facet__dropdown">invalid choice!</div>;
-    }
-    return (
-      <div className="facet__dropdown">
-        <div className="facet__dropdown__title">
-          <b>{activeFacets.length}</b> selected
-        </div>
-        {arr.map(function(val, i) {
-          return (
-            <label key={val} htmlFor={`facet_${facetTitle}_${i}`}>
-              <input
-                id={`facet_${facetTitle}_${i}`}
-                type="radio"
-                onChange={() => onSubmitFilter(val)}
-              />{' '}
-              {val}
-            </label>
-          );
-        }, this)}
-      </div>
-    );
-  });
-
-  Dropdown.defaultProps = {
-    activeFacets: [],
-    onSubmitFilter: () => {},
-  };
-
-  Dropdown.propTypes = {
-    activeFacets: PropTypes.arrayOf(PropTypes.string),
-    onSubmitFilter: PropTypes.func,
-  };
-
   const ContainerComponent = ({
     activeFacets,
     reduxState: state,
@@ -104,8 +51,8 @@ define([
           unselectFacet={unselectFacet}
         >
           {header}
+          <Dropdown activeFacets={activeFacets} onSubmitFilter={submitFilter} />
         </ToggleList>
-        <Dropdown activeFacets={activeFacets} onSubmitFilter={submitFilter} />
       </div>
     );
   };

--- a/src/js/widgets/facet/facet-dropdown.jsx.js
+++ b/src/js/widgets/facet/facet-dropdown.jsx.js
@@ -1,0 +1,79 @@
+define(['react', 'react-prop-types', 'react-redux'], function(
+  React,
+  PropTypes,
+  { useSelector }
+) {
+  const Dropdown = ({ activeFacets, onSubmitFilter }) => {
+    const { logicOptions, facetTitle } = useSelector((state) => ({
+      logicOptions: state.config.logicOptions,
+      facetTitle: state.config.facetTitle,
+    }));
+
+    // no dropdown if no selected facets!
+    if (activeFacets.length === 0) {
+      return <div style={{ display: 'none' }} />;
+    }
+
+    if (activeFacets.length > 25) {
+      return (
+        <div className="facet__dropdown">
+          <div>select no more than 25 facets at a time</div>
+        </div>
+      );
+    }
+
+    const arr = logicOptions[activeFacets.length === 1 ? 'single' : 'multiple'];
+
+    if (arr[0] === 'invalid choice') {
+      return (
+        <div className="facet__dropdown">
+          <div>invalid choice!</div>
+        </div>
+      );
+    }
+    return (
+      <div className="facet__dropdown">
+        <div
+          className="facet__dropdown__title"
+          style={{ display: 'flex', flexDirection: 'column' }}
+        >
+          <div>{facetTitle}</div>
+          <div>
+            <b>{activeFacets.length}</b> selected
+          </div>
+        </div>
+        <div
+          className="btn-group-vertical"
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            flexDirection: 'column',
+          }}
+        >
+          {arr.map((val) => (
+            <button
+              key={val}
+              className="btn btn-default"
+              type="button"
+              onClick={() => onSubmitFilter(val)}
+            >
+              {val}
+            </button>
+          ))}
+        </div>
+      </div>
+    );
+  };
+
+  Dropdown.defaultProps = {
+    activeFacets: [],
+    onSubmitFilter: () => {},
+  };
+
+  Dropdown.propTypes = {
+    activeFacets: PropTypes.arrayOf(PropTypes.string),
+    onSubmitFilter: PropTypes.func,
+  };
+
+  return Dropdown;
+});

--- a/src/js/widgets/facet/toggle_list.jsx.js
+++ b/src/js/widgets/facet/toggle_list.jsx.js
@@ -151,16 +151,16 @@ define(['react', 'd3', 'react-prop-types', 'react-redux'], function(
           selectFacet: selectFacet,
           unselectFacet: unselectFacet,
           label: i,
+          toggleFacet,
         };
         // if it's hierarchical, pass down some more data so that the checkbox can instantiate its own toggleList
         if (checkboxProps.hierarchical) {
           checkboxProps = {
             ...checkboxProps,
-            showMoreFacets,
+            showMoreFacets: showMoreFacets,
             resetVisibleFacets,
-            toggleFacet,
             reduxState: state,
-            currentLevel,
+            currentLevel: currentLevel,
           };
         }
 

--- a/src/js/widgets/facet/toggle_list.jsx.js
+++ b/src/js/widgets/facet/toggle_list.jsx.js
@@ -35,7 +35,7 @@ define(['react', 'd3', 'react-prop-types', 'react-redux'], function(
       if (e.target.checked) {
         // toggle open author hierarchical facets here, so users can see what the hierarchy means
         selectFacet(id);
-        if (config.hierMaxLevels === 2) {
+        if (config.hierMaxLevels === 2 && typeof toggleFacet === 'function') {
           toggleFacet(id, true);
         }
       } else {
@@ -43,7 +43,9 @@ define(['react', 'd3', 'react-prop-types', 'react-redux'], function(
       }
     };
 
-    const label = `facet-label__title_${config.facetField}_${index}`;
+    const label = `facet-label__title_${config.facetField}_${
+      hierarchical ? '' : 'child'
+    }_${index}`;
     var checkbox = (
       <label className="facet-label" htmlFor={`${label}__checkbox`}>
         <input
@@ -151,7 +153,6 @@ define(['react', 'd3', 'react-prop-types', 'react-redux'], function(
           selectFacet: selectFacet,
           unselectFacet: unselectFacet,
           label: i,
-          toggleFacet,
         };
         // if it's hierarchical, pass down some more data so that the checkbox can instantiate its own toggleList
         if (checkboxProps.hierarchical) {
@@ -161,9 +162,9 @@ define(['react', 'd3', 'react-prop-types', 'react-redux'], function(
             resetVisibleFacets,
             reduxState: state,
             currentLevel: currentLevel,
+            toggleFacet: toggleFacet,
           };
         }
-
         return (
           <li key={c.value}>
             {/* eslint-disable-next-line react/jsx-props-no-spreading */}

--- a/src/js/widgets/navbar/template/navbar.html
+++ b/src/js/widgets/navbar/template/navbar.html
@@ -172,7 +172,7 @@
                         <li class="no-hover-style" style="padding:15px 10px;">You are signed in as <br/> <span class="s-text-bold">{{currentUser}}</span></li>
                         <li ><a href="#user/home"> <i class="fa fa-user" aria-hidden="true"></i> My Home Page</a></li>
                         <li><a href="#user/libraries"> <i class="fa fa-book" aria-hidden="true"></i> ADS Libraries</a></li>
-                        <li><a href="#user/settings/librarylink"> <i class="fa fa-cog" aria-hidden="true"></i> Customize Settings</a></li>
+                        <li><a href="#user/settings/application"> <i class="fa fa-cog" aria-hidden="true"></i> Customize Settings</a></li>
                         <li class="divider"></li>
                         <li><a href="javascript:void(0)" class="logout">Log Out</a></li>
                     </ul>

--- a/src/js/widgets/preferences/templates/application.html
+++ b/src/js/widgets/preferences/templates/application.html
@@ -3,20 +3,20 @@
 <div class="panel-body" id="application-settings-container">
   <div class="row">
     <div class="col-md-12">
-      <form id="app-settings-form" role="form" class="form-horizontal">
+      <form id="app-settings-form" class="form-horizontal">
 
         <!-- NUM AUTHORS -->
         <div class="form-group">
           <label for="numAuthors">
             Authors Visible Per Result
-            <a href="#collapseNumAuthorsDesc" data-toggle="collapse" role="button" aria-expanded="false"
+            <button href="#collapseNumAuthorsDesc" data-toggle="collapse" class="btn-link" aria-expanded="false"
               aria-controls="collapseNumAuthorsDesc" aria-label="number of authors per result">
               <i class="fa fa-question-circle" aria-hidden="true"></i>
-            </a>
+            </button>
           </label>
           <p>
             <div class="collapse" id="collapseNumAuthorsDesc">
-              <div class="card card-body text-muted">
+              <div class="card card-body">
                 <p>
                   Specifies the number of authors to show under each result before the list is truncated.
                   <br> (
@@ -37,14 +37,14 @@
         <div class="form-group">
           <label for="externalLinks">
             Default Action For External Links
-            <a href="#collapseExternalLinks" data-toggle="collapse" role="button" aria-expanded="false"
+            <button href="#collapseExternalLinks" data-toggle="collapse" class="btn-link" aria-expanded="false"
               aria-controls="collapseExternalLinks" aria-label="default action for external links">
               <i class="fa fa-question-circle" aria-hidden="true"></i>
-            </a>
+          </button>
           </label>
           <p>
             <div class="collapse" id="collapseExternalLinks">
-              <div class="card card-body text-muted">
+              <div class="card card-body">
                 <p>
                   Select the default action when opening an external link.
                   <br> (
@@ -65,14 +65,14 @@
         <div class="form-group">
           <label for="homePage">
             Default Home Page
-            <a href="#collapseHomePage" data-toggle="collapse" role="button" aria-expanded="false"
+            <button href="#collapseHomePage" data-toggle="collapse" class="btn-link" aria-expanded="false"
               aria-controls="collapseHomePage" aria-label="default home page">
               <i class="fa fa-question-circle" aria-hidden="true"></i>
-            </a>
+            </button>
           </label>
           <p>
             <div class="collapse" id="collapseHomePage">
-              <div class="card card-body text-muted">
+              <div class="card card-body">
                 <p>
                   Select the default landing page shown when loading the application or starting a new search.
                   <br> (
@@ -91,16 +91,16 @@
 
         <!-- Default Collection -->
         <div class="form-group">
-          <label for="database">
+          <label id="defaultDatabaseLabel">
             Default Collection(s)
-            <a href="#collapseDatabase" data-toggle="collapse" role="button" aria-expanded="false"
+            <button href="#collapseDatabase" data-toggle="collapse" class="btn-link" aria-expanded="false"
               aria-controls="collapseDatabase" aria-label="default collection">
               <i class="fa fa-question-circle" aria-hidden="true"></i>
-            </a>
+            </button>
           </label>
           <p>
             <div class="collapse" id="collapseDatabase">
-              <div class="card card-body text-muted">
+              <div class="card card-body">
                 <p>
                   This will apply a default collection facet to each search. You can manually remove or alter it from there.
                   <br> (
@@ -109,7 +109,7 @@
               </div>
             </div>
           </p>
-          <div class="btn-group" data-toggle="buttons">
+          <div class="btn-group" data-toggle="buttons" role="group" aria-labelledby="defaultDatabaseLabel">
             {{#each databaseSelected}}
             <label class="database-select btn btn-default {{#if this.value}} active {{/if}}">
               <input type="checkbox" name="database" checked="{{this.value}}" id="database_{{this.name}}"> {{this.name}}
@@ -121,14 +121,14 @@
         <div class="form-group">
           <label for="exportFormat">
             Default Export Format
-            <a href="#collapseExportFormat" data-toggle="collapse" role="button" aria-expanded="false"
+            <button href="#collapseExportFormat" data-toggle="collapse" class="btn-link" aria-expanded="false"
               aria-controls="collapseExportFormat" aria-label="default export format">
               <i class="fa fa-question-circle" aria-hidden="true"></i>
-            </a>
+            </button>
           </label>
           <p>
             <div class="collapse" id="collapseExportFormat">
-              <div class="card card-body text-muted">
+              <div class="card card-body">
                 <p>
                   Select the default export format you would like to use when opening the Export tool.
                   <br> (
@@ -149,14 +149,14 @@
         <div class="form-group">
           <label for="addCustomFormat">
             Custom Formats
-            <a href="#collapseAddCustomFormat" data-toggle="collapse" role="button" aria-expanded="false"
+            <button href="#collapseAddCustomFormat" data-toggle="collapse" class="btn-link" aria-expanded="false"
               aria-controls="collapseAddCustomFormat" aria-label="custom formats">
               <i class="fa fa-question-circle" aria-hidden="true"></i>
-            </a>
+            </button>
           </label>
           <p>
             <div class="collapse" id="collapseAddCustomFormat">
-              <div class="card card-body text-muted">
+              <div class="card card-body">
                 <p>
                   Edit your saved custom formats
                 </p>
@@ -185,11 +185,11 @@
                   <input type="text" class="form-control custom-format-edit" placeholder="%l (%Y), %j, %V, %p.\n" id="custom-format-code-{{id}}" value="{{code}}" data-id="{{id}}">
                 </div>
                 <span class="col-xs-2 text-right">
-                  <button role="button" data-id="{{id}}" class="btn-link addCustomFormatConfirmEdit"
+                  <button data-id="{{id}}" class="btn-link addCustomFormatConfirmEdit"
                     title="confirm edit">
                     <i class="fa fa-check text-success" aria-hidden="true"></i>
                   </button>
-                  <button role="button" data-id="{{id}}" class="btn-link addCustomFormatCancelEdit"
+                  <button data-id="{{id}}" class="btn-link addCustomFormatCancelEdit"
                     title="cancel edit">
                     <i class="fa fa-times text-danger" aria-hidden="true"></i>
                   </button>
@@ -205,11 +205,11 @@
                   </p>
                 </div>
                 <span class="col-xs-2 text-right">
-                  <button role="button" data-id="{{id}}" class="btn-link addCustomFormatEdit"
+                  <button data-id="{{id}}" class="btn-link addCustomFormatEdit"
                     title="edit custom format">
                     <i class="fa fa-pencil text-primary" aria-hidden="true"></i>
                   </button>
-                  <button role="button" data-id="{{id}}" class="btn-link addCustomFormatEdit"
+                  <button data-id="{{id}}" class="btn-link addCustomFormatEdit"
                     title="delete custom format">
                     <i class="fa fa-times text-danger" aria-hidden="true"></i>
                   </button>
@@ -235,14 +235,14 @@
         <div class="form-group">
           <label for="hideSideBars">
             Results List Side Bars
-            <a href="#collapseHideSideBars" data-toggle="collapse" role="button" aria-expanded="false"
+            <button href="#collapseHideSideBars" data-toggle="collapse" class="btn-link" aria-expanded="false"
               aria-controls="collapseHideSideBars" aria-label="results list side bars">
               <i class="fa fa-question-circle" aria-hidden="true"></i>
-            </a>
+            </button>
           </label>
           <p>
             <div class="collapse" id="collapseHideSideBars">
-              <div class="card card-body text-muted">
+              <div class="card card-body">
                 <p>
                   Select the default state of the results list sidebars (hide/show)
                   <br> (
@@ -263,18 +263,21 @@
         <div class="form-group">
           <label for="bibtexKeyFormat">
             BibTeX Default Export Key Format
-            <a href="#collapsebibtexKeyFormat" data-toggle="collapse" role="button" aria-expanded="false"
+            <button href="#collapsebibtexKeyFormat" data-toggle="collapse" class="btn-link" aria-expanded="false"
               aria-controls="collapsebibtexKeyFormat" aria-label="bibtex default export key format">
               <i class="fa fa-question-circle" aria-hidden="true"></i>
-            </a>
+            </button>
           </label>
           <p>
             <div class="collapse" id="collapsebibtexKeyFormat">
-              <div class="card card-body text-muted">
+              <div class="card card-body">
                 <p>
                   Select the default key format when exporting in BibTeX (<a href="http://adsabs.github.io/help/actions/export" rel="noopener" target="_blank">Learn More <i
                       class="fa fa-external-link" aria-hidden="true"></i></a>)
                   <table class="table">
+                    <caption>
+                      Key format codes and descriptions
+                    </caption>
                     <thead>
                       <tr>
                         <th>Code</th>
@@ -313,14 +316,14 @@
         <div class="form-group">
           <label for="bibtexJournalFormat">
             TeX Journal Name Handling
-            <a href="#collapseBibtexJournalFormat" data-toggle="collapse" role="button" aria-expanded="false"
+            <button href="#collapseBibtexJournalFormat" data-toggle="collapse" class="btn-link" aria-expanded="false"
               aria-controls="collapseBibtexJournalFormat" aria-label="results list side bars">
               <i class="fa fa-question-circle" aria-hidden="true"></i>
-            </a>
+            </button>
           </label>
           <p>
             <div class="collapse" id="collapseBibtexJournalFormat">
-              <div class="card card-body text-muted">
+              <div class="card card-body">
                 <p>
                   This setting is used to define how journal names are rendered in the output of the following TeX-based formats: BibTeX, BibTeX ABS, and AASTeX. If journal macros are used (default), the following file contains the proper journal definitions compatible with most Astronomy Journals: <a href="http://adsabs.harvard.edu/abs_doc/aas_macros.html">http://adsabs.harvard.edu/abs_doc/aas_macros.html</a>
                   <br> (
@@ -343,14 +346,14 @@
             <div class="form-group">
               <label for="bibtexMaxAuthors">
                 BibTeX Default Export Max Authors
-                <a href="#collapsebibtexMaxAuthors" data-toggle="collapse" role="button" aria-expanded="false"
+                <a href="#collapsebibtexMaxAuthors" data-toggle="collapse" class="btn-link" aria-expanded="false"
                   aria-controls="collapsebibtexMaxAuthors" aria-label="bibtex default export max authors">
                   <i class="fa fa-question-circle" aria-hidden="true"></i>
                 </a>
               </label>
               <p>
                 <div class="collapse" id="collapsebibtexMaxAuthors">
-                  <div class="card card-body text-muted">
+                  <div class="card card-body">
                     <p>
                       Select the default max number of authors shown when exporting in BibTeX
                       <br> (
@@ -372,14 +375,14 @@
             <div class="form-group">
               <label for="bibtexAuthorCutoff">
                 BibTeX Default Author Cutoff
-                <a href="#collapsebibtexAuthorCutoff" data-toggle="collapse" role="button" aria-expanded="false"
+                <button href="#collapsebibtexAuthorCutoff" data-toggle="collapse" class="btn-link" aria-expanded="false"
                   aria-controls="collapsebibtexAuthorCutoff" aria-label="bibtex default author cutoff">
                   <i class="fa fa-question-circle" aria-hidden="true"></i>
-                </a>
+                </button>
               </label>
               <p>
                 <div class="collapse" id="collapsebibtexAuthorCutoff">
-                  <div class="card card-body text-muted">
+                  <div class="card card-body">
                     <p>
                         <p>
                           If the number of authors in the list is larger than the cutoff,
@@ -405,18 +408,21 @@
         <div class="form-group">
           <label for="bibtexABSKeyFormat">
             BibTeX ABS Default Export Key Format
-            <a href="#collapsebibtexABSKeyFormat" data-toggle="collapse" role="button" aria-expanded="false"
+            <button href="#collapsebibtexABSKeyFormat" data-toggle="collapse" class="btn-link" aria-expanded="false"
               aria-controls="collapsebibtexABSKeyFormat" aria-label="bibtex abs default export key format">
               <i class="fa fa-question-circle" aria-hidden="true"></i>
-            </a>
+            </button>
           </label>
           <p>
             <div class="collapse" id="collapsebibtexABSKeyFormat">
-              <div class="card card-body text-muted">
+              <div class="card card-body">
                 <p>
                   Select the default key format when exporting in BibTeX ABS (<a href="http://adsabs.github.io/help/actions/export" rel="noopener" target="_blank">Learn More <i
                       class="fa fa-external-link" aria-hidden="true"></i></a>)
                   <table class="table">
+                    <caption>
+                      Key format codes and descriptions
+                    </caption>
                     <thead>
                       <tr>
                         <th>Code</th>
@@ -457,14 +463,14 @@
             <div class="form-group">
               <label for="bibtexABSMaxAuthors">
                 BibTeX ABS Default Export Max Authors
-                <a href="#collapsebibtexABSMaxAuthors" data-toggle="collapse" role="button" aria-expanded="false"
+                <button href="#collapsebibtexABSMaxAuthors" data-toggle="collapse" class="btn-link" aria-expanded="false"
                   aria-controls="collapsebibtexABSMaxAuthors" aria-label="bibtex abs default export max authors">
                   <i class="fa fa-question-circle" aria-hidden="true"></i>
-                </a>
+                </button>
               </label>
                 <p>
                   <div class="collapse" id="collapsebibtexABSMaxAuthors">
-                    <div class="card card-body text-muted">
+                    <div class="card card-body">
                       <p>
                         Select the default max number of authors shown when exporting in BibTeX ABS
                         <br> (
@@ -486,14 +492,14 @@
             <div class="form-group">
               <label for="bibtexABSAuthorCutoff">
                 BibTeX ABS Default Author Cutoff
-                <a href="#collapsebibtexABSAuthorCutoff" data-toggle="collapse" role="button" aria-expanded="false"
+                <button href="#collapsebibtexABSAuthorCutoff" data-toggle="collapse" class="btn-link" aria-expanded="false"
                   aria-controls="collapsebibtexABSAuthorCutoff" aria-label="bibtex abs default author cutoff">
                   <i class="fa fa-question-circle" aria-hidden="true"></i>
-                </a>
+                </button>
               </label>
               <p>
                 <div class="collapse" id="collapsebibtexABSAuthorCutoff">
-                  <div class="card card-body text-muted">
+                  <div class="card card-body">
                     <p>
                         <p>
                           If the number of authors in the list is larger than the cutoff,

--- a/src/js/widgets/search_bar/templates/search_bar_template.html
+++ b/src/js/widgets/search_bar/templates/search_bar_template.html
@@ -113,8 +113,8 @@
           </dd>
           <dt>astronomy</dt>
           <dd>
-            <button class="text-link">database:astronomy</button>
-            <i class="icon-help" aria-hidden="true" data-toggle="tooltip" title="limit to physics papers by searching database:physics"></i>
+            <button class="text-link">collection:astronomy</button>
+            <i class="icon-help" aria-hidden="true" data-toggle="tooltip" title="limit to physics papers by searching collection:physics"></i>
           </dd>
           <dt>OR</dt>
           <dd>

--- a/src/js/wraps/user_settings_page_manager/user_page_manager.js
+++ b/src/js/wraps/user_settings_page_manager/user_page_manager.js
@@ -35,7 +35,7 @@ define([
         category: 'preferences',
       },
       UserPreferences__orcid: {
-        title: 'ORCID Settings',
+        title: 'ORCID',
         path: 'user/settings/orcid',
         category: 'preferences',
       },
@@ -45,7 +45,7 @@ define([
         category: 'preferences',
       },
       UserPreferences__application: {
-        title: 'Application',
+        title: 'Search',
         path: 'user/settings/application',
         category: 'preferences',
       },

--- a/src/styles/sass/ads-sass/facets.scss
+++ b/src/styles/sass/ads-sass/facets.scss
@@ -9,12 +9,12 @@
   color: $text-color;
   letter-spacing: 0.05rem;
   font-size: 18px;
-  position:relative;
+  position: relative;
   top: -2px;
   @extend .secondary-header;
   @media (min-width: $screen-lg-min) {
     font-size: 20px;
-    position:relative;
+    position: relative;
     top: -3px;
   }
 }
@@ -127,7 +127,6 @@
   @extend .s-ads-card;
   box-shadow: 0 0 20px rgba(77, 77, 77, 0.5);
   padding: 10px;
-
 }
 .facet__dropdown__title {
   border-bottom: 2px solid #4073dd;
@@ -135,7 +134,6 @@
   color: #666666;
   padding-bottom: 5px;
   margin-bottom: 5px;
-
 }
 
 .facet__dropdown label {

--- a/test/mocha/js/widgets/facet_widget.spec.js
+++ b/test/mocha/js/widgets/facet_widget.spec.js
@@ -1,730 +1,762 @@
 define([
-    'redux',
-    'js/widgets/facet/actions',
-    'js/widgets/facet/reducers',
-    'js/widgets/facet/create_store',
-    'js/wraps/author_facet',
-    'js/bugutils/minimal_pubsub',
-    'react',
-    'react-dom',
-    ],
-
-  function(
-    Redux,
-    Actions,
-    Reducers,
-    createStore,
-    AuthorFacet,
-    MinSub,
-    React,
-    ReactDOM
-  ) {
-
-    describe('FacetWidget', function() {
-
-      var sampleResponse = {
-        'responseHeader': {
-          'status': 0,
-          'QTime': 18,
-          'params': {
-            'facet.limit': '25',
-            'q': 'author:"accomazzi,a"',
-            'facet.field': 'author_facet_hier',
-            'fl': 'id',
-            'facet.prefix': '0/',
-            'sort': 'date desc',
-            'facet.mincount': '1',
-            'facet': 'true',
-            'wt': 'json',
-            'facet.offset': '0'
-          }
+  'redux',
+  'js/widgets/facet/actions',
+  'js/widgets/facet/reducers',
+  'js/widgets/facet/create_store',
+  'js/wraps/author_facet',
+  'js/bugutils/minimal_pubsub',
+  'react',
+  'react-dom',
+], function(
+  Redux,
+  Actions,
+  Reducers,
+  createStore,
+  AuthorFacet,
+  MinSub,
+  React,
+  ReactDOM
+) {
+  describe('FacetWidget', function() {
+    var sampleResponse = {
+      responseHeader: {
+        status: 0,
+        QTime: 18,
+        params: {
+          'facet.limit': '25',
+          q: 'author:"accomazzi,a"',
+          'facet.field': 'author_facet_hier',
+          fl: 'id',
+          'facet.prefix': '0/',
+          sort: 'date desc',
+          'facet.mincount': '1',
+          facet: 'true',
+          wt: 'json',
+          'facet.offset': '0',
         },
-        'response': {
-          'numFound': 186,
-          'start': 0,
-          'docs': [{
-              'id': '11310415'
-              }, {
-              'id': '11266285'
-              }, {
-              'id': '11121250'
-              }, {
-              'id': '11057812'
-              }
-            ]
-        },
-        'facet_counts': {
-          'facet_queries': {},
-          'facet_fields': {
-            'author_facet_hier': ['0/Accomazzi, A', 186, '0/Kurtz, M', 151, '0/Grant, C', 146, '0/Murray, S', 142]
+      },
+      response: {
+        numFound: 186,
+        start: 0,
+        docs: [
+          {
+            id: '11310415',
           },
-          'facet_dates': {},
-          'facet_ranges': {}
+          {
+            id: '11266285',
+          },
+          {
+            id: '11121250',
+          },
+          {
+            id: '11057812',
+          },
+        ],
+      },
+      facet_counts: {
+        facet_queries: {},
+        facet_fields: {
+          author_facet_hier: [
+            '0/Accomazzi, A',
+            186,
+            '0/Kurtz, M',
+            151,
+            '0/Grant, C',
+            146,
+            '0/Murray, S',
+            142,
+          ],
+        },
+        facet_dates: {},
+        facet_ranges: {},
+      },
+    };
+
+    afterEach(function() {
+      document.querySelector('#test').innerHTML = '';
+    });
+
+    it('should have the appropriate default state given individual widget presets', function() {
+      var store = createStore();
+
+      expect(JSON.stringify(store.getState())).to.eql(
+        JSON.stringify({
+          config: {
+            preprocessors: [],
+            hierMaxLevels: 1,
+            openByDefault: false,
+          },
+          state: {
+            open: false,
+            visible: 5,
+            selected: [],
+          },
+          pagination: {
+            finished: false,
+          },
+          children: [],
+          facets: {},
+        })
+      );
+
+      //now provide it with author config
+      var widget = AuthorFacet();
+
+      //ensure that the config object is located in each widget's store rather than on the widget object itself
+
+      expect(Object.keys(widget.store.getState())).to.eql([
+        'config',
+        'state',
+        'pagination',
+        'children',
+        'facets',
+      ]);
+
+      expect(JSON.stringify(widget.store.getState())).to.eql(
+        JSON.stringify({
+          config: {
+            preprocessors: [],
+            hierMaxLevels: 2,
+            facetField: 'author_facet_hier',
+            openByDefault: true,
+            facetTitle: 'Authors',
+            logicOptions: {
+              single: ['limit to', 'exclude'],
+              multiple: ['and', 'or', 'exclude'],
+            },
+          },
+          state: {
+            open: false,
+            visible: 5,
+            selected: [],
+          },
+          pagination: {
+            finished: false,
+          },
+          children: [],
+          facets: {},
+        })
+      );
+    });
+
+    it('should handle data request and response events properly', function() {
+      var widget = AuthorFacet();
+
+      widget.store.dispatch(Actions().data_requested());
+
+      //only pagination "loading" key is changed
+      expect(
+        JSON.stringify(_.pick(widget.store.getState(), 'state', 'pagination'))
+      ).to.eql(
+        JSON.stringify({
+          state: {
+            open: false,
+            visible: 5,
+            selected: [],
+          },
+          pagination: {
+            state: 'loading',
+            finished: false,
+          },
+        })
+      );
+
+      widget.store.dispatch(Actions().data_received(sampleResponse));
+
+      expect(JSON.stringify(widget.store.getState())).to.eql(
+        JSON.stringify({
+          config: {
+            preprocessors: [],
+            hierMaxLevels: 2,
+            facetField: 'author_facet_hier',
+            openByDefault: true,
+            facetTitle: 'Authors',
+            logicOptions: {
+              single: ['limit to', 'exclude'],
+              multiple: ['and', 'or', 'exclude'],
+            },
+          },
+          state: {
+            open: false,
+            visible: 5,
+            selected: [],
+          },
+          pagination: {
+            state: 'success',
+            finished: true,
+          },
+          children: [
+            '0/Accomazzi, A',
+            '0/Kurtz, M',
+            '0/Grant, C',
+            '0/Murray, S',
+          ],
+          facets: {
+            '0/Accomazzi, A': {
+              name: 'Accomazzi, A',
+              value: '0/Accomazzi, A',
+              count: 186,
+              pagination: {
+                finished: false,
+              },
+              children: [],
+              state: {
+                open: false,
+                visible: 5,
+                selected: [],
+              },
+            },
+            '0/Kurtz, M': {
+              name: 'Kurtz, M',
+              value: '0/Kurtz, M',
+              count: 151,
+              pagination: {
+                finished: false,
+              },
+              children: [],
+              state: {
+                open: false,
+                visible: 5,
+                selected: [],
+              },
+            },
+            '0/Grant, C': {
+              name: 'Grant, C',
+              value: '0/Grant, C',
+              count: 146,
+              pagination: {
+                finished: false,
+              },
+              children: [],
+              state: {
+                open: false,
+                visible: 5,
+                selected: [],
+              },
+            },
+            '0/Murray, S': {
+              name: 'Murray, S',
+              value: '0/Murray, S',
+              count: 142,
+              pagination: {
+                finished: false,
+              },
+              children: [],
+              state: {
+                open: false,
+                visible: 5,
+                selected: [],
+              },
+            },
+          },
+        })
+      );
+
+      //now test fetching data for child facet
+      widget.store.dispatch(Actions().data_requested('0/Accomazzi, A'));
+
+      expect(
+        JSON.stringify(widget.store.getState().facets['0/Accomazzi, A'])
+      ).to.eql(
+        JSON.stringify({
+          name: 'Accomazzi, A',
+          value: '0/Accomazzi, A',
+          count: 186,
+          pagination: {
+            state: 'loading',
+            finished: false,
+          },
+          children: [],
+          state: {
+            open: false,
+            visible: 5,
+            selected: [],
+          },
+        })
+      );
+
+      //test hierarchical facet data received
+      widget.store.dispatch(
+        Actions().data_received(sampleResponse, '0/Accomazzi, A')
+      );
+
+      expect(
+        JSON.stringify(widget.store.getState().facets['0/Accomazzi, A'])
+      ).to.eql(
+        JSON.stringify({
+          name: 'Accomazzi, A',
+          value: '0/Accomazzi, A',
+          count: 186,
+          pagination: {
+            state: 'success',
+            finished: true,
+          },
+          children: [
+            '0/Accomazzi, A',
+            '0/Kurtz, M',
+            '0/Grant, C',
+            '0/Murray, S',
+          ],
+          state: {
+            open: false,
+            visible: 5,
+            selected: [],
+          },
+        })
+      );
+    });
+
+    it('should only set the finished param in the pagination state if fewer facets return than were requested', function() {
+      var widget = AuthorFacet();
+      var shortResponse = _.cloneDeep(sampleResponse);
+
+      //should return only 5 facets instead of the requested 25
+      shortResponse.facet_counts.facet_fields.author_facet_hier = shortResponse.facet_counts.facet_fields.author_facet_hier.slice(
+        0,
+        10
+      );
+      widget.store.dispatch(Actions().data_received(shortResponse));
+
+      expect(JSON.stringify(widget.store.getState().pagination)).to.eql(
+        JSON.stringify({
+          state: 'success',
+          finished: true,
+        })
+      );
+
+      //finished = true got set bc response number was < 25
+      //now mock a longer response
+      var widget = AuthorFacet();
+      var longResponse = _.cloneDeep(sampleResponse);
+      //representing 25 responses
+      longResponse.facet_counts.facet_fields.author_facet_hier = _.range(
+        50
+      ).map(function(n) {
+        if (n % 2 === 0) {
+          return '0/fake name';
+        } else {
+          return 5;
         }
+      });
+
+      widget.store.dispatch(Actions().data_received(longResponse));
+
+      expect(JSON.stringify(widget.store.getState().pagination)).to.eql(
+        JSON.stringify({
+          state: 'success',
+          finished: false,
+        })
+      );
+    });
+
+    it("should mediate requests/responses through the widget's connection with pub sub", function() {
+      var longResponse = _.cloneDeep(sampleResponse);
+      //representing 25 responses
+      longResponse.facet_counts.facet_fields.author_facet_hier = _.range(
+        40
+      ).map(function(n) {
+        if (n % 2 === 0) {
+          return '0/fake name';
+        } else {
+          return 5;
+        }
+      });
+
+      var minsub = new (MinSub.extend({
+        request: sinon.spy(),
+      }))({
+        verbose: false,
+      });
+
+      var widget = AuthorFacet({ debug: true });
+      widget.activate(minsub.beehive.getHardenedInstance());
+
+      //set in some initial data
+      widget.store.dispatch(widget.actions.data_received(longResponse));
+
+      //request
+      minsub.publish(
+        minsub.INVITING_REQUEST,
+        new minsub.T.QUERY({
+          q: 'star',
+        })
+      );
+
+      //initial data should be totally cleared
+      expect(Object.keys(widget.store.getState().facets).length).to.eql(0);
+
+      //request was made
+      expect(
+        JSON.stringify(minsub.request.args[0][0].get('query').toJSON())
+      ).to.eql(
+        JSON.stringify({
+          q: ['star'],
+          facet: ['true'],
+          'facet.mincount': ['1'],
+          'facet.limit': [20],
+          fl: ['id'],
+          'facet.prefix': ['0/'],
+          'facet.field': ['author_facet_hier'],
+          'facet.offset': [0],
+          rows: [1],
+        })
+      );
+
+      //facet state was toggled open, since it's open by default
+      expect(widget.store.getState().state.open).to.be.true;
+
+      //response
+      widget.store.dispatch(widget.actions.data_received(longResponse));
+
+      //now test pagination
+      widget.store.dispatch(widget.actions.fetch_data());
+
+      expect(
+        JSON.stringify(minsub.request.args[1][0].get('query').toJSON())
+      ).to.eql(
+        JSON.stringify({
+          q: ['star'],
+          facet: ['true'],
+          'facet.mincount': ['1'],
+          'facet.limit': [20],
+          fl: ['id'],
+          'facet.prefix': ['0/'],
+          'facet.field': ['author_facet_hier'],
+          'facet.offset': [20],
+          rows: [1],
+        })
+      );
+    });
+
+    it('should fetch the first set of facets automatically when facet or facet child is toggled for the first time', function() {
+      var store = createStore();
+      var actions = Actions();
+      actions.fetch_data = sinon.spy(function() {
+        return {
+          type: 'fake',
+        };
+      });
+
+      expect(actions.fetch_data.callCount).to.eql(0);
+      expect(store.getState().state).to.eql({
+        open: false,
+        visible: 5,
+        selected: [],
+      });
+
+      store.dispatch(actions.toggle_facet());
+      expect(actions.fetch_data.callCount).to.eql(1);
+
+      expect(store.getState().state).to.eql({
+        open: true,
+        visible: 5,
+        selected: [],
+      });
+
+      store.dispatch(actions.toggle_facet(false));
+      expect(store.getState().state).to.eql({
+        open: false,
+        visible: 5,
+        selected: [],
+      });
+
+      //now do the same thing, but this time with pre-loaded facets, nothing should be requested
+
+      store.dispatch(Actions().data_received(sampleResponse));
+
+      store.dispatch(actions.toggle_facet());
+      expect(store.getState().state).to.eql({
+        open: true,
+        visible: 5,
+        selected: [],
+      });
+
+      expect(actions.fetch_data.callCount).to.eql(1);
+    });
+
+    it('should have an action to totally reset the widget state while maintaining the individual widget config', function() {
+      var widget = AuthorFacet();
+
+      widget.store.dispatch(widget.actions.data_received(sampleResponse));
+      widget.store.dispatch(widget.actions.reset_state());
+      expect(JSON.stringify(widget.store.getState())).to.eql(
+        JSON.stringify({
+          config: {
+            preprocessors: [],
+            hierMaxLevels: 2,
+            facetField: 'author_facet_hier',
+            openByDefault: true,
+            facetTitle: 'Authors',
+            logicOptions: {
+              single: ['limit to', 'exclude'],
+              multiple: ['and', 'or', 'exclude'],
+            },
+          },
+          state: {
+            open: false,
+            visible: 5,
+            selected: [],
+          },
+          pagination: {
+            finished: false,
+          },
+          children: [],
+          facets: {},
+        })
+      );
+    });
+
+    it('should automatically open, load and select children of hierarchical facets when they are selected', function() {
+      var widget = AuthorFacet();
+      //happens in the view
+      $('#test').append(widget.render().el);
+
+      widget.store.dispatch(widget.actions.data_received(sampleResponse));
+
+      var hierarchicalResponse = _.cloneDeep(sampleResponse);
+      hierarchicalResponse.facet_counts.facet_fields.author_facet_hier = [
+        '1/Accomazzi, A/Accomazzi, Alberto',
+        5,
+        '1/Accomazzi, A/Accomazzi, A A',
+        10,
+      ];
+      widget.store.dispatch(
+        widget.actions.data_received(hierarchicalResponse, '0/Accomazzi, A')
+      );
+
+      //should be closed by default
+      expect(
+        $('#test')
+          .find('.facet__icon:first')
+          .hasClass('facet__icon--closed')
+      ).to.be.true;
+      expect(
+        $('#test')
+          .find('.facet__icon:first')
+          .hasClass('facet__icon--open')
+      ).to.be.false;
+
+      //open
+      widget.store.dispatch(widget.actions.toggle_facet());
+
+      expect(
+        $('#test')
+          .find('.facet__icon:first')
+          .hasClass('facet__icon--closed')
+      ).to.be.false;
+      expect(
+        $('#test')
+          .find('.facet__icon:first')
+          .hasClass('facet__icon--open')
+      ).to.be.true;
+
+      expect(widget.store.getState().state.selected).to.eql([]);
+      widget.store.dispatch(widget.actions.select_facet('0/Accomazzi, A'));
+
+      expect(widget.store.getState().state.selected).to.eql([
+        '1/Accomazzi, A/Accomazzi, Alberto',
+        '1/Accomazzi, A/Accomazzi, A A',
+        '0/Accomazzi, A',
+      ]);
+
+      //but logic dropdown should show as if only 1 choice were selected
+      expect(
+        $('#test')
+          .find('.facet__dropdown button')
+          .map(function(i, el) {
+            return el.textContent.trim();
+          })
+          .get()
+      ).to.eql(['limit to', 'exclude']);
+
+      $('#test').empty();
+    });
+
+    it('should be able to submit facets', function() {
+      var widget = AuthorFacet();
+      widget.store.dispatch(widget.actions.data_received(sampleResponse));
+      widget.store.dispatch(widget.actions.select_facet('0/Accomazzi, A'));
+      expect(JSON.stringify(widget.store.getState().state)).to.eql(
+        JSON.stringify({
+          open: false,
+          visible: 5,
+          selected: ['0/Accomazzi, A'],
+        })
+      );
+      widget.store.dispatch(widget.actions.select_facet('0/Kurtz, M'));
+      expect(JSON.stringify(widget.store.getState().state)).to.eql(
+        JSON.stringify({
+          open: false,
+          visible: 5,
+          selected: ['0/Accomazzi, A', '0/Kurtz, M'],
+        })
+      );
+
+      widget.setCurrentQuery(
+        new MinSub.prototype.T.QUERY({
+          q: 'star',
+        })
+      );
+      widget.dispatchNewQuery = sinon.spy();
+      widget.store.dispatch(widget.actions.submit_filter('or'));
+      expect(JSON.stringify(widget.dispatchNewQuery.args[0][0])).to.eql(
+        JSON.stringify({
+          q: ['star'],
+          fq_author: [
+            '(author_facet_hier:"0/Accomazzi, A" OR author_facet_hier:"0/Kurtz, M")',
+          ],
+          filter_author_facet_hier_fq_author: [
+            'OR',
+            'author_facet_hier:"0/Accomazzi, A"',
+            'author_facet_hier:"0/Kurtz, M"',
+          ],
+          fq: ['{!type=aqp v=$fq_author}'],
+        })
+      );
+    });
+
+    it('should have a dropdown that shows the user the appropriate logic options', function() {
+      var widget = AuthorFacet();
+
+      var albertoResponse = _.cloneDeep(sampleResponse);
+      albertoResponse.facet_counts.facet_fields.author_facet_hier = albertoResponse.facet_counts.facet_fields.author_facet_hier.slice(
+        0,
+        2
+      );
+
+      widget.store.dispatch(widget.actions.data_received(albertoResponse));
+      //now mock a hierarchical child response
+      var hierarchicalResponse = _.cloneDeep(sampleResponse);
+      // generate a long list of fake sub alberto names
+
+      function randomString(len) {
+        var alphabet = 'abcdefghijklmnopqrstuvwxyz'.split('');
+        var s = '';
+        while (len > 0) {
+          s += alphabet[Math.floor(Math.random() * 26)];
+          len -= 1;
+        }
+        return s;
       }
 
-      afterEach(function(){
-        document.querySelector("#test").innerHTML = '';
-      })
-
-      it('should have the appropriate default state given individual widget presets', function() {
-
-        var store = createStore();
-
-        expect(JSON.stringify(store.getState())).to.eql(JSON.stringify({
-          'config': {
-            'preprocessors': [],
-            'hierMaxLevels': 1,
-            'openByDefault': false
-          },
-          'state': {
-            'open': false,
-            'visible': 5,
-            'selected': []
-          },
-          'pagination': {
-            'finished': false
-          },
-          'children': [],
-          'facets': {}
-        }));
-
-        //now provide it with author config
-        var widget = AuthorFacet();
-
-        //ensure that the config object is located in each widget's store rather than on the widget object itself
-
-        expect(Object.keys(widget.store.getState())).to.eql(['config', 'state', 'pagination', 'children', 'facets']);
-
-        expect(JSON.stringify(widget.store.getState())).to.eql(JSON.stringify({
-          'config': {
-            'preprocessors': [],
-            'hierMaxLevels': 2,
-            'facetField': 'author_facet_hier',
-            'openByDefault': true,
-            'facetTitle': 'Authors',
-            'logicOptions': {
-              'single': [
-                  'limit to',
-                  'exclude'
-                ],
-              'multiple': [
-                  'and',
-                  'or',
-                  'exclude'
-                ]
-            }
-          },
-          'state': {
-            'open': false,
-            'visible': 5,
-            'selected': []
-          },
-          'pagination': {
-            'finished': false
-          },
-          'children': [],
-          'facets': {}
-        }))
-
+      var hierNames = _.range(100).map(function(n, i) {
+        if (i % 2 !== 0) return 5;
+        return '1/Accomazzi, A/' + randomString(12);
       });
 
-      it('should handle data request and response events properly', function() {
+      hierarchicalResponse.facet_counts.facet_fields.author_facet_hier = hierNames;
+      widget.store.dispatch(
+        widget.actions.data_received(hierarchicalResponse, '0/Accomazzi, A')
+      );
 
-        var widget = AuthorFacet();
+      $('#test').append(widget.render().el);
 
-        widget.store.dispatch(Actions().data_requested());
+      widget.store.dispatch(widget.actions.toggle_facet());
+      widget.store.dispatch(widget.actions.toggle_facet('0/Accomazzi, A'));
 
-        //only pagination "loading" key is changed
-        expect(JSON.stringify(_.pick(widget.store.getState(), 'state', 'pagination'))).to.eql(
-          JSON.stringify({
-            'state': {
-              'open': false,
-              'visible': 5,
-              'selected': []
-            },
-            'pagination': {
-              'state': 'loading',
-              'finished': false
-            }
+      //mimicking the user pushing the 'more' button a bunch of times
+      widget.store.dispatch(widget.actions.increase_visible('0/Accomazzi, A'));
+      widget.store.dispatch(widget.actions.increase_visible('0/Accomazzi, A'));
+      widget.store.dispatch(widget.actions.increase_visible('0/Accomazzi, A'));
+      widget.store.dispatch(widget.actions.increase_visible('0/Accomazzi, A'));
+
+      //select 2 facets
+      Object.keys(widget.store.getState().facets)
+        .slice(2, 4)
+        .forEach(function(id) {
+          widget.store.dispatch(widget.actions.select_facet(id));
+        });
+
+      expect(
+        [].slice
+          .apply(document.querySelectorAll('.facet__dropdown button'))
+          .map(function(l) {
+            return l.textContent.trim();
           })
-        );
+      ).to.eql(['and', 'or', 'exclude']);
 
-        widget.store.dispatch(Actions().data_received(sampleResponse));
+      //select the parent (Just 'Alberto, A')
+      widget.store.dispatch(widget.actions.select_facet('0/Accomazzi, A'));
 
-        expect(JSON.stringify(widget.store.getState())).to
-          .eql(JSON.stringify({
-            'config': {
-              'preprocessors': [],
-              'hierMaxLevels': 2,
-              'facetField': 'author_facet_hier',
-              'openByDefault': true,
-              'facetTitle': 'Authors',
-              'logicOptions': {
-                'single': [
-                      'limit to',
-                      'exclude'
-                    ],
-                'multiple': [
-                      'and',
-                      'or',
-                      'exclude'
-                    ]
-              }
-            },
-            'state': {
-              'open': false,
-              'visible': 5,
-              'selected': []
-            },
-            'pagination': {
-              'state': 'success',
-              'finished': true
-            },
-            'children': [
-                  '0/Accomazzi, A',
-                  '0/Kurtz, M',
-                  '0/Grant, C',
-                  '0/Murray, S'
-                ],
-            'facets': {
-              '0/Accomazzi, A': {
-                'name': 'Accomazzi, A',
-                'value': '0/Accomazzi, A',
-                'count': 186,
-                'pagination': {
-                  'finished': false
-                },
-                'children': [],
-                'state': {
-                  'open': false,
-                  'visible': 5,
-                  'selected': []
-                }
-              },
-              '0/Kurtz, M': {
-                'name': 'Kurtz, M',
-                'value': '0/Kurtz, M',
-                'count': 151,
-                'pagination': {
-                  'finished': false
-                },
-                'children': [],
-                'state': {
-                  'open': false,
-                  'visible': 5,
-                  'selected': []
-                }
-              },
-              '0/Grant, C': {
-                'name': 'Grant, C',
-                'value': '0/Grant, C',
-                'count': 146,
-                'pagination': {
-                  'finished': false
-                },
-                'children': [],
-                'state': {
-                  'open': false,
-                  'visible': 5,
-                  'selected': []
-                }
-              },
-              '0/Murray, S': {
-                'name': 'Murray, S',
-                'value': '0/Murray, S',
-                'count': 142,
-                'pagination': {
-                  'finished': false
-                },
-                'children': [],
-                'state': {
-                  'open': false,
-                  'visible': 5,
-                  'selected': []
-                }
-              }
-            }
-          }))
+      //this should select all the ~~VISIBLE~~ children
+      expect(
+        widget.store.getState().facets['0/Accomazzi, A'].state.visible
+      ).to.eql(25);
+      expect(widget.store.getState().state.selected.length).to.eql(26);
 
-        //now test fetching data for child facet
-        widget.store.dispatch(Actions().data_requested('0/Accomazzi, A'));
+      expect(
+        [].slice
+          .apply(document.querySelectorAll('.facet__dropdown button'))
+          .map(function(l) {
+            return l.textContent.trim();
+          })
+      ).to.eql(['limit to', 'exclude']);
 
-        expect(JSON.stringify(widget.store.getState().facets['0/Accomazzi, A'])).to.eql(JSON.stringify({
-          'name': 'Accomazzi, A',
-          'value': '0/Accomazzi, A',
-          'count': 186,
-          'pagination': {
-            'state': 'loading',
-            'finished': false
-          },
-          'children': [],
-          'state': {
-            'open': false,
-            'visible': 5,
-            'selected': []
-          }
-        }));
+      // now showing 30 facets
+      widget.store.dispatch(widget.actions.increase_visible('0/Accomazzi, A'));
 
-        //test hierarchical facet data received
-        widget.store.dispatch(Actions().data_received(sampleResponse, '0/Accomazzi, A'));
-
-        expect(JSON.stringify(widget.store.getState().facets['0/Accomazzi, A'])).to.eql(JSON.stringify({
-            'name': 'Accomazzi, A',
-            'value': '0/Accomazzi, A',
-            'count': 186,
-            'pagination': {
-              'state': 'success',
-              'finished': true
-            },
-            'children': [
-              '0/Accomazzi, A',
-              '0/Kurtz, M',
-              '0/Grant, C',
-              '0/Murray, S'
-            ],
-            'state': {
-              'open': false,
-              'visible': 5,
-              'selected': []
-            }
-          }
-
-        ));
-
-      });
-
-      it('should only set the finished param in the pagination state if fewer facets return than were requested', function() {
-
-        var widget = AuthorFacet();
-        var shortResponse = _.cloneDeep(sampleResponse);
-
-        //should return only 5 facets instead of the requested 25
-        shortResponse.facet_counts.facet_fields.author_facet_hier = shortResponse.facet_counts.facet_fields.author_facet_hier.slice(0, 10);
-        widget.store.dispatch(Actions().data_received(shortResponse));
-
-        expect(JSON.stringify(widget.store.getState().pagination)).to.eql(JSON.stringify({
-          state: 'success',
-          finished: true
-        }));
-
-        //finished = true got set bc response number was < 25
-        //now mock a longer response
-        var widget = AuthorFacet();
-        var longResponse = _.cloneDeep(sampleResponse);
-        //representing 25 responses
-        longResponse.facet_counts.facet_fields.author_facet_hier = _.range(50).map(function(n) {
-          if (n % 2 === 0) {
-            return '0/fake name'
-          } else {
-            return 5
-          }
+      //now deselect one of the facets
+      Object.keys(widget.store.getState().facets)
+        .slice(2, 3)
+        .forEach(function(id) {
+          widget.store.dispatch(widget.actions.unselect_facet(id));
         });
 
-        widget.store.dispatch(Actions().data_received(longResponse));
+      expect(document.querySelector('.facet__dropdown').textContent).to.eql(
+        'select no more than 25 facets at a time'
+      );
+    });
 
-        expect(JSON.stringify(widget.store.getState().pagination)).to.eql(JSON.stringify({
-          'state': 'success',
-          'finished': false
-        }))
+    it('should only submit necessary facets on submit (for hierarchical facets, avoid sending children)', function() {
+      var widget = AuthorFacet();
 
-      });
+      widget.store.dispatch(widget.actions.data_received(sampleResponse));
+      //now mock a hierarchical child response
+      var hierarchicalResponse = _.cloneDeep(sampleResponse);
+      hierarchicalResponse.facet_counts.facet_fields.author_facet_hier = [
+        '1/Accomazzi, A/Accomazzi, Alberto',
+        5,
+        '1/Accomazzi, A/Accomazzi, A A',
+        10,
+      ];
+      widget.store.dispatch(
+        widget.actions.data_received(hierarchicalResponse, '0/Accomazzi, A')
+      );
 
-      it('should mediate requests/responses through the widget\'s connection with pub sub', function() {
+      expect(widget.store.getState().facets['0/Accomazzi, A'].children).to.eql([
+        '1/Accomazzi, A/Accomazzi, Alberto',
+        '1/Accomazzi, A/Accomazzi, A A',
+      ]);
 
-        var longResponse = _.cloneDeep(sampleResponse);
-        //representing 25 responses
-        longResponse.facet_counts.facet_fields.author_facet_hier = _.range(40).map(function(n) {
-          if (n % 2 === 0) {
-            return '0/fake name'
-          } else {
-            return 5
-          }
-        });
+      widget.store.dispatch(widget.actions.select_facet('0/Accomazzi, A'));
 
-        var minsub = new(MinSub.extend({
-          request: sinon.spy()
-        }))({
-          verbose: false
-        });
+      //should contain parent AND children
+      expect(widget.store.getState().state.selected).to.eql([
+        '1/Accomazzi, A/Accomazzi, Alberto',
+        '1/Accomazzi, A/Accomazzi, A A',
+        '0/Accomazzi, A',
+      ]);
 
-        var widget = AuthorFacet({ debug: true });
-        widget.activate(minsub.beehive.getHardenedInstance());
-
-        //set in some initial data
-        widget.store.dispatch(widget.actions.data_received(longResponse));
-
-        //request
-        minsub.publish(minsub.INVITING_REQUEST, new minsub.T.QUERY({
-          q: 'star'
-        }));
-
-        //initial data should be totally cleared
-        expect(Object.keys(widget.store.getState().facets).length).to.eql(0);
-
-        //request was made
-        expect(JSON.stringify(minsub.request.args[0][0].get('query').toJSON())).to.eql(JSON.stringify({
-          'q': [
-              'star'
-            ],
-          'facet': [
-              'true'
-            ],
-          'facet.mincount': [
-              '1'
-            ],
-          'facet.limit': [
-              20
-            ],
-          'fl': [
-              'id'
-            ],
-          'facet.prefix': [
-              '0/'
-            ],
-          'facet.field': [
-              'author_facet_hier'
-            ],
-          'facet.offset': [
-              0
-            ],
-          'rows': [
-              1
-            ]
-        }))
-
-        //facet state was toggled open, since it's open by default
-        expect(widget.store.getState().state.open).to.be.true;
-
-        //response
-        widget.store.dispatch(widget.actions.data_received(longResponse));
-
-        //now test pagination
-        widget.store.dispatch(widget.actions.fetch_data());
-
-        expect(JSON.stringify(minsub.request.args[1][0].get('query').toJSON())).to.eql(JSON.stringify({
-          'q': [
-                'star'
-              ],
-          'facet': [
-                'true'
-              ],
-          'facet.mincount': [
-                '1'
-              ],
-          'facet.limit': [
-                20
-              ],
-          'fl': [
-                'id'
-              ],
-          'facet.prefix': [
-                '0/'
-              ],
-          'facet.field': [
-                'author_facet_hier'
-              ],
-          'facet.offset': [
-                20
-              ],
-          'rows': [
-                1
-              ]
-        }));
-
-      });
-
-      it('should fetch the first set of facets automatically when facet or facet child is toggled for the first time', function() {
-
-        var store = createStore();
-        var actions = Actions();
-        actions.fetch_data = sinon.spy(function() {
-          return {
-            type: 'fake'
-          }
-        });
-
-        expect(actions.fetch_data.callCount).to.eql(0);
-        expect(store.getState().state).to.eql({
-          open: false,
-          visible: 5,
-          selected: []
+      widget.setCurrentQuery(
+        new MinSub.prototype.T.QUERY({
+          q: 'star',
         })
+      );
+      widget.dispatchNewQuery = sinon.spy();
+      widget.submitFilter('and');
 
-        store.dispatch(actions.toggle_facet());
-        expect(actions.fetch_data.callCount).to.eql(1);
-
-        expect(store.getState().state).to.eql({
-          open: true,
-          visible: 5,
-          selected: []
+      //only submitting parent
+      expect(JSON.stringify(widget.dispatchNewQuery.args[0][0])).to.eql(
+        JSON.stringify({
+          q: ['star'],
+          fq_author: ['(author_facet_hier:"0/Accomazzi, A")'],
+          filter_author_facet_hier_fq_author: [
+            'AND',
+            'author_facet_hier:"0/Accomazzi, A"',
+          ],
+          fq: ['{!type=aqp v=$fq_author}'],
         })
-
-        store.dispatch(actions.toggle_facet(false));
-        expect(store.getState().state).to.eql({
-          open: false,
-          visible: 5,
-          selected: []
-        })
-
-        //now do the same thing, but this time with pre-loaded facets, nothing should be requested
-
-        store.dispatch(Actions().data_received(sampleResponse));
-
-        store.dispatch(actions.toggle_facet());
-        expect(store.getState().state).to.eql({
-          open: true,
-          visible: 5,
-          selected: []
-        })
-
-        expect(actions.fetch_data.callCount).to.eql(1);
-
-      });
-
-      it('should have an action to totally reset the widget state while maintaining the individual widget config', function() {
-
-        var widget = AuthorFacet();
-
-        widget.store.dispatch(widget.actions.data_received(sampleResponse));
-        widget.store.dispatch(widget.actions.reset_state());
-        expect(JSON.stringify(widget.store.getState())).to.eql(JSON.stringify({
-          'config': {
-            'preprocessors': [],
-            'hierMaxLevels': 2,
-            'facetField': 'author_facet_hier',
-            'openByDefault': true,
-            'facetTitle': 'Authors',
-            'logicOptions': {
-              'single': [
-                'limit to',
-                'exclude'
-              ],
-              'multiple': [
-                'and',
-                'or',
-                'exclude'
-              ]
-            }
-          },
-          'state': {
-            'open': false,
-            'visible': 5,
-            'selected': []
-          },
-          'pagination': {
-            'finished': false
-          },
-          'children': [],
-          'facets': {}
-        }));
-      });
-
-      it('should automatically open, load and select children of hierarchical facets when they are selected', function() {
-        var widget = AuthorFacet();
-        //happens in the view
-        $('#test').append(widget.render().el);
-
-        widget.store.dispatch(widget.actions.data_received(sampleResponse));
-
-        var hierarchicalResponse = _.cloneDeep(sampleResponse);
-        hierarchicalResponse.facet_counts.facet_fields.author_facet_hier = ['1/Accomazzi, A/Accomazzi, Alberto', 5, '1/Accomazzi, A/Accomazzi, A A', 10]
-        widget.store.dispatch(widget.actions.data_received(hierarchicalResponse, '0/Accomazzi, A'));
-
-        //should be closed by default
-        expect($('#test').find('.facet__icon:first').hasClass('facet__icon--closed')).to.be.true;
-        expect($('#test').find('.facet__icon:first').hasClass('facet__icon--open')).to.be.false;
-
-        //open
-        widget.store.dispatch(widget.actions.toggle_facet());
-
-        expect($('#test').find('.facet__icon:first').hasClass('facet__icon--closed')).to.be.false;
-        expect($('#test').find('.facet__icon:first').hasClass('facet__icon--open')).to.be.true;
-
-        expect(widget.store.getState().state.selected).to
-          .eql([]);
-        widget.store.dispatch(widget.actions.select_facet('0/Accomazzi, A'));
-
-        expect(widget.store.getState().state.selected).to
-          .eql([
-          "1/Accomazzi, A/Accomazzi, Alberto",
-          "1/Accomazzi, A/Accomazzi, A A",
-          "0/Accomazzi, A"
-        ]);
-
-        //but logic dropdown should show as if only 1 choice were selected
-        expect($('#test').find('.facet__dropdown label').map(function(i, el) {
-            return el.textContent
-          }).get()).to
-          .eql([' limit to', ' exclude']);
-
-        $('#test').empty();
-
-      });
-
-      it('should be able to submit facets', function() {
-
-        var widget = AuthorFacet();
-        widget.store.dispatch(widget.actions.data_received(sampleResponse));
-        widget.store.dispatch(widget.actions.select_facet('0/Accomazzi, A'));
-        expect(JSON.stringify(widget.store.getState().state)).to.eql(JSON.stringify({
-          open: false,
-          visible: 5,
-          selected: ['0/Accomazzi, A']
-        }));
-        widget.store.dispatch(widget.actions.select_facet('0/Kurtz, M'));
-        expect(JSON.stringify(widget.store.getState().state)).to.eql(JSON.stringify({
-          open: false,
-          visible: 5,
-          selected: ['0/Accomazzi, A', '0/Kurtz, M']
-        }));
-
-        widget.setCurrentQuery(new MinSub.prototype.T.QUERY({
-          q: 'star'
-        }))
-        widget.dispatchNewQuery = sinon.spy();
-        widget.store.dispatch(widget.actions.submit_filter('or'));
-        expect(JSON.stringify(widget.dispatchNewQuery.args[0][0])).to.eql(JSON.stringify({
-          'q': [
-                  'star'
-                ],
-          'fq_author': [
-                  '(author_facet_hier:"0/Accomazzi, A" OR author_facet_hier:"0/Kurtz, M")'
-                ],
-          'filter_author_facet_hier_fq_author': [
-                  'OR',
-                  'author_facet_hier:"0/Accomazzi, A"',
-                  'author_facet_hier:"0/Kurtz, M"'
-                ],
-          'fq': [
-                  '{!type=aqp v=$fq_author}'
-                ]
-        }))
-
-      });
-
-      it("should have a dropdown that shows the user the appropriate logic options", function(){
-
-        var widget = AuthorFacet();
-
-        var albertoResponse = _.cloneDeep(sampleResponse);
-        albertoResponse.facet_counts.facet_fields.author_facet_hier = albertoResponse.facet_counts.facet_fields.author_facet_hier.slice(0, 2);
-
-        widget.store.dispatch(widget.actions.data_received(albertoResponse));
-        //now mock a hierarchical child response
-        var hierarchicalResponse = _.cloneDeep(sampleResponse);
-        // generate a long list of fake sub alberto names
-
-        function randomString(len) {
-          var alphabet = 'abcdefghijklmnopqrstuvwxyz'.split('');
-          var s = '';
-          while(len > 0) {
-            s+= alphabet[Math.floor(Math.random() * 26)];
-            len-=1;
-          }
-          return s;
-        }
-
-        var hierNames = _.range(100).map(function(n, i){
-          if (i % 2 !== 0) return 5;
-          return '1/Accomazzi, A/' + randomString(12);
-        });
-
-        hierarchicalResponse.facet_counts.facet_fields.author_facet_hier = hierNames;
-        widget.store.dispatch(widget.actions.data_received(hierarchicalResponse, '0/Accomazzi, A'));
-
-        $('#test').append(widget.render().el);
-
-        widget.store.dispatch(widget.actions.toggle_facet());
-        widget.store.dispatch(widget.actions.toggle_facet('0/Accomazzi, A'));
-
-        //mimicking the user pushing the 'more' button a bunch of times
-        widget.store.dispatch(widget.actions.increase_visible('0/Accomazzi, A'));
-        widget.store.dispatch(widget.actions.increase_visible('0/Accomazzi, A'));
-        widget.store.dispatch(widget.actions.increase_visible('0/Accomazzi, A'));
-        widget.store.dispatch(widget.actions.increase_visible('0/Accomazzi, A'));
-
-          //select 2 facets
-          Object.keys(widget.store.getState().facets).slice(2,4).forEach(function(id){
-              widget.store.dispatch(widget.actions.select_facet(id))
-          });
-
-        expect([].slice.apply(document.querySelectorAll('.facet__dropdown label'))
-        .map(function(l){return l.textContent}))
-        .to.eql([" and", " or", " exclude"]);
-
-        //select the parent (Just 'Alberto, A')
-        widget.store.dispatch(widget.actions.select_facet('0/Accomazzi, A'))
-
-          //this should select all the ~~VISIBLE~~ children
-          expect(widget.store.getState().facets['0/Accomazzi, A'].state.visible).to.eql(25);
-          expect(widget.store.getState().state.selected.length).to.eql(26)
-
-          expect([].slice.apply(document.querySelectorAll('.facet__dropdown label'))
-          .map(function(l){return l.textContent})).to.eql([" limit to", " exclude"]);
-
-          // now showing 30 facets
-          widget.store.dispatch(widget.actions.increase_visible('0/Accomazzi, A'));
-
-          //now deselect one of the facets
-          Object.keys(widget.store.getState().facets).slice(2,3).forEach(function(id){
-              widget.store.dispatch(widget.actions.unselect_facet(id))
-          });
-
-          expect(document.querySelector('.facet__dropdown').textContent).to.eql(
-            'select no more than 25 facets at a time'
-          )
-
-
-      });
-
-      it('should only submit necessary facets on submit (for hierarchical facets, avoid sending children)', function() {
-
-        var widget = AuthorFacet();
-
-        widget.store.dispatch(widget.actions.data_received(sampleResponse));
-        //now mock a hierarchical child response
-        var hierarchicalResponse = _.cloneDeep(sampleResponse);
-        hierarchicalResponse.facet_counts.facet_fields.author_facet_hier = ['1/Accomazzi, A/Accomazzi, Alberto', 5, '1/Accomazzi, A/Accomazzi, A A', 10]
-        widget.store.dispatch(widget.actions.data_received(hierarchicalResponse, '0/Accomazzi, A'));
-
-        expect(widget.store.getState().facets['0/Accomazzi, A'].children).to.eql(
-          [
-          '1/Accomazzi, A/Accomazzi, Alberto',
-          '1/Accomazzi, A/Accomazzi, A A'
-        ]);
-
-        widget.store.dispatch(widget.actions.select_facet('0/Accomazzi, A'));
-
-        //should contain parent AND children
-        expect(widget.store.getState().state.selected).to.eql([
-          '1/Accomazzi, A/Accomazzi, Alberto',
-          '1/Accomazzi, A/Accomazzi, A A',
-          '0/Accomazzi, A'
-        ]);
-
-        widget.setCurrentQuery(new MinSub.prototype.T.QUERY({
-          q: 'star'
-        }));
-        widget.dispatchNewQuery = sinon.spy();
-        widget.submitFilter('and');
-
-        //only submitting parent
-        expect(JSON.stringify(widget.dispatchNewQuery.args[0][0])).to.eql(JSON.stringify({
-          'q': [
-              'star'
-            ],
-          'fq_author': [
-              '(author_facet_hier:"0/Accomazzi, A")'
-            ],
-          'filter_author_facet_hier_fq_author': [
-              'AND',
-              'author_facet_hier:"0/Accomazzi, A"'
-            ],
-          'fq': [
-              '{!type=aqp v=$fq_author}'
-            ]
-        }))
-      })
+      );
     });
   });
+});


### PR DESCRIPTION
By default now the settings links point to application settings
Application settings now renamed "Search"
On the landing page examples, "Database" renamed "Collection"
Several accessibility updates
Fixes and improvements for facets
- Remove dependency on cssTransitionGroup
- Change to more semantic buttons for dropdown
- Fix issue with Ids that was causing duplicate selections