### PR TITLE
Fixes for search examples

### DIFF
--- a/src/js/react/Recommender/components/SearchExamples.jsx.js
+++ b/src/js/react/Recommender/components/SearchExamples.jsx.js
@@ -25,7 +25,12 @@ define([
       <React.Fragment>
         <dt>{label}</dt>
         <dd>
-          <button type="button" onClick={onClick} className="text-link">
+          <button
+            type="button"
+            onClick={onClick}
+            className="text-link"
+            style={{ border: 'dotted 1px rgba(0,0,0,0.3)', marginRight: '4px' }}
+          >
             {text}
           </button>
           {tooltip && (
@@ -62,8 +67,15 @@ define([
     };
 
     return (
-      <div style={{ paddingTop: '1rem' }}>
-        <div className="col-sm-5 quick-reference">
+      <div
+        style={{
+          paddingTop: '1rem',
+          display: 'flex',
+          justifyContent: 'space-between',
+          flexWrap: 'wrap',
+        }}
+      >
+        <div className="quick-reference">
           <Dl>
             {searchExamples.slice(0, 7).map((entry) => (
               <Entry
@@ -71,11 +83,12 @@ define([
                 text={entry.example}
                 tooltip={entry.tooltip}
                 onClick={() => onClick(entry.example)}
+                key={entry.label}
               />
             ))}
           </Dl>
         </div>
-        <div className="col-sm-7 quick-reference">
+        <div className="quick-reference">
           <Dl>
             {searchExamples.slice(7).map((entry) => (
               <Entry
@@ -83,6 +96,7 @@ define([
                 text={entry.example}
                 tooltip={entry.tooltip}
                 onClick={() => onClick(entry.example)}
+                key={entry.label}
               />
             ))}
           </Dl>

--- a/src/js/widgets/search_bar/search_bar_widget.js
+++ b/src/js/widgets/search_bar/search_bar_widget.js
@@ -344,16 +344,6 @@ define([
       });
 
       this.$('[data-toggle="tooltip"]').tooltip();
-
-      // this is for search examples, sets form value on click
-      this.$('.search-quick-links button').on('click', (e) => {
-        const value = e.currentTarget.innerText.trim();
-
-        if (value) {
-          this.setFormVal(`${this.getFormVal()} ${value}`);
-          this.$input.focus();
-        }
-      });
     },
 
     events: {
@@ -771,6 +761,12 @@ define([
           arg.preventDefault();
           $input.select();
           $(document.documentElement).scrollTop(0);
+        }
+      } else if (event === 'recommender/update-search-text') {
+        const value = arg.text;
+        if (value) {
+          this.view.setFormVal(`${this.view.getFormVal()} ${value}`);
+          this.view.$input.focus();
         }
       }
     },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6970899/99301763-701bd680-281c-11eb-9114-a95c24e94145.png)
Makes search example buttons match old styling (prior to recommender) 
Buttons now work again.
Fix React error about missing keys