### PR TITLE
ORCID last character may contain X

### DIFF
--- a/src/js/react/MyAdsDashboard/components/CitationsEntry.jsx.js
+++ b/src/js/react/MyAdsDashboard/components/CitationsEntry.jsx.js
@@ -105,7 +105,7 @@ define(['underscore', 'react', 'react-bootstrap', 'react-prop-types'], function(
       let valid = true;
       let error = '';
 
-      if (type === 'ORCiD' && !text.match(/^\d{4}-?\d{4}-?\d{4}-?\d{4}$/)) {
+      if (type === 'ORCiD' && !text.match(/^\d{4}-?\d{4}-?\d{4}-?\d{3}[X\d]$/)) {
         // orcid formatting is off
         valid = false;
         error = 'ORCiD must in the format: 9999-9999-9999-9999';


### PR DESCRIPTION
- The last character in the ORCID iD is a checksum. In accordance with
  ISO/IEC 7064:2003, MOD 11-2, this checksum must be "0" - "9" or "X", a
  capital letter X which represents the value 10

Source: https://support.orcid.org/hc/en-us/articles/360006897674-Structure-of-the-ORCID-Identifier