### PR TITLE
Adjust inconsistent sizing and paddings of the right column widgets

### DIFF
--- a/src/js/wraps/abstract_page_manager/abstract-page-layout.html
+++ b/src/js/wraps/abstract_page_manager/abstract-page-layout.html
@@ -36,7 +36,7 @@
                 </div>
             </div>
             <div data-widget="ShowResources" class="col-sm-3" id="resources-container"/>
-            <div class="s-right-col-container col-sm-3 col-lg-2 s-right-column" id="right-col-container">
+            <div class="s-right-col-container col-sm-3 s-right-column" id="right-col-container">
                 <div data-widget="ShowLibraryAdd"/>
                 <div data-widget="ShowGraphicsSidebar"/>
                 <div data-widget="ShowAssociated"/>

--- a/src/styles/sass/ads-sass/abstract-page-widgets.scss
+++ b/src/styles/sass/ads-sass/abstract-page-widgets.scss
@@ -300,10 +300,15 @@ $sciencewise-color: rgb(179, 27, 27);
 #resources-container {
   transition: transform 0.5s ease-in-out;
   padding-left: 0;
-  padding-right: 0;
+  padding-right: 15px;
+
+  @media (max-width: $screen-md) {
+    padding-right: 0;
+  }
 
   @media (max-width: $screen-xs-max) {
     position: absolute;
+    padding-right: 0;
     width: 100%;
     left: 100%;
     top: 0;

--- a/src/styles/sass/ads-sass/page-managers.scss
+++ b/src/styles/sass/ads-sass/page-managers.scss
@@ -230,11 +230,6 @@ Styles for Abstract Page
 
   @media only screen and (max-width: $screen-md-max) {
     font-size: smaller;
-    margin-right: 20px;
-  }
-
-  @media only screen and (max-width: $screen-sm-max) {
-    margin: 0px 20px 0px 20px;
   }
 
   @media only screen and (max-width: $screen-xs-max) {


### PR DESCRIPTION
Adjust inconsistent sizing and paddings of the right column widgets in abstract page

Before it looks like this
![Screen Shot 2021-05-28 at 4 17 42 PM](https://user-images.githubusercontent.com/636361/120049864-3cdab100-bfd0-11eb-8ff2-ea8153f20b99.png)

Of this, depending on screen size
![Screen Shot 2021-05-28 at 4 17 59 PM](https://user-images.githubusercontent.com/636361/120049878-47954600-bfd0-11eb-9498-6e3975fe289f.png)

Now it's consistent on all screen sizes
![Screen Shot 2021-05-28 at 4 19 01 PM](https://user-images.githubusercontent.com/636361/120049923-6bf12280-bfd0-11eb-8da9-dd228bcc2f76.png)
