### PR TITLE
Quick fixes for horizontal scroll bar

### DIFF
--- a/src/js/modules/orcid/widget/templates/container-template.html
+++ b/src/js/modules/orcid/widget/templates/container-template.html
@@ -1,5 +1,5 @@
 
-<div class="row s-results-control-row-container">
+<div class="s-results-control-row-container">
 
 
     <div class="col-sm-10 col-sm-offset-1" style="padding:0 9%" >
@@ -49,7 +49,7 @@
 
     </div>
 </div>
-<div class="row s-darker-background">
+<div class="row s-darker-background" style="margin-right:0;">
     <div class="col-sm-10 s-main-content-container" style="margin-top:20px;padding-top: 20px; float:none">
         <div class="row">
             <ul class="col-sm-12 results-list  s-results-list list-unstyled s-display-block" aria-label="list of results">

--- a/src/js/page_managers/templates/authentication-page-layout.html
+++ b/src/js/page_managers/templates/authentication-page-layout.html
@@ -1,7 +1,7 @@
-<div class="row s-message-control-row" id="message-control-row">
+<div class="s-message-control-row" id="message-control-row">
     <div data-widget="AlertsWidget"/>
 </div>
-<div class="row s-darker-background">
+<div class="row s-darker-background" style="margin-right:0;"">
     <div class="col-sm-12">
         <div data-widget="Authentication"/>
 

--- a/src/js/page_managers/templates/results-page-layout.html
+++ b/src/js/page_managers/templates/results-page-layout.html
@@ -21,7 +21,7 @@
   <div class="row">
     <div class="col-xs-12 s-dynamic-page-body" id="dynamic-page-body">
       <div class="max-width-wrapper">
-        <div class="row">
+        <div>
           <div
             class="hidden-xs col-sm-3 col-md-2 s-left-column s-results-column"
             id="results-left-column"

--- a/src/js/wraps/abstract_page_manager/abstract-page-layout.html
+++ b/src/js/wraps/abstract_page_manager/abstract-page-layout.html
@@ -1,15 +1,15 @@
 <div id="abstract-page-layout" class="s-abstract-page-layout">
 
-    <div class="row s-stable-search-bar-height">
+    <div class="s-stable-search-bar-height">
         <div class="s-search-bar-full-width-container">
             <div class="col-xs-0 col-sm-12 col-md-2 s-back-button-container"></div>
             <div class="col-xs-12 col-sm-9 col-md-7 s-search-bar-row" id="search-bar-row" data-widget="SearchWidget"></div>
         </div>
     </div>
-    <div class="row nav-button-container s-nav-button-container">
+    <div class="nav-button-container s-nav-button-container">
        <button class="btn btn-primary-faded toggle-menu s-toggle-menu "> <i class="fa fa-bars" aria-hidden="true"></i> Show Menu </button>
      </div>
-    <div class="row s-dynamic-page-body" id="dynamic-page-body">
+    <div class="s-dynamic-page-body" id="dynamic-page-body">
         <div class="s-abstract-content">
 
             <div class="col-sm-2 nav-container s-nav-container" id="left-column"> </div>

--- a/src/js/wraps/home_page_manager/home-page-layout.html
+++ b/src/js/wraps/home_page_manager/home-page-layout.html
@@ -1,16 +1,16 @@
-<div class="row">
+<div>
   <div class="col-sm-12">
     <div data-widget="UserNavbarWidget" />
   </div>
 </div>
 
-<div class="nav-button-container s-nav-button-container row">
+<div class="nav-button-container s-nav-button-container">
   <button class="btn btn-primary-faded toggle-menu s-toggle-menu ">
     <i class="fa fa-bars" aria-hidden="true"></i> Show Menu
   </button>
 </div>
 
-<div class="row s-darker-background">
+<div class="row s-darker-background" style="margin-right:0;">
   <div class="col-sm-2 nav-container s-nav-container"></div>
   <div class="col-sm-10 body-min-height"></div>
 </div>

--- a/src/js/wraps/libraries_page_manager/libraries-page-layout.html
+++ b/src/js/wraps/libraries_page_manager/libraries-page-layout.html
@@ -1,16 +1,16 @@
-<div class="row">
+<div>
   <div class="col-sm-12">
     <div data-widget="UserNavbarWidget" />
   </div>
 </div>
 
-<div class="row nav-button-container s-nav-button-container">
+<div class="nav-button-container s-nav-button-container">
   <button class="btn btn-primary-faded toggle-menu s-toggle-menu ">
     <i class="fa fa-bars" aria-hidden="true"></i> Show Menu
   </button>
 </div>
 
-<div class="row s-darker-background">
+<div class="row s-darker-background" style="margin-right:0;"">
   <div class="col-sm-2 nav-container s-nav-container"></div>
   <div class="col-sm-10 body-min-height">
     <div data-widget="IndividualLibraryWidget" />

--- a/src/js/wraps/public_libraries_page_manager/public-libraries-page-layout.html
+++ b/src/js/wraps/public_libraries_page_manager/public-libraries-page-layout.html
@@ -1,4 +1,4 @@
-<div class="row s-darker-background">
+<div class="row s-darker-background" style="margin-right:0;"">
   <div class="col-sm-12">
     <div class="s-public-lib-descriptor">
       <h3>

--- a/src/js/wraps/user_settings_page_manager/user-settings-layout.html
+++ b/src/js/wraps/user_settings_page_manager/user-settings-layout.html
@@ -1,15 +1,15 @@
-<div class="row">
+<div>
   <div class="col-sm-12">
     <div data-widget="UserNavbarWidget" />
   </div>
 </div>
-<div class="nav-button-container s-nav-button-container row">
+<div class="nav-button-container s-nav-button-container">
   <button class="btn btn-primary-faded toggle-menu s-toggle-menu ">
     <i class="fa fa-bars" aria-hidden="true"></i> Show Menu
   </button>
 </div>
 
-<div class="row s-darker-background">
+<div class="row s-darker-background" style="margin-right:0;"">
   <div class="col-sm-2 nav-container s-nav-container"></div>
 
     <div class="col-sm-10">


### PR DESCRIPTION
Scroll bar has been showing up on some pages.  Seems like the culprit is
the extra margin introduced by `.row` classes on bootstrap.  More likely
there are overlapping grid elements causing the issues, but that is a
much larger fix