### PR TITLE
Nav submenu position in mobile

### DIFF
--- a/src/styles/sass/ads-sass/navbar.scss
+++ b/src/styles/sass/ads-sass/navbar.scss
@@ -27,6 +27,22 @@
   }
 }
 
+  @media screen and (max-width: $screen-sm) {
+    .navbar-nav {
+      position: relative;
+
+      .dropdown {
+        position:unset;
+      }
+
+      .open .dropdown-menu {
+        position: absolute;
+        top: 0;
+        left: 150px;
+      }
+    }
+  } 
+
 //to vertically align
 .navbar-nav .dropdown-toggle,
 .navbar-nav .dropdown {


### PR DESCRIPTION
In mobile view where nav menu is vertical, aligned sub-menu to the top to reduce vertical scrolling
![Screen Shot 2021-04-14 at 9 04 52 AM](https://user-images.githubusercontent.com/636361/114742333-7b5a2c00-9d00-11eb-94c4-d794e6cf7241.png)
