### PR TITLE
Fix arxiv id not showing on abstract page

### DIFF
--- a/src/js/widgets/abstract/widget.js
+++ b/src/js/widgets/abstract/widget.js
@@ -135,20 +135,19 @@ define([
         doc.pubnote = _.unescape(doc.pubnote);
       }
 
-      if (doc.identifier) {
-        var id = _.find(doc.identifier, function(d) {
-          return d.toLowerCase().startsWith('arxiv');
-        });
-        if (id) {
-          doc.arxiv = {
-            id: id,
-            href: LinkGeneratorMixin.createUrlByType(
-              doc.bibcode,
-              'arxiv',
-              id.split(':')[1]
-            ),
-          };
-        }
+      const ids = Array.isArray(doc.identifier)
+        ? doc.identifier
+        : doc.original_identifier;
+      const id = (ids || []).find((v) => v.match(/^arxiv/i));
+      if (id) {
+        doc.arxiv = {
+          id: id,
+          href: LinkGeneratorMixin.createUrlByType(
+            doc.bibcode,
+            'arxiv',
+            id.split(':')[1]
+          ),
+        };
       }
 
       return doc;

--- a/src/js/widgets/list_of_things/widget.js
+++ b/src/js/widgets/list_of_things/widget.js
@@ -336,6 +336,7 @@ define([
       docs = _.map(docs, function(d) {
         d.all_ids = d.identifier;
         if (d.bibcode) {
+          d.original_identifier = d.identifier;
           d.identifier = d.bibcode ? d.bibcode : d.identifier;
         }
         return d;


### PR DESCRIPTION
Identifier field was being mutated upstream when doing a search, added a
new `original_identifier` field to doc to allow for access to these
values from abstract page