### PR TITLE
Fix discovery.vars issue

### DIFF
--- a/grunt/copy.js
+++ b/grunt/copy.js
@@ -272,8 +272,8 @@ module.exports = function(grunt) {
     },
 
     discovery_vars: {
-      src: 'src/discovery.vars.js.default',
-      dest: 'src/discovery.vars.js',
+      src: 'src/config/discovery.vars.js.default',
+      dest: 'src/config/discovery.vars.js',
       filter: function() {
         // Only copy if over if it does not exist
         var dest = grunt.task.current.data.dest;

--- a/grunt/optimize-build.js
+++ b/grunt/optimize-build.js
@@ -223,6 +223,7 @@ module.exports = function(grunt) {
           include: [
             ...globFiles([
               'config/**/*.js',
+              '!config/discovery.vars.js',
               '!config/shim.js',
               'js/apps/discovery/**/*.js',
               '!js/apps/discovery/router.js',

--- a/grunt/requirejs.js
+++ b/grunt/requirejs.js
@@ -413,7 +413,6 @@
       "include": [
         "config/common.config",
         "config/discovery.config",
-        "config/discovery.vars",
         "js/apps/discovery/main",
         "js/apps/discovery/navigator",
         "js/components/alerts",

--- a/grunt/string-replace.js
+++ b/grunt/string-replace.js
@@ -74,7 +74,7 @@ module.exports = {
           replacement: 'APP_VERSION="<%= appVersion %>";',
         },
         {
-          pattern: '<APP_VERSION>',
+          pattern: /<APP_VERSION>/g,
           replacement: '<%= appVersion %>',
         },
       ],

--- a/src/index.html
+++ b/src/index.html
@@ -14,10 +14,14 @@
       name="description"
       content="A powerful, streamlined new Astrophysics Data System"
     />
-    <link rel="preload" href="./styles/css/styles.css" as="style" />
+    <link
+      rel="preload"
+      href="./styles/css/styles.css?v=<APP_VERSION>"
+      as="style"
+    />
     <link rel="preload" href="./libs/requirejs/require.js" as="script" />
-    <link rel="preload" href="./config/shim.js" as="script" />
-    <link rel="stylesheet" href="./styles/css/styles.css" />
+    <link rel="preload" href="./config/shim.js?v=<APP_VERSION>" as="script" />
+    <link rel="stylesheet" href="./styles/css/styles.css?v=<APP_VERSION>" />
     <link
       rel="icon"
       type="image/png"


### PR DESCRIPTION
Removes discovery.vars from main bundle

Adds version to more requests made directly in index.html (for cache busting)

Small fix to path for `grunt setup`