### PR TITLE
Add fix for classic form collections checkboxes

### DIFF
--- a/src/js/widgets/classic_form/widget.js
+++ b/src/js/widgets/classic_form/widget.js
@@ -70,9 +70,9 @@ define([
         .value();
       if (trues.length > 1) {
         if (fullSet && keys.length === trues.length) {
-          return '(' + keys.join(' AND ') + ')';
+          return '(' + trues.join(' AND ') + ')';
         }
-        return '(' + keys.join(' OR ') + ')';
+        return '(' + trues.join(' OR ') + ')';
       }
       return trues[0];
     },

--- a/test/mocha/js/widgets/classic_search_widget.spec.js
+++ b/test/mocha/js/widgets/classic_search_widget.spec.js
@@ -107,8 +107,8 @@ define([
       $Q.abs().val('a b c d +e -f =g +"h" -"i"');
       $Q.bibstem().val('a b c d +e -f =g +"h" -"i"');
       triggerChanges();
-
       setTimeout(function() {
+        
         expect(w.model.get('query')).to.eql({
           "q": [
             "pubdate:[2010-10 TO 9999-12]",
@@ -169,10 +169,10 @@ define([
             ],
             "__fq_database": [
               "AND",
-              "(astronomy OR physics OR general)"
+              "(astronomy OR physics)"
             ],
             "fq_database": [
-              "database: (astronomy OR physics OR general)"
+              "database: (astronomy OR physics)"
             ],
             "__fq_property": [
               "AND",


### PR DESCRIPTION
Stop the form from adding all the entries anyway even if the user
selects only 1 or 2 collections