### PR TITLE
Add minify back in

### DIFF
--- a/grunt/aliases.yaml
+++ b/grunt/aliases.yaml
@@ -126,3 +126,4 @@ release:
     - cssmin
     - htmlmin
     - imagemin
+    - uglify


### PR DESCRIPTION
Not sure why it was removed.  But adding back in the minification step to the release builds