### PR TITLE
Change requirejs resource timeout from 30s -> 7s

### DIFF
--- a/src/config/discovery.config.js
+++ b/src/config/discovery.config.js
@@ -10,7 +10,7 @@ require.config({
   })(),
 
   // this will be overridden in the compiled file
-  waitSeconds: 30,
+  waitSeconds: 7,
 
   // Configuration we want to make available to modules of ths application
   // see: http://requirejs.org/docs/api.html#config-moduleconfig

--- a/src/config/shim.js
+++ b/src/config/shim.js
@@ -60,7 +60,7 @@
       // sometimes requirejs isn't ready yet, this will wait for it
       if (window.requirejs) {
         window.requirejs.config({
-          waitSeconds: 30,
+          waitSeconds: 7,
           urlArgs: version,
         });
 


### PR DESCRIPTION
7s is the default according to requirejs docs
(https://requirejs.org/docs/api.html#config-waitSeconds)