### PR TITLE
Hide Add to library widget when showing explore widgets

### DIFF
--- a/src/js/page_managers/templates/results-page-layout.html
+++ b/src/js/page_managers/templates/results-page-layout.html
@@ -66,20 +66,21 @@
             </div>
           </div>
           
-          <div data-widget="QueryInfo" class="s-right-column col-sm-3" id="query-info-container"/>
-          <div
-            class="hidden-xs col-sm-3 col-md-3 results-right-column s-right-column s-results-column"
-            id="results-right-column"
-          >
-            <h2 class="sr-only">
-              Additional Functionality (Information about your query, and more
-              search filters)
-            </h2>
+          <div id="results-right-column">
+            <div data-widget="QueryInfo" class="s-right-column col-sm-3" id="query-info-container"/>
+            <div
+              class="hidden-xs col-sm-3 col-md-3 results-right-column s-right-column s-results-column"
+            >
+              <h2 class="sr-only">
+                Additional Functionality (Information about your query, and more
+                search filters)
+              </h2>
 
-            <div data-widget="MyAdsFreeform" />
-            <div data-widget="OrcidSelector" />
-            <div data-widget="GraphTabs" />
-            <div data-widget="QueryDebugInfo" data-debug="true" />
+              <div data-widget="MyAdsFreeform" />
+              <div data-widget="OrcidSelector" />
+              <div data-widget="GraphTabs" />
+              <div data-widget="QueryDebugInfo" data-debug="true" />
+            </div>
           </div>
         </div>
       </div>

--- a/src/js/page_managers/three_column_view.js
+++ b/src/js/page_managers/three_column_view.js
@@ -125,11 +125,12 @@ define([
       $leftCol = this.$('#results-left-column');
       $rightCol = this.$('#results-right-column');
       $middleCol = this.$('#results-middle-column');
+      $action = this.$('#results-actions-toggle');
 
       _.each(
         [
           ['left', leftState, $leftCol],
-          ['right', rightState, $rightCol],
+          ['right', rightState, $rightCol, $action],
         ],
         function(x) {
           if (x[1] == 'open') {
@@ -138,8 +139,14 @@ define([
             setTimeout(function() {
               $col.children().show(0);
             }, 200);
+            if (x[3]) {
+              x[3].removeClass('hidden');
+            }
           } else {
             x[2].addClass('hidden');
+            if (x[3]) {
+              x[3].addClass('hidden');
+            }
           }
         }
       );


### PR DESCRIPTION
This PR fixed  a bug introduced when we pulled out Add library widget to be shown in single column. Add library widget should not be visible when showing explore pages. 
![Screenshot 2021-04-26 at 18 12 49](https://user-images.githubusercontent.com/636361/116134201-8019cb00-a684-11eb-9591-396a6c23a3a1.png)
