### PR TITLE
Fix auto-sorting selection based on fields

### DIFF
--- a/src/js/widgets/search_bar/search_bar_widget.js
+++ b/src/js/widgets/search_bar/search_bar_widget.js
@@ -935,32 +935,29 @@ define([
 
       // make sure not to override an explicit sort if there is one
       if (!query.has('sort')) {
-        var queryVal = query.get('q')[0];
+        const queryVal = query.get('q')[0];
 
         // citations operator should be sorted by pubdate, so it isn't added here
-        var toMatch = [
-          'trending(',
-          'instructive(',
-          'useful(',
-          'references(',
-          'reviews(',
-          'similar(',
+        const fields = [
+          'trending',
+          'instructive',
+          'useful',
+          'references',
+          'reviews',
+          'similar',
         ];
+        const fieldReg = new RegExp(`(${fields.join('|')})(?=\\()`, 'gi');
+        const matches = queryVal.match(fieldReg);
 
-        // if there are multiple, this will just match the first operator
-        var operator = _.find(toMatch, function(e) {
-          if (queryVal.indexOf(e) !== -1) {
-            return e;
+        // we're only concerned with the first match (outermost)
+        let sort = 'date desc';
+        if (matches) {
+          sort = 'score desc';
+          if (matches[0] === 'references') {
+            sort = 'first_author asc';
           }
-        });
-
-        if (operator == 'references(') {
-          query.set('sort', 'first_author asc');
-        } else if (operator) {
-          query.set('sort', 'score desc');
-        } else if (!operator) {
-          query.set('sort', 'date desc');
         }
+        query.set('sort', sort);
       } else if (currentQuery && currentQuery.has('sort')) {
         query.set('sort', currentQuery.get('sort'));
       }

--- a/test/mocha/js/widgets/search_bar_widget.spec.js
+++ b/test/mocha/js/widgets/search_bar_widget.spec.js
@@ -223,6 +223,10 @@ define([
       widget.changeDefaultSort(q8);
       expect(q8.get('sort')[0]).to.eql('score desc');
 
+      var q9 = new ApiQuery({ q: 'reviews(references(star))' });
+      widget.changeDefaultSort(q9);
+      expect(q9.get('sort')[0]).to.eql('score desc');
+
       done();
     });
 


### PR DESCRIPTION
Now the search bar will pick the outermost field that it finds for selecting the sort value.