### PR TITLE
Fix modal label from showing up below content

### DIFF
--- a/src/js/widgets/alerts/modal_view.js
+++ b/src/js/widgets/alerts/modal_view.js
@@ -26,7 +26,7 @@ define([
         $('body').append(() => {
           let out = '';
           if ($('#alert-modal-label').length === 0) {
-            out += '<div id="alert-modal-label">Alert</div>';
+            out += '<div id="alert-modal-label" class="sr-only">Alert</div>';
           }
 
           out +=


### PR DESCRIPTION
Label was showing up on the bottom of the page causing a double scrollbar to appear

This was causing an extra scrollbar to appear at times