### PR TITLE
Fix logout issue

### DIFF
--- a/src/js/components/session.js
+++ b/src/js/components/session.js
@@ -114,6 +114,7 @@ define([
             type: 'POST',
             headers: { 'X-CSRFToken': csrfToken },
             contentType: 'application/json',
+            fail: this.logoutSuccess,
             done: this.logoutSuccess,
           },
         });


### PR DESCRIPTION
This is probably mainly a problem during development, but switching
between environments can cause session tokens to be reused causing the
server to respond with an error when trying logout.  The user is then
unable to logout, and no message appears.

I don't see any downside of just making the interface reflect the user's
intent even if the logout doesn't succeed on the server, so rather than
an error, just make it appear to succeed and allow subsequent login(s)
to refresh the token.