### PR TITLE
add polyfill for intersectionObserver

### DIFF
--- a/grunt/concurrent.js
+++ b/grunt/concurrent.js
@@ -22,6 +22,7 @@ module.exports = {
     'curl:xstate-react',
     'curl:array-flat-polyfill',
     'curl:sinon',
+    'curl:polyfill',
   ],
   hash_require: ['hash_require:js', 'hash_require:css'],
 };

--- a/grunt/curl.js
+++ b/grunt/curl.js
@@ -77,4 +77,8 @@ module.exports = {
     src: 'https://cdnjs.cloudflare.com/ajax/libs/sinon.js/1.9.0/sinon.min.js',
     dest: 'src/libs/sinon/index.js',
   },
+  polyfill: {
+    src: 'https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver',
+    dest: 'src/libs/polyfill/index.js',
+  },
 };

--- a/src/config/common.config.js
+++ b/src/config/common.config.js
@@ -46,6 +46,7 @@ define([], function() {
     'config/discovery.vars',
     'regenerator-runtime',
     'array-flat-polyfill',
+    'polyfill',
   ], function(config) {
     // rca: not sure why the ganalytics is loaded here instead of inside analytics.js
     //      perhaps it is because it is much/little sooner this way?

--- a/src/config/discovery.config.js
+++ b/src/config/discovery.config.js
@@ -322,6 +322,7 @@ require.config({
     xstate: 'libs/xstate/index',
     '@xstate/react': 'libs/xstate-react/index',
     'array-flat-polyfill': 'libs/polyfills/array-flat-polyfill',
+    polyfill: 'libs/polyfill/index',
   },
 
   hbs: {


### PR DESCRIPTION
Several users have mentioned getting 404 pages on older browsers, I think this is the reason.  This adds a polyfill.