### PR TITLE
null-check author list on abstract page

### DIFF
--- a/src/js/widgets/abstract/widget.js
+++ b/src/js/widgets/abstract/widget.js
@@ -68,7 +68,8 @@ define([
         };
       }
       // "aff" is the name of the affiliations array that comes from solr
-      doc.aff = doc.aff || [];
+      doc.aff = Array.isArray(doc.aff) ? doc.aff : [];
+      doc.author = Array.isArray(doc.author) ? doc.author : [];
 
       // remove html-encoding from affiliations
       doc.aff = doc.aff.map(_.unescape);


### PR DESCRIPTION
To reproduce:
1. Go to: https://ui.adsabs.harvard.edu/search/p_=0&q=%22defending%20planet%20earth%22%20year%3A2010&sort=date%20desc%2C%20bibcode%20desc
2. click on first result
3. Observe the spinning wheel never stops

This bug occurs for papers with no authors