### PR TITLE
Make login submit usable with enter

### DIFF
--- a/src/js/widgets/authentication/templates/log-in.html
+++ b/src/js/widgets/authentication/templates/log-in.html
@@ -31,7 +31,7 @@
       />
     </div>
 
-    <button class="btn btn-link show-reset-password-1">
+    <button type="button" class="btn btn-link show-reset-password-1">
       Forgot your password?
     </button>
     <span class="help-block no-show s-help-block"></span>


### PR DESCRIPTION
On the login page, the forgot password was moved above the submit, which caused it to become the submit button when pressed enter.
* Added `type="button"` to the forgot password button