### PR TITLE
Hover over dropdown menu

### DIFF
--- a/src/js/widgets/list_of_things/item_view.js
+++ b/src/js/widgets/list_of_things/item_view.js
@@ -65,7 +65,7 @@ define([
       'mouseenter .letter-icon': 'showLinks',
       'mouseleave .letter-icon': 'hideLinks',
       'focusout .letter-icon': 'hideLinks',
-      'click .letter-icon a': 'emitAnalyticsEvent',
+      'click .letter-icon': 'toggleShowLinksWithClick',
       'click .show-all-authors': 'showAllAuthors',
       'click .show-less-authors': 'showLessAuthors',
       // only relevant to results view for the moment
@@ -204,12 +204,25 @@ define([
       }
     },
 
+    toggleShowLinksWithClick: function(e) {
+      // only allows open drop down with click using mobile
+      // in desktop, mouse over will show dropdown
+      if (this.model.get('isMobileOrTablet')) {
+        if (
+          $(e.currentTarget)
+            .find('ul')
+            .hasClass('hidden')
+        ) {
+          this.showLinks(e);
+        } else {
+          this.hideLinks(e);
+        }
+      }
+    },
+
     showLinks: function(e) {
       var $c = $(e.currentTarget);
-      if (
-        !$c.find('.active-link').length ||
-        this.model.get('isMobileOrTablet')
-      ) {
+      if (!$c.find('.active-link').length) {
         return;
       }
 

--- a/src/js/widgets/list_of_things/templates/item-template.html
+++ b/src/js/widgets/list_of_things/templates/item-template.html
@@ -53,7 +53,7 @@
 
                     {{#if links.text}}
 
-                        <a href="{{links.text.[0].url}}" target="_blank" rel="noreferrer noopener" class="btn-link active-link s-active-link" aria-disabled="false">
+                        <a class="btn-link active-link s-active-link" aria-disabled="false">
                             <i class="s-text-icon" aria-hidden="true"></i>
                             <span class="sr-only">quick access to full text links</span>
                         </a>
@@ -81,7 +81,7 @@
 
                 {{#if links.list}}
 
-                <a href="{{links.list.[0].url}}" class="btn-link active-link s-active-link" aria-disabled="false">
+                <a class="btn-link active-link s-active-link" aria-disabled="false">
                     <i class="s-list-icon" aria-hidden="true"></i>
                     <span class="sr-only">quick links to lists of references, citations and more</span>
                 </a>
@@ -109,7 +109,7 @@
 
                 {{#if links.data}}
 
-                <a href="{{links.data.[0].url}}" target="_blank" rel="noreferrer noopener" class="btn-link active-link s-active-link" aria-disabled="false">
+                <a class="btn-link active-link s-active-link" aria-disabled="false">
                     <i class="s-data-icon" aria-hidden="true"></i>
                     <span class="sr-only">quick links to data associated with this article</span>
                 </a>


### PR DESCRIPTION
* On touch screen, make hover over icon menu (in search result items) accessible using click.
* If not on a touch screen, removed the original click action completely (which took you to one of the menu links)

![Screen Shot 2021-04-22 at 9 07 16 AM](https://user-images.githubusercontent.com/636361/115747943-92290000-a34a-11eb-80a8-a1644c457755.png)

