### PR TITLE
Switch library collab dropdown to <select>

### DIFF
--- a/src/js/react/LibraryCollaborators/components/ManageButton.jsx.js
+++ b/src/js/react/LibraryCollaborators/components/ManageButton.jsx.js
@@ -1,48 +1,41 @@
-define(['react', 'prop-types', 'react-bootstrap', '../constants'], function(
+define(['react', 'prop-types', '../constants'], function(
   React,
   PropTypes,
-  { DropdownButton, MenuItem },
   { Permissions }
 ) {
-  const ManageButton = ({ permission, onChange, ...otherProps }) => {
+  const ManageButton = ({
+    permission = Permissions.READ,
+    onChange,
+    ...otherProps
+  }) => {
+    const handleChange = (e) => {
+      onChange(Permissions[e.currentTarget.value.toUpperCase()]);
+    };
+
     return (
       <div>
         <span className="sr-only" id="permission-selected">
           {permission.label} permission selected
         </span>
-        <DropdownButton
-          bsStyle="default"
-          bsSize="sm"
-          style={{
-            minWidth: '120px',
-          }}
-          {...otherProps}
-          title={permission.label}
-          key={permission.id}
+        <select
+          key={`select-${permission.id}`}
           id={`manage-permission-${permission.id}`}
           aria-labelledby="permission-selected"
-          dropup
+          value={permission.id}
+          onChange={handleChange}
+          {...otherProps}
+          className="form-control"
         >
-          {Object.keys(Permissions).map((key) => {
-            const item = Permissions[key];
-
-            if (permission !== item) {
-              return (
-                <MenuItem
-                  key={item.id}
-                  eventKey={item.id}
-                  href="javascript:void(0);"
-                  onSelect={() => onChange(item)}
-                  title={item.description}
-                >
-                  {item.label}
-                </MenuItem>
-              );
-            }
-
-            return null;
-          })}
-        </DropdownButton>
+          {Object.values(Permissions).map((item) => (
+            <option
+              key={`option-${item.id}`}
+              value={item.id}
+              title={item.description}
+            >
+              {item.label}
+            </option>
+          ))}
+        </select>
       </div>
     );
   };


### PR DESCRIPTION
Was unable to figure out the root cause of the issue with the react-bootstrap dropdown.  It appears that the `onClick` event fires and toggles the dropdown, but then an overlay component that captures outside click events triggers immediately closing the menu.  So I'm not sure if some sub-dependency was updated and broke the *unsupported* react-bootstrap (Bootstrap v3) dropdown.  I doubt it'll get fixed on their end, so switching to a basic `<select>` seems like the best solution for now