### PR TITLE
Fix submenu overlap

### DIFF
--- a/src/styles/sass/ads-sass/navbar.scss
+++ b/src/styles/sass/ads-sass/navbar.scss
@@ -280,3 +280,9 @@ input.cmn-toggle-round:checked + label:after {
 .about-page-icon {
   font-size: 22px;
 }
+
+@media screen and (max-width: $screen-sm) {
+  .nav > li.dropdown {
+    display: flex;
+  }
+}


### PR DESCRIPTION
Adjusted navigation submenu so that they don't overlap of top-level menu in mobile screen.