### PR TITLE
Add orcid icon and link to orcid search from abstract page

### DIFF
--- a/src/js/widgets/abstract/templates/abstract_template.html
+++ b/src/js/widgets/abstract/templates/abstract_template.html
@@ -38,7 +38,7 @@ hideCloseButton=true widgetLoadingSize="big"}} {{else if error}}
 
 <div id="authors-and-aff" class="s-authors-and-aff">
   <ul class="list-inline">
-    {{#each authorAff}} {{#if @last}}
+    {{#each authorAff}}
     <li class="author">
       <a href="#search/q=author:{{this.[5]}}&sort=date%20desc,%20bibcode%20desc">
         {{this.[0]}}
@@ -65,42 +65,21 @@ hideCloseButton=true widgetLoadingSize="big"}} {{else if error}}
           {{/compare}}
         {{/compare}}
       </span>    
-      <span class="affiliation hide"> (<i>{{this.[1]}}</i>)</span>
+      <span class="affiliation hide"> (<i>{{this.[1]}}</i>)</span>{{#if @last}}{{else}};{{/if}}
     </li>
-    {{else}}
-    <li class="author">
-      <a href="#search/q=author:{{this.[5]}}&sort=date%20desc,%20bibcode%20desc">{{this.[0]}}</a>
-      <span>
-        {{#compare this.[2] '-' operator="!=="}}
-          <a class="orcid-author" href="#search/q=orcid:{{this.[2]}}&sort=date%20desc,%20bibcode%20desc">
-            <img class="inactive" src="../../styles/img/orcid-inactive.svg" alt="search by orcid">
-            <img class="active hidden" src="../../styles/img/orcid-active.svg" alt="search by orcid">
-          </a>
-        {{else}}
-          {{#compare this.[3] '-' operator="!=="}}
-            <a class="orcid-author" href="#search/q=orcid:{{this.[3]}}&sort=date%20desc,%20bibcode%20desc">
-              <img class="inactive" src="../../styles/img/orcid-inactive.svg" alt="search by orcid">
-              <img class="active hidden" src="../../styles/img/orcid-active.svg" alt="search by orcid">
-            </a>
-          {{else}}
-            {{#compare this.[4] '-' operator="!=="}}
-              <a class="orcid-author" href="#search/q=orcid:{{this.[4]}}&sort=date%20desc,%20bibcode%20desc">
-                <img class="inactive" src="../../styles/img/orcid-inactive.svg" alt="search by orcid">
-                <img class="active hidden" src="../../styles/img/orcid-active.svg" alt="search by orcid"> 
-              </a>
-            {{/compare}}
-          {{/compare}}
-        {{/compare}}
-      </span> 
-      <span class="affiliation hide"> (<i>{{this.[1]}}</i>)</span>;
-    </li>
-    {{/if}} {{/each}} {{#if hasMoreAuthors}}
+    {{/each}} 
+    
+    {{#if hasMoreAuthors}}
     <li class="author extra-dots">
       ; <a data-target="more-authors" title="Show all authors">...</a>
     </li>
-    {{/if}} {{#each authorAffExtra}} {{#if @last}}
+    {{/if}} 
+    
+    {{#each authorAffExtra}}
     <li class="author extra hide">
-      <a href="#search/q=author:{{this.[5]}}&sort=date%20desc,%20bibcode%20desc">{{this.[0]}}</a>
+      <a href="#search/q=author:{{this.[5]}}&sort=date%20desc,%20bibcode%20desc">
+        {{this.[0]}}
+      </a>
       <span>
         {{#compare this.[2] '-' operator="!=="}}
           <a class="orcid-author" href="#search/q=orcid:{{this.[2]}}&sort=date%20desc,%20bibcode%20desc">
@@ -123,36 +102,10 @@ hideCloseButton=true widgetLoadingSize="big"}} {{else if error}}
           {{/compare}}
         {{/compare}}
       </span> 
-      <span class="affiliation hide"> (<i>{{this.[1]}}</i>)</span>
+      <span class="affiliation hide"> (<i>{{this.[1]}}</i>)</span>{{#if @last}}{{else}};{{/if}}
     </li>
-    {{else}}
-    <li class="author extra hide">
-      <a href="#search/q=author:{{this.[5]}}&sort=date%20desc,%20bibcode%20desc">{{this.[0]}}</a>
-      <span>
-        {{#compare this.[2] '-' operator="!=="}}
-          <a class="orcid-author" href="#search/q=orcid:{{this.[2]}}&sort=date%20desc,%20bibcode%20desc">
-            <img class="inactive" src="../../styles/img/orcid-inactive.svg" alt="search by orcid">
-            <img class="active hidden" src="../../styles/img/orcid-active.svg" alt="search by orcid">
-          </a>
-        {{else}}
-          {{#compare this.[3] '-' operator="!=="}}
-            <a class="orcid-author" href="#search/q=orcid:{{this.[3]}}&sort=date%20desc,%20bibcode%20desc">
-              <img class="inactive" src="../../styles/img/orcid-inactive.svg" alt="search by orcid">
-              <img class="active hidden" src="../../styles/img/orcid-active.svg" alt="search by orcid">
-            </a>
-          {{else}}
-            {{#compare this.[4] '-' operator="!=="}}
-              <a class="orcid-author" href="#search/q=orcid:{{this.[4]}}&sort=date%20desc,%20bibcode%20desc">
-                <img class="inactive" src="../../styles/img/orcid-inactive.svg" alt="search by orcid">
-                <img class="active hidden" src="../../styles/img/orcid-active.svg" alt="search by orcid">
-              </a>
-            {{/compare}}
-          {{/compare}}
-        {{/compare}}
-      </span> 
-      <span class="affiliation hide"> (<i>{{this.[1]}}</i>)</span>;
-    </li>
-    {{/if}} {{/each}}
+    {{/each}}
+    
   </ul>
 </div>
 {{/if}}

--- a/src/js/widgets/abstract/templates/abstract_template.html
+++ b/src/js/widgets/abstract/templates/abstract_template.html
@@ -40,15 +40,53 @@ hideCloseButton=true widgetLoadingSize="big"}} {{else if error}}
   <ul class="list-inline">
     {{#each authorAff}} {{#if @last}}
     <li class="author">
-      <a href="#search/q=author:{{this.[2]}}&sort=date%20desc,%20bibcode%20desc"
-        >{{this.[0]}}</a
-      ><span class="affiliation hide"> (<i>{{this.[1]}}</i>)</span>
+      <a href="#search/q=author:{{this.[5]}}&sort=date%20desc,%20bibcode%20desc">
+        {{this.[0]}}
+      </a>
+      <span class="orcid-author">
+        {{#compare this.[2] '-' operator="!=="}}
+          <a href="#search/q=orcid:{{this.[2]}}&sort=date%20desc,%20bibcode%20desc">
+            <img src="../../styles/img/orcid-active.svg" alt="search by orcid">
+          </a>
+        {{else}}
+          {{#compare this.[3] '-' operator="!=="}}
+            <a href="#search/q=orcid:{{this.[3]}}&sort=date%20desc,%20bibcode%20desc">
+              <img src="../../styles/img/orcid-active.svg" alt="search by orcid">
+            </a>
+          {{else}}
+            {{#compare this.[4] '-' operator="!=="}}
+              <a href="#search/q=orcid:{{this.[4]}}&sort=date%20desc,%20bibcode%20desc">
+                <img src="../../styles/img/orcid-active.svg" alt="search by orcid">
+              </a>
+            {{/compare}}
+          {{/compare}}
+        {{/compare}}
+      </span>    
+      <span class="affiliation hide"> (<i>{{this.[1]}}</i>)</span>
     </li>
     {{else}}
     <li class="author">
-      <a href="#search/q=author:{{this.[2]}}&sort=date%20desc,%20bibcode%20desc"
-        >{{this.[0]}}</a
-      ><span class="affiliation hide"> (<i>{{this.[1]}}</i>)</span>;
+      <a href="#search/q=author:{{this.[5]}}&sort=date%20desc,%20bibcode%20desc">{{this.[0]}}</a>
+      <span class="orcid-author">
+        {{#compare this.[2] '-' operator="!=="}}
+          <a href="#search/q=orcid:{{this.[2]}}&sort=date%20desc,%20bibcode%20desc">
+            <img src="../../styles/img/orcid-active.svg" alt="search by orcid">
+          </a>
+        {{else}}
+          {{#compare this.[3] '-' operator="!=="}}
+            <a href="#search/q=orcid:{{this.[3]}}&sort=date%20desc,%20bibcode%20desc">
+              <img src="../../styles/img/orcid-active.svg" alt="search by orcid">
+            </a>
+          {{else}}
+            {{#compare this.[4] '-' operator="!=="}}
+              <a href="#search/q=orcid:{{this.[4]}}&sort=date%20desc,%20bibcode%20desc">
+                <img src="../../styles/img/orcid-active.svg" alt="search by orcid">
+              </a>
+            {{/compare}}
+          {{/compare}}
+        {{/compare}}
+      </span> 
+      <span class="affiliation hide"> (<i>{{this.[1]}}</i>)</span>;
     </li>
     {{/if}} {{/each}} {{#if hasMoreAuthors}}
     <li class="author extra-dots">
@@ -56,15 +94,51 @@ hideCloseButton=true widgetLoadingSize="big"}} {{else if error}}
     </li>
     {{/if}} {{#each authorAffExtra}} {{#if @last}}
     <li class="author extra hide">
-      <a href="#search/q=author:{{this.[2]}}&sort=date%20desc,%20bibcode%20desc"
-        >{{this.[0]}}</a
-      ><span class="affiliation hide"> (<i>{{this.[1]}}</i>)</span>
+      <a href="#search/q=author:{{this.[5]}}&sort=date%20desc,%20bibcode%20desc">{{this.[0]}}</a>
+      <span class="orcid-author">
+        {{#compare this.[2] '-' operator="!=="}}
+          <a href="#search/q=orcid:{{this.[2]}}&sort=date%20desc,%20bibcode%20desc">
+            <img src="../../styles/img/orcid-active.svg" alt="search by orcid">
+          </a>
+        {{else}}
+          {{#compare this.[3] '-' operator="!=="}}
+            <a href="#search/q=orcid:{{this.[3]}}&sort=date%20desc,%20bibcode%20desc">
+              <img src="../../styles/img/orcid-active.svg" alt="search by orcid">
+            </a>
+          {{else}}
+            {{#compare this.[4] '-' operator="!=="}}
+              <a href="#search/q=orcid:{{this.[4]}}&sort=date%20desc,%20bibcode%20desc">
+                <img src="../../styles/img/orcid-active.svg" alt="search by orcid">
+              </a>
+            {{/compare}}
+          {{/compare}}
+        {{/compare}}
+      </span> 
+      <span class="affiliation hide"> (<i>{{this.[1]}}</i>)</span>
     </li>
     {{else}}
     <li class="author extra hide">
-      <a href="#search/q=author:{{this.[2]}}&sort=date%20desc,%20bibcode%20desc"
-        >{{this.[0]}}</a
-      ><span class="affiliation hide"> (<i>{{this.[1]}}</i>)</span>;
+      <a href="#search/q=author:{{this.[5]}}&sort=date%20desc,%20bibcode%20desc">{{this.[0]}}</a>
+      <span class="orcid-author">
+        {{#compare this.[2] '-' operator="!=="}}
+          <a href="#search/q=orcid:{{this.[2]}}&sort=date%20desc,%20bibcode%20desc">
+            <img src="../../styles/img/orcid-active.svg" alt="search by orcid">
+          </a>
+        {{else}}
+          {{#compare this.[3] '-' operator="!=="}}
+            <a href="#search/q=orcid:{{this.[3]}}&sort=date%20desc,%20bibcode%20desc">
+              <img src="../../styles/img/orcid-active.svg" alt="search by orcid">
+            </a>
+          {{else}}
+            {{#compare this.[4] '-' operator="!=="}}
+              <a href="#search/q=orcid:{{this.[4]}}&sort=date%20desc,%20bibcode%20desc">
+                <img src="../../styles/img/orcid-active.svg" alt="search by orcid">
+              </a>
+            {{/compare}}
+          {{/compare}}
+        {{/compare}}
+      </span> 
+      <span class="affiliation hide"> (<i>{{this.[1]}}</i>)</span>;
     </li>
     {{/if}} {{/each}}
   </ul>

--- a/src/js/widgets/abstract/templates/abstract_template.html
+++ b/src/js/widgets/abstract/templates/abstract_template.html
@@ -43,20 +43,23 @@ hideCloseButton=true widgetLoadingSize="big"}} {{else if error}}
       <a href="#search/q=author:{{this.[5]}}&sort=date%20desc,%20bibcode%20desc">
         {{this.[0]}}
       </a>
-      <span class="orcid-author">
+      <span>
         {{#compare this.[2] '-' operator="!=="}}
-          <a href="#search/q=orcid:{{this.[2]}}&sort=date%20desc,%20bibcode%20desc">
-            <img src="../../styles/img/orcid-active.svg" alt="search by orcid">
+          <a class="orcid-author" href="#search/q=orcid:{{this.[2]}}&sort=date%20desc,%20bibcode%20desc">
+            <img class="inactive" src="../../styles/img/orcid-inactive.svg" alt="search by orcid">
+            <img class="active hidden" src="../../styles/img/orcid-active.svg" alt="search by orcid">
           </a>
         {{else}}
           {{#compare this.[3] '-' operator="!=="}}
-            <a href="#search/q=orcid:{{this.[3]}}&sort=date%20desc,%20bibcode%20desc">
-              <img src="../../styles/img/orcid-active.svg" alt="search by orcid">
+            <a class="orcid-author" href="#search/q=orcid:{{this.[3]}}&sort=date%20desc,%20bibcode%20desc">
+              <img class="inactive" src="../../styles/img/orcid-inactive.svg" alt="search by orcid">
+              <img class="active hidden" src="../../styles/img/orcid-active.svg" alt="search by orcid">
             </a>
           {{else}}
             {{#compare this.[4] '-' operator="!=="}}
-              <a href="#search/q=orcid:{{this.[4]}}&sort=date%20desc,%20bibcode%20desc">
-                <img src="../../styles/img/orcid-active.svg" alt="search by orcid">
+              <a class="orcid-author" href="#search/q=orcid:{{this.[4]}}&sort=date%20desc,%20bibcode%20desc">
+                <img class="inactive" src="../../styles/img/orcid-inactive.svg" alt="search by orcid">
+                <img class="active hidden" src="../../styles/img/orcid-active.svg" alt="search by orcid">
               </a>
             {{/compare}}
           {{/compare}}
@@ -67,20 +70,23 @@ hideCloseButton=true widgetLoadingSize="big"}} {{else if error}}
     {{else}}
     <li class="author">
       <a href="#search/q=author:{{this.[5]}}&sort=date%20desc,%20bibcode%20desc">{{this.[0]}}</a>
-      <span class="orcid-author">
+      <span>
         {{#compare this.[2] '-' operator="!=="}}
-          <a href="#search/q=orcid:{{this.[2]}}&sort=date%20desc,%20bibcode%20desc">
-            <img src="../../styles/img/orcid-active.svg" alt="search by orcid">
+          <a class="orcid-author" href="#search/q=orcid:{{this.[2]}}&sort=date%20desc,%20bibcode%20desc">
+            <img class="inactive" src="../../styles/img/orcid-inactive.svg" alt="search by orcid">
+            <img class="active hidden" src="../../styles/img/orcid-active.svg" alt="search by orcid">
           </a>
         {{else}}
           {{#compare this.[3] '-' operator="!=="}}
-            <a href="#search/q=orcid:{{this.[3]}}&sort=date%20desc,%20bibcode%20desc">
-              <img src="../../styles/img/orcid-active.svg" alt="search by orcid">
+            <a class="orcid-author" href="#search/q=orcid:{{this.[3]}}&sort=date%20desc,%20bibcode%20desc">
+              <img class="inactive" src="../../styles/img/orcid-inactive.svg" alt="search by orcid">
+              <img class="active hidden" src="../../styles/img/orcid-active.svg" alt="search by orcid">
             </a>
           {{else}}
             {{#compare this.[4] '-' operator="!=="}}
-              <a href="#search/q=orcid:{{this.[4]}}&sort=date%20desc,%20bibcode%20desc">
-                <img src="../../styles/img/orcid-active.svg" alt="search by orcid">
+              <a class="orcid-author" href="#search/q=orcid:{{this.[4]}}&sort=date%20desc,%20bibcode%20desc">
+                <img class="inactive" src="../../styles/img/orcid-inactive.svg" alt="search by orcid">
+                <img class="active hidden" src="../../styles/img/orcid-active.svg" alt="search by orcid"> 
               </a>
             {{/compare}}
           {{/compare}}
@@ -95,20 +101,23 @@ hideCloseButton=true widgetLoadingSize="big"}} {{else if error}}
     {{/if}} {{#each authorAffExtra}} {{#if @last}}
     <li class="author extra hide">
       <a href="#search/q=author:{{this.[5]}}&sort=date%20desc,%20bibcode%20desc">{{this.[0]}}</a>
-      <span class="orcid-author">
+      <span>
         {{#compare this.[2] '-' operator="!=="}}
-          <a href="#search/q=orcid:{{this.[2]}}&sort=date%20desc,%20bibcode%20desc">
-            <img src="../../styles/img/orcid-active.svg" alt="search by orcid">
+          <a class="orcid-author" href="#search/q=orcid:{{this.[2]}}&sort=date%20desc,%20bibcode%20desc">
+            <img class="inactive" src="../../styles/img/orcid-inactive.svg" alt="search by orcid">
+            <img class="active hidden" src="../../styles/img/orcid-active.svg" alt="search by orcid">
           </a>
         {{else}}
           {{#compare this.[3] '-' operator="!=="}}
-            <a href="#search/q=orcid:{{this.[3]}}&sort=date%20desc,%20bibcode%20desc">
-              <img src="../../styles/img/orcid-active.svg" alt="search by orcid">
+            <a class="orcid-author" href="#search/q=orcid:{{this.[3]}}&sort=date%20desc,%20bibcode%20desc">
+              <img class="inactive" src="../../styles/img/orcid-inactive.svg" alt="search by orcid">
+              <img class="active hidden" src="../../styles/img/orcid-active.svg" alt="search by orcid">
             </a>
           {{else}}
             {{#compare this.[4] '-' operator="!=="}}
-              <a href="#search/q=orcid:{{this.[4]}}&sort=date%20desc,%20bibcode%20desc">
-                <img src="../../styles/img/orcid-active.svg" alt="search by orcid">
+              <a class="orcid-author" href="#search/q=orcid:{{this.[4]}}&sort=date%20desc,%20bibcode%20desc">
+                <img class="inactive" src="../../styles/img/orcid-inactive.svg" alt="search by orcid">
+                <img class="active hidden" src="../../styles/img/orcid-active.svg" alt="search by orcid">
               </a>
             {{/compare}}
           {{/compare}}
@@ -119,20 +128,23 @@ hideCloseButton=true widgetLoadingSize="big"}} {{else if error}}
     {{else}}
     <li class="author extra hide">
       <a href="#search/q=author:{{this.[5]}}&sort=date%20desc,%20bibcode%20desc">{{this.[0]}}</a>
-      <span class="orcid-author">
+      <span>
         {{#compare this.[2] '-' operator="!=="}}
-          <a href="#search/q=orcid:{{this.[2]}}&sort=date%20desc,%20bibcode%20desc">
-            <img src="../../styles/img/orcid-active.svg" alt="search by orcid">
+          <a class="orcid-author" href="#search/q=orcid:{{this.[2]}}&sort=date%20desc,%20bibcode%20desc">
+            <img class="inactive" src="../../styles/img/orcid-inactive.svg" alt="search by orcid">
+            <img class="active hidden" src="../../styles/img/orcid-active.svg" alt="search by orcid">
           </a>
         {{else}}
           {{#compare this.[3] '-' operator="!=="}}
-            <a href="#search/q=orcid:{{this.[3]}}&sort=date%20desc,%20bibcode%20desc">
-              <img src="../../styles/img/orcid-active.svg" alt="search by orcid">
+            <a class="orcid-author" href="#search/q=orcid:{{this.[3]}}&sort=date%20desc,%20bibcode%20desc">
+              <img class="inactive" src="../../styles/img/orcid-inactive.svg" alt="search by orcid">
+              <img class="active hidden" src="../../styles/img/orcid-active.svg" alt="search by orcid">
             </a>
           {{else}}
             {{#compare this.[4] '-' operator="!=="}}
-              <a href="#search/q=orcid:{{this.[4]}}&sort=date%20desc,%20bibcode%20desc">
-                <img src="../../styles/img/orcid-active.svg" alt="search by orcid">
+              <a class="orcid-author" href="#search/q=orcid:{{this.[4]}}&sort=date%20desc,%20bibcode%20desc">
+                <img class="inactive" src="../../styles/img/orcid-inactive.svg" alt="search by orcid">
+                <img class="active hidden" src="../../styles/img/orcid-active.svg" alt="search by orcid">
               </a>
             {{/compare}}
           {{/compare}}

--- a/src/js/widgets/abstract/widget.js
+++ b/src/js/widgets/abstract/widget.js
@@ -74,6 +74,7 @@ define([
       doc.aff = doc.aff.map(_.unescape);
 
       const numAuthors = doc.author.length;
+      const defaultList = _.range(numAuthors).map(() => '-');
       if (doc.aff.length) {
         doc.hasAffiliation = _.without(doc.aff, '-').length;
 
@@ -81,18 +82,18 @@ define([
         doc.authorAff = _.zip(
           doc.author,
           doc.aff,
-          doc.orcid_pub ? doc.orcid_pub : _.range(numAuthors).map(() => '-'),
-          doc.orcid_user ? doc.orcid_user : _.range(numAuthors).map(() => '-'),
-          doc.orcid_other ? doc.orcid_other : _.range(numAuthors).map(() => '-')
+          doc.orcid_pub ? doc.orcid_pub : defaultList,
+          doc.orcid_user ? doc.orcid_user : defaultList,
+          doc.orcid_other ? doc.orcid_other : defaultList
         );
       } else if (doc.author) {
         doc.hasAffiliation = false;
         doc.authorAff = _.zip(
           doc.author,
           _.range(doc.author.length),
-          doc.orcid_pub ? doc.orcid_pub : _.range(numAuthors).map(() => '-'),
-          doc.orcid_user ? doc.orcid_user : _.range(numAuthors).map(() => '-'),
-          doc.orcid_other ? doc.orcid_other : _.range(numAuthors).map(() => '-')
+          doc.orcid_pub ? doc.orcid_pub : defaultList,
+          doc.orcid_user ? doc.orcid_user : defaultList,
+          doc.orcid_other ? doc.orcid_other : defaultList
         );
       }
 

--- a/src/js/widgets/abstract/widget.js
+++ b/src/js/widgets/abstract/widget.js
@@ -192,6 +192,26 @@ define([
       'click a[target="next"]': 'onClick',
       'click a[data-target="DOI"]': 'emitAnalytics',
       'click a[data-target="arXiv"]': 'emitAnalytics',
+      'mouseenter .orcid-author': 'highlightOrcidAuthor',
+      'mouseleave .orcid-author': 'unhighlightOrcidAuthor',
+    },
+
+    highlightOrcidAuthor: function(e) {
+      const $target = $(e.currentTarget);
+      const $active = $target.find('.active');
+      if ($active.hasClass('hidden')) {
+        $active.removeClass('hidden');
+        $target.find('.inactive').addClass('hidden');
+      }
+    },
+
+    unhighlightOrcidAuthor: function(e) {
+      const $target = $(e.currentTarget);
+      const $inactive = $target.find('.inactive');
+      if ($inactive.hasClass('hidden')) {
+        $inactive.removeClass('hidden');
+        $target.find('.active').addClass('hidden');
+      }
     },
 
     toggleMoreAuthors: function() {

--- a/src/styles/sass/ads-sass/visualizations.scss
+++ b/src/styles/sass/ads-sass/visualizations.scss
@@ -380,7 +380,7 @@ $group-circle-active: lighten($brand-warning, 10%);
   width: auto;
 }
 
-.orcid-author a:hover {
+.orcid-author:hover {
   text-decoration: none;
 }
 

--- a/src/styles/sass/ads-sass/visualizations.scss
+++ b/src/styles/sass/ads-sass/visualizations.scss
@@ -375,6 +375,15 @@ $group-circle-active: lighten($brand-warning, 10%);
   }
 }
 
+.orcid-author img {
+  height: 20px;
+  width: auto;
+}
+
+.orcid-author a:hover {
+  text-decoration: none;
+}
+
 .selected-link {
   stroke: darken($brand-warning, 10%);
   stroke-width: 2px;

--- a/test/mocha/js/widgets/abstract_widget.spec.js
+++ b/test/mocha/js/widgets/abstract_widget.spec.js
@@ -30,6 +30,9 @@ define(['backbone', 'marionette', 'jquery', 'js/widgets/abstract/widget',
                 "pubdate": "1981-00-00",
                 "title": ["Planetary Ephemerides <A href=\"test-url\">TEST</A>"],
                 "aff": ["Heidelberg, Universität, Heidelberg, Germany", "California Institute of Technology, Jet Propulsion Laboratory, Pasadena, CA"],
+                "orcid_pub": ["1234", "-"],
+                "orcid_user": ["4321", "5678"],
+                "orcid_other": ["-", "8765"],
                 "citation_count" : 5,
                 "[citations]" : { num_citations : 3, num_references: 34 },
                 read_count: 30,
@@ -122,10 +125,10 @@ define(['backbone', 'marionette', 'jquery', 'js/widgets/abstract/widget',
         expect(aw._docs['foo'].pubdate).to.equal("1981-00-00");
         expect(aw._docs['foo'].formattedDate).to.equal("1981");
         expect(aw._docs['foo'].pub).to.equal("IAU Colloq. 56: Reference Coordinate Systems for Earth Dynamics");
-        expect(aw._docs['foo'].authorAff[0]).to.eql(["Lieske, J. H.","Heidelberg, Universität, Heidelberg, Germany","%22Lieske%2C+J.+H.%22"]);
+        expect(aw._docs['foo'].authorAff[0]).to.eql(["Lieske, J. H.","Heidelberg, Universität, Heidelberg, Germany","1234","4321","-","%22Lieske%2C+J.+H.%22"]);
         expect(aw._docs['foo'].authorAff[1]).to.eql([
           "Standish, E. M.",
-          "California Institute of Technology, Jet Propulsion Laboratory, Pasadena, CA",
+          "California Institute of Technology, Jet Propulsion Laboratory, Pasadena, CA","-","5678","8765",
           "%22Standish%2C+E.+M.%22"
         ]);
         expect(aw._docs['foo'].authorAffExtra).to.eql(undefined);
@@ -142,8 +145,22 @@ define(['backbone', 'marionette', 'jquery', 'js/widgets/abstract/widget',
         expect(spy.callCount).to.eql(2);
         expect(aw._docs['foo'].hasAffiliation).to.eql(2);
         expect(aw._docs['foo'].hasMoreAuthors).to.eql(1);
-        expect(aw._docs['foo'].authorAff[0]).to.eql(["Lieske, J. H.","Heidelberg, Universität, Heidelberg, Germany","%22Lieske%2C+J.+H.%22"]);
-        expect(aw._docs['foo'].authorAffExtra[0]).to.eql(["Standish, E. M.","California Institute of Technology, Jet Propulsion Laboratory, Pasadena, CA","%22Standish%2C+E.+M.%22"]);
+        expect(aw._docs['foo'].authorAff[0]).to.eql([
+          'Lieske, J. H.',
+          'Heidelberg, Universität, Heidelberg, Germany',
+          '1234',
+          '4321',
+          '-',
+          '%22Lieske%2C+J.+H.%22',
+        ]);
+        expect(aw._docs['foo'].authorAffExtra[0]).to.eql([
+          'Standish, E. M.',
+          'California Institute of Technology, Jet Propulsion Laboratory, Pasadena, CA',
+          '-',
+          '5678',
+          '8765',
+          '%22Standish%2C+E.+M.%22',
+        ]);
 
       });
 


### PR DESCRIPTION
In abstract page, add orcid icon next to author and link to orcid search
The orcid used is based on this priority:
1. `orcid_pub`
2. `orcid_user`
3. `orcid_other`
![Screen Shot 2021-04-29 at 6 59 59 AM](https://user-images.githubusercontent.com/636361/116729772-6df99e80-a99c-11eb-83f9-9041d23352fb.png)

