### PR TITLE
Fix string-replace so it properly replaces version

### DIFF
--- a/grunt/string-replace.js
+++ b/grunt/string-replace.js
@@ -47,7 +47,7 @@ module.exports = {
     },
     options: {
       replacements: [{
-        pattern: /APP_VERSION=['"]['"];/ig,
+        pattern: 'APP_VERSION=""',
         replacement: 'APP_VERSION="<%= appVersion %>";'
       }]
     }

--- a/src/config/shim.js
+++ b/src/config/shim.js
@@ -1,6 +1,7 @@
 (function() {
   // ############ DON'T EDIT THIS LINE
-  var APP_VERSION = '';
+  // prettier-ignore
+  var APP_VERSION="";
   // #################################
 
   /*


### PR DESCRIPTION
Probably the culprit was editor auto-formatting... Added prettier ignore
line to hopefully keep that from happening.