### PR TITLE
Make landing page links append rather than replace

### DIFF
--- a/src/js/widgets/search_bar/search_bar_widget.js
+++ b/src/js/widgets/search_bar/search_bar_widget.js
@@ -350,7 +350,8 @@ define([
         const value = e.currentTarget.innerText.trim();
 
         if (value) {
-          this.setFormVal(value);
+          this.setFormVal(`${this.getFormVal()} ${value}`);
+          this.$input.focus();
         }
       });
     },


### PR DESCRIPTION
For the examples below the search bar on the landing page, those links
should append the value onto the search and not replace.