### PR TITLE
Bug fix: Results graph hanging after click on "close"

### DIFF
--- a/src/js/widgets/bubble_chart/widget.js
+++ b/src/js/widgets/bubble_chart/widget.js
@@ -1064,7 +1064,7 @@ define([
       });
       this.listenTo(this.view, 'filterBibs', this.onFilterBibs);
       this.listenTo(this.view, 'close-widget', () => {
-        this.resetModel();
+        this.resetModel(true);
         this.broadcastClose();
       });
       this.widgetName = 'bubble_chart';
@@ -1088,8 +1088,8 @@ define([
       }
     },
 
-    resetModel() {
-      this.model.reset(false);
+    resetModel(silent = false) {
+      this.model.reset(silent);
     },
 
     // for now, called to show vis for library


### PR DESCRIPTION
To reproduce the problem, do a search, then go to "results graph". Change to the third type display (read count + citation count). Then click the close button. This will cause the component to spin forever and not able to close. Because when selected the third display, the x, y values have changed from default, then a call to reset (when click on close)  causes x and y values change back to default, causing a re-render call with no valid plot data.

This PR fixes this issue but preventing a re-render when closing.

<img width="1202" alt="Screen Shot 2021-06-10 at 6 32 29 AM" src="https://user-images.githubusercontent.com/636361/121533972-a33ed680-c9b5-11eb-9e98-91c70d177a2a.png">
