### PR TITLE
Fix break when parsing url strings with '%'

### DIFF
--- a/src/js/components/multi_params.js
+++ b/src/js/components/multi_params.js
@@ -228,7 +228,13 @@ define(['backbone', 'underscore', 'jquery'], function(Backbone, _, $) {
           vall = hash.join('=');
         }
 
-        value = decodeURIComponent(vall.split('+').join(' '));
+        // replace literal '%' with code and '+' become literal spaces
+        value = decodeURIComponent(
+          vall
+            .replace(/%(?!\d|[ABCDEF]+)/gi, '%25')
+            .split('+')
+            .join(' ')
+        );
         if (attrs[key] !== undefined) {
           attrs[key].push(value);
         } else {


### PR DESCRIPTION
URLs containing percent signs as part of the original non-encoded string
do not get encoded properly when passed to the parser.  This results in
a `Malformed URI` when trying to decode the string.

Solution is to replace percent sign literals with their encoded version.

fixes #2054