### PR TITLE
Fixed library issues

### DIFF
--- a/src/js/widgets/library_individual/templates/library-header.html
+++ b/src/js/widgets/library_individual/templates/library-header.html
@@ -265,6 +265,9 @@
     {{owner}}
   </div>
   <br />
+{{#compare permission "none"}}
+<br/>
+{{else}}
   {{#compare permission "read"}}
   <br />
   <p>
@@ -320,6 +323,7 @@
   </div>
 
   {{/compare}}
+{{/compare}}
 </div>
 
 <!-- tabs -->

--- a/src/js/widgets/library_individual/templates/library-header.html
+++ b/src/js/widgets/library_individual/templates/library-header.html
@@ -155,7 +155,7 @@
 {{/if}} {{else}}
 <!-- not public -->
 
-{{#if edit}}
+
 <div class="pull-right" style="position:relative;z-index:1">
   {{#if largeLibrary}}
   <button
@@ -184,6 +184,7 @@
   </button>
   {{/if}}
 </div>
+{{#if edit}}
 <div class="editable-item">
   <h2>
     {{name}}

--- a/src/js/widgets/library_list/templates/library-container.html
+++ b/src/js/widgets/library_list/templates/library-container.html
@@ -12,7 +12,9 @@
         </div>
         <div class="col-sm-6">
           <div class="button-toolbar">
+            {{#if editRecords}}
             <button class="btn btn-danger btn-sm hidden" id="bulk-delete">Delete Selected</button>
+            {{/if}}
             <button class="btn btn-default btn-sm hidden" id="bulk-limit">
               <i class="fa fa-archive" aria-hidden="true"></i> Show Selection in Results Page
             </button>


### PR DESCRIPTION
This PR addresses the following three issues of library view:
* When user viewing a public library who is not a collaborator, the edit buttons says “You have none privileges", but allows user to click on “View editing options” and add/remove papers. 
  * In this case, when user has no permission, this edit button is removed.
* When selecting records, the “delete” option appears but the user cannot actually delete any record.
  * Delete button is not shown if user has no edit permission
* "View library in results page" button is not shown unless user has edit permission
  * Show "View library in results page" button regardless of permission
