### PR TITLE
Fix author list semi-colon issue

### DIFF
--- a/src/js/widgets/abstract/templates/abstract_template.html
+++ b/src/js/widgets/abstract/templates/abstract_template.html
@@ -70,8 +70,11 @@ hideCloseButton=true widgetLoadingSize="big"}} {{else if error}}
     {{/each}} 
     
     {{#if hasMoreAuthors}}
-    <li class="author extra-dots">
-      ; <a data-target="more-authors" title="Show all authors">...</a>
+    <li class="author">
+      ; 
+      <span class="extra-dots">
+        <a data-target="more-authors" title="Show all authors">...</a>
+      </span>
     </li>
     {{/if}} 
     

--- a/src/js/widgets/abstract/widget.js
+++ b/src/js/widgets/abstract/widget.js
@@ -218,7 +218,7 @@ define([
 
     toggleMoreAuthors: function() {
       this.$('.author.extra').toggleClass('hide');
-      this.$('.author.extra-dots').toggleClass('hide');
+      this.$('.author .extra-dots').toggleClass('hide');
       if (this.$('.author.extra').hasClass('hide')) {
         this.$('#toggle-more-authors').text('Show all authors');
       } else {


### PR DESCRIPTION
fixes user reported bug, which caused the author list to remove trailing
semi-colon from initial list (before expanding).  Which ran two author
names together.

Before:
<img width="422" alt="image" src="https://user-images.githubusercontent.com/6970899/144566661-8c3a46fc-be72-430c-8777-281a206fc810.png">

After:
<img width="371" alt="image" src="https://user-images.githubusercontent.com/6970899/144566722-2f3153ac-39da-4b5f-a749-bbd796bb8eba.png">
