### PR TITLE
Unhide dark mode switch

### DIFF
--- a/src/js/dark-mode-switch.js
+++ b/src/js/dark-mode-switch.js
@@ -22,6 +22,7 @@ define([], function() {
 
   const init = () => {
     darkSwitch = document.getElementById('darkSwitch');
+    darkSwitch.classList.remove('hidden');
 
     // 1. check app setting
     if (localStorage.getItem('darkSwitch') !== null) {


### PR DESCRIPTION
Correspond to a fix of ADSCore for dark mode. ADSCore doesn't show dark mode switch, and when BBB is loaded, the switch should be displayed.