### PR TITLE
Bug fix: When paper has no title

### DIFF
--- a/src/js/widgets/list_of_things/details_widget.js
+++ b/src/js/widgets/list_of_things/details_widget.js
@@ -64,9 +64,7 @@ define([
             this.dispatchRequest(data.bibcode);
           }, this);
 
-          this.model.has('title')
-            ? doDispatch()
-            : this.model.once('change:title', doDispatch);
+          doDispatch();
         }
       });
 


### PR DESCRIPTION
When paper has no title, the abs -> citations and abs -> references did not load (spins forever).  Because the component is waiting until the model has title set, which never happens. This PR addressed the problem

<img width="927" alt="Screen Shot 2021-06-10 at 6 27 24 AM" src="https://user-images.githubusercontent.com/636361/121533227-ef3d4b80-c9b4-11eb-86de-e9692db64670.png">