### PR TITLE
Merge resources and related materials

### DIFF
--- a/src/js/widgets/associated/components/app.jsx.js
+++ b/src/js/widgets/associated/components/app.jsx.js
@@ -3,11 +3,12 @@ define(['underscore', 'react', 'prop-types'], function(_, React, PropTypes) {
   const styles = {
     list: {
       listStyleType: 'none',
-      marginLeft: '-10px',
-      padding: '0',
+      marginLeft: '7px',
     },
     link: {
       fontSize: '1em',
+      borderLeft: 'solid 3px grey',
+      paddingLeft: '5px',
     },
     icon: {
       fontSize: '1.4em',
@@ -28,7 +29,7 @@ define(['underscore', 'react', 'prop-types'], function(_, React, PropTypes) {
     const getLink = (item) => {
       if (item.external) {
         return (
-          <React.Fragment>
+          <>
             <a
               href={item.url}
               target="_blank"
@@ -38,7 +39,7 @@ define(['underscore', 'react', 'prop-types'], function(_, React, PropTypes) {
               {item.name}{' '}
             </a>
             <i className="fa fa-external-link" aria-hidden="true" />
-          </React.Fragment>
+          </>
         );
       }
       return (
@@ -49,29 +50,19 @@ define(['underscore', 'react', 'prop-types'], function(_, React, PropTypes) {
     };
 
     return (
-      <ul style={styles.list}>
+      <div style={styles.list} id="associated_works">
         {items.map((i) => (
-          <li key={i.id} style={styles.link}>
+          <div
+            key={i.id}
+            style={styles.link}
+            className="resources__content__link associated_work"
+          >
             {i.circular ? i.name : getLink(i)}
-          </li>
+          </div>
         ))}
-      </ul>
+      </div>
     );
   };
-
-  // container for wrapping children
-  const Container = ({ children }) => (
-    <div className="s-right-col-widget-container" style={{ padding: 10 }}>
-      {children}
-    </div>
-  );
-
-  // simple button
-  const ShowAllBtn = ({ onClick }) => (
-    <button className="btn btn-default btn-xs" onClick={(e) => onClick(e)}>
-      Show All
-    </button>
-  );
 
   // Associated Articles Widget
   class App extends React.Component {
@@ -79,17 +70,10 @@ define(['underscore', 'react', 'prop-types'], function(_, React, PropTypes) {
       super(props);
       this.state = {
         showAllBtn: false,
+        showAll: false,
         items: [],
       };
-    }
-
-    // remove the button and update the items to show everything
-    onShowAll(e) {
-      e.preventDefault();
-      this.setState({
-        showAllBtn: false,
-        items: this.props.items,
-      });
+      this.onToggleShowAll = this.onToggleShowAll.bind(this);
     }
 
     // check items length, and slice them smaller if necessary
@@ -98,23 +82,42 @@ define(['underscore', 'react', 'prop-types'], function(_, React, PropTypes) {
         this.setState({
           items: props.items.slice(0, 4),
           showAllBtn: true,
+          showAll: false,
         });
       } else {
         this.setState({ items: props.items });
       }
     }
 
+    onToggleShowAll(e) {
+      e.preventDefault();
+      this.setState((prevState) => ({
+        showAll: !prevState.showAll,
+        items: prevState.showAll
+          ? this.props.items.slice(0, 4)
+          : this.props.items,
+      }));
+    }
+
     render() {
       const { loading, handleLinkClick, hasError } = this.props;
-      const { items, showAllBtn } = this.state;
+      const { items, showAllBtn, showAll } = this.state;
 
       if (items.length > 0) {
         return (
-          <Container>
-            <Title>Associated Works ({this.props.items.length})</Title>
+          <div className="resources__container">
+            <Title>Related Materials ({this.props.items.length})</Title>
             <Links items={items} onClick={handleLinkClick} />
-            {showAllBtn && <ShowAllBtn onClick={(e) => this.onShowAll(e)} />}
-          </Container>
+            {showAllBtn && (
+              <input
+                type="button"
+                id="associated_works_btn"
+                className="btn btn-default btn-xs"
+                onClick={this.onToggleShowAll}
+                value={showAll ? 'Show Less' : 'Show All'}
+              />
+            )}
+          </div>
         );
       }
       return null;

--- a/src/js/widgets/resources/components/app.jsx.js
+++ b/src/js/widgets/resources/components/app.jsx.js
@@ -108,24 +108,28 @@ define(['underscore', 'react', 'prop-types'], function(_, React, PropTypes) {
 
   // Main View
   const App = (props) => (
-    <div className="s-right-col-widget-container" style={{ padding: 10 }}>
+    <div>
       {props.loading && <Loading />}
       {props.noResults && !props.loading && <NoResults />}
       {!props.loading && !props.hasError && (
-        <div className="resources__container">
-          {!_.isEmpty(props.fullTextSources) && (
-            <FullTextLinkList
-              items={props.fullTextSources}
-              onClick={props.onLinkClick}
-            />
-          )}
-          {!_.isEmpty(props.dataProducts) && (
-            <DataProductLinkList
-              items={props.dataProducts}
-              onClick={props.onLinkClick}
-            />
-          )}
-        </div>
+        <>
+          <div className="resources__container">
+            {!_.isEmpty(props.fullTextSources) && (
+              <FullTextLinkList
+                items={props.fullTextSources}
+                onClick={props.onLinkClick}
+              />
+            )}
+          </div>
+          <div className="resources__container">
+            {!_.isEmpty(props.dataProducts) && (
+              <DataProductLinkList
+                items={props.dataProducts}
+                onClick={props.onLinkClick}
+              />
+            )}
+          </div>
+        </>
       )}
     </div>
   );

--- a/src/js/wraps/abstract_page_manager/abstract-page-layout.html
+++ b/src/js/wraps/abstract_page_manager/abstract-page-layout.html
@@ -35,11 +35,21 @@
                     </div>
                 </div>
             </div>
-            <div data-widget="ShowResources" class="col-sm-3" id="resources-container"/>
+            <div class="col-sm-3" id="resources-container">
+                <div class="resources-container">
+                    <div class="s-right-col-widget-container" style="max-height: 50vh;
+                    overflow-y: auto;">
+                        <div data-widget="ShowResources" />
+                        <div data-widget="ShowAssociated"/>
+                    </div>
+                </div>
+            </div>
+
             <div class="s-right-col-container col-sm-3 s-right-column" id="right-col-container">
+                <div style="padding:10px;">
                 <div data-widget="ShowLibraryAdd"/>
                 <div data-widget="ShowGraphicsSidebar"/>
-                <div data-widget="ShowAssociated"/>
+                </div>
             </div>
 
             <div class="col-lg-1"></div>

--- a/src/styles/sass/ads-sass/abstract-page-widgets.scss
+++ b/src/styles/sass/ads-sass/abstract-page-widgets.scss
@@ -297,10 +297,18 @@ $sciencewise-color: rgb(179, 27, 27);
   }
 }
 
+.resources-container {
+  padding: 10px;
+  padding-top: 0;
+
+  @media (max-width: $screen-xs-max) {
+    padding: 0;
+  }
+}
+
 #resources-container {
   transition: transform 0.5s ease-in-out;
   padding-left: 0;
-  padding-right: 15px;
 
   @media (max-width: $screen-md) {
     padding-right: 0;
@@ -313,11 +321,9 @@ $sciencewise-color: rgb(179, 27, 27);
     left: 100%;
     top: 0;
     z-index: $z-index-4;
-    border-right: 1px solid $gray-lighter;
 
     &.show {
       transform: translate(-100%);
     }
   }
-  
 }

--- a/src/styles/sass/ads-sass/page-managers.scss
+++ b/src/styles/sass/ads-sass/page-managers.scss
@@ -153,6 +153,10 @@ s-search-bar-motion is applied */
 .s-abstract-content {
   #right-col-container {
     padding-left: 0;
+
+    @media screen and (min-width: $screen-xs-max) {
+      float: right;
+    }
   }
 }
 
@@ -240,6 +244,7 @@ Styles for Abstract Page
     margin: 0 0 1% 6%;
   }
 }
+
 .s-right-col-widget-title {
   margin-top: 2px;
   @extend .secondary-header;

--- a/src/styles/sass/ads-sass/widget.scss
+++ b/src/styles/sass/ads-sass/widget.scss
@@ -93,6 +93,8 @@ div[data-widget='ShowPaperExport'] .close-circle {
 .resources__container {
   background-color: white;
   position: relative;
+  padding-top: 2px;
+  padding-bottom: 2px;
 }
 
 .resources__content__title {
@@ -112,6 +114,10 @@ div[data-widget='ShowPaperExport'] .close-circle {
   margin-left: -10px;
   padding-left: 10px;
   padding-right: 8px;
+}
+
+.resources__content__link {
+  line-height: 1.75em;
 }
 
 .resources__full__list {

--- a/test/mocha/js/widgets/associated_widget.spec.js
+++ b/test/mocha/js/widgets/associated_widget.spec.js
@@ -3,51 +3,50 @@ define([
   'jquery',
   'js/widgets/associated/widget.jsx',
   'js/widgets/base/base_widget',
-  'js/bugutils/minimal_pubsub'
-], function (_, $, Widget, BaseWidget, MinPubSub) {
-
-  const mockResponse = function (n) {
+  'js/bugutils/minimal_pubsub',
+], function(_, $, Widget, BaseWidget, MinPubSub) {
+  const mockResponse = function(n) {
     return {
       links: {
-        records: _.map(_.range(n || 0), function (i) {
+        records: _.map(_.range(n || 0), function(i) {
           const bib = 'foobar' + i;
           return {
             url: '/link_gateway/' + bib + '/associated/baz',
             bibcode: bib,
-            title: 'testtest' + i
-          }
-        })
-      }
-    }
+            title: 'testtest' + i,
+          };
+        }),
+      },
+    };
   };
 
-  const init = function () {
+  const init = function() {
     this.sb = sinon.sandbox.create();
-    this.pubsub = new(MinPubSub.extend({
-      request: this.sb.stub()
+    this.pubsub = new (MinPubSub.extend({
+      request: this.sb.stub(),
     }))({
-      verbose: false
+      verbose: false,
     });
-    this.state = function (w) {
+    this.state = function(w) {
       return w.store.getState();
     };
   };
 
-  const teardown = function () {
+  const teardown = function() {
     this.sb.restore();
     this.pubsub.destroy();
     this.state = null;
     $('test-area').empty();
   };
 
-  describe('Associated Widget (associated_widget.spec.js)', function () {
-    describe('Widget Essentials', function () {
+  describe('Associated Widget (associated_widget.spec.js)', function() {
+    describe('Widget Essentials', function() {
       beforeEach(init);
       afterEach(teardown);
-      it('instance of base widget', function () {
-        expect((new Widget()) instanceof BaseWidget).to.eql(true);
+      it('instance of base widget', function() {
+        expect(new Widget() instanceof BaseWidget).to.eql(true);
       });
-      it('makes all necessary subscriptions', function (done) {
+      it('makes all necessary subscriptions', function(done) {
         const w = new Widget();
         const getPubSub = this.sb.stub(w, 'getPubSub');
         // activateWidget makes an extra subscription, we won't count that
@@ -56,7 +55,7 @@ define([
         const stubs = {
           CUSTOM_EVENT: 1,
           DELIVERING_RESPONSE: 2,
-          subscribe: this.sb.spy()
+          subscribe: this.sb.spy(),
         };
         getPubSub.returns(stubs);
         w.activate(this.pubsub.beehive);
@@ -66,16 +65,16 @@ define([
         done();
       });
     });
-    describe('Communicating with the API', function () {
+    describe('Communicating with the API', function() {
       beforeEach(init);
       afterEach(teardown);
-      it('waits for abstract to fire event before attempting to load', function (done) {
+      it('waits for abstract to fire event before attempting to load', function(done) {
         const w = new Widget();
         w.activate(this.pubsub.beehive);
         const rSpy = this.pubsub.request;
         this.pubsub.publish(this.pubsub.CUSTOM_EVENT, 'latest-abstract-data', {
           bibcode: 'foo',
-          property: ['ASSOCIATED']
+          property: ['ASSOCIATED'],
         });
         expect(rSpy.calledOnce).to.eql(true);
         expect(rSpy.args[0][0].get('target')).to.eql('resolver/foo/associated');
@@ -83,13 +82,13 @@ define([
         done();
       });
 
-      it('works if bibcode is array', function (done) {
+      it('works if bibcode is array', function(done) {
         const w = new Widget();
         w.activate(this.pubsub.beehive);
         const rSpy = this.pubsub.request;
         this.pubsub.publish(this.pubsub.CUSTOM_EVENT, 'latest-abstract-data', {
           bibcode: ['foo'],
-          property: ['ASSOCIATED']
+          property: ['ASSOCIATED'],
         });
         expect(rSpy.calledOnce).to.eql(true);
         expect(rSpy.args[0][0].get('target')).to.eql('resolver/foo/associated');
@@ -97,13 +96,13 @@ define([
         done();
       });
 
-      it('attempts to find identifier if bibcode is missing', function (done) {
+      it('attempts to find identifier if bibcode is missing', function(done) {
         const w = new Widget();
         w.activate(this.pubsub.beehive);
         const rSpy = this.pubsub.request;
         this.pubsub.publish(this.pubsub.CUSTOM_EVENT, 'latest-abstract-data', {
           identifier: ['foo', 'bar'],
-          property: ['ASSOCIATED']
+          property: ['ASSOCIATED'],
         });
         expect(rSpy.calledOnce).to.eql(true);
         expect(rSpy.args[0][0].get('target')).to.eql('resolver/foo/associated');
@@ -111,19 +110,19 @@ define([
         done();
       });
 
-      it('does not fire if associated is not present on property', function (done) {
+      it('does not fire if associated is not present on property', function(done) {
         const w = new Widget();
         w.activate(this.pubsub.beehive);
         const rSpy = this.pubsub.request;
         this.pubsub.publish(this.pubsub.CUSTOM_EVENT, 'latest-abstract-data', {
           identifier: ['foo', 'bar'],
-          property: ['REFEREED']
+          property: ['REFEREED'],
         });
         expect(rSpy.calledOnce).to.eql(false);
         done();
       });
 
-      it('does not fire if data is not present', function (done) {
+      it('does not fire if data is not present', function(done) {
         const w = new Widget();
         w.activate(this.pubsub.beehive);
         const rSpy = this.pubsub.request;
@@ -132,140 +131,151 @@ define([
         done();
       });
 
-      it('does not fire if the current bibcode equals the new one', function (done) {
+      it('does not fire if the current bibcode equals the new one', function(done) {
         const w = new Widget();
         w.activate(this.pubsub.beehive);
         const rSpy = this.pubsub.request;
         this.pubsub.publish(this.pubsub.CUSTOM_EVENT, 'latest-abstract-data', {
           bibcode: 'foo',
-          property: ['ASSOCIATED']
+          property: ['ASSOCIATED'],
         });
         expect(rSpy.calledOnce).to.eql(true);
         this.pubsub.publish(this.pubsub.CUSTOM_EVENT, 'latest-abstract-data', {
           bibcode: 'foo',
-          property: ['ASSOCIATED']
+          property: ['ASSOCIATED'],
         });
         expect(rSpy.calledTwice).to.eql(false);
         done();
       });
     });
 
-    describe('User Interface', function () {
+    describe('User Interface', function() {
       beforeEach(init);
       afterEach(teardown);
-      it('if loading, do not render', function (done) {
+      it('if loading, do not render', function(done) {
         const w = new Widget();
         const $el = $(w.view.render().$el).appendTo('#test-area');
         w.activate(this.pubsub.beehive);
         const mockQuery = {
           toJSON: _.constant({
-            q: ['bibcode:foo']
-          })
+            q: ['bibcode:foo'],
+          }),
         };
         this.pubsub.publish(this.pubsub.DISPLAY_DOCUMENTS, mockQuery);
         expect(this.state(w).ui.loading).to.eql(true);
         expect($el.find('.fa-spinner').length).to.eql(0);
-        expect($el.find('ul').length).to.eql(0);
-        expect($el.find('li').length).to.eql(0);
-        expect($el.find('button').length).to.eql(0);
+        expect($el.find('#associated_works').length).to.eql(0);
+        expect($el.find('.associated_work').length).to.eql(0);
+        expect($el.find('#associated_works_btn').length).to.eql(0);
         done();
       });
-      it('if no items, do not render', function (done) {
+      it('if no items, do not render', function(done) {
         const w = new Widget();
         const $el = $(w.view.render().$el).appendTo('#test-area');
         w.activate(this.pubsub.beehive);
         const mockQuery = {
           toJSON: _.constant({
-            q: ['bibcode:foo']
-          })
+            q: ['bibcode:foo'],
+          }),
         };
         this.pubsub.request.returns(mockResponse(0)); // no docs
         this.pubsub.publish(this.pubsub.DISPLAY_DOCUMENTS, mockQuery);
         expect($el.find('.fa-spinner').length).to.eql(0);
-        expect($el.find('ul').length).to.eql(0);
-        expect($el.find('li').length).to.eql(0);
-        expect($el.find('button').length).to.eql(0);
+        expect($el.find('#associated_works').length).to.eql(0);
+        expect($el.find('.associated_work').length).to.eql(0);
+        expect($el.find('#associated_works_btn').length).to.eql(0);
         done();
       });
-      it('if error, do not render', function (done) {
+      it('if error, do not render', function(done) {
         const w = new Widget();
         const $el = $(w.view.render().$el).appendTo('#test-area');
         w.activate(this.pubsub.beehive);
         this.pubsub.request.returns('nothing here'); // the error
         this.pubsub.publish(this.pubsub.CUSTOM_EVENT, 'latest-abstract-data', {
           bibcode: 'foo',
-          property: ['ASSOCIATED']
+          property: ['ASSOCIATED'],
         });
         expect($el.find('.fa-spinner').length).to.eql(0);
-        expect($el.find('ul').length).to.eql(0);
-        expect($el.find('li').length).to.eql(0);
-        expect($el.find('button').length).to.eql(0);
+        expect($el.find('#associated_works').length).to.eql(0);
+        expect($el.find('.associated_work').length).to.eql(0);
+        expect($el.find('#associated_works_btn').length).to.eql(0);
         done();
       });
-      it('if items count less than or equal to max, do not show button', function (done) {
+      it('if items count less than or equal to max, do not show button', function(done) {
         const w = new Widget();
         const $el = $(w.view.render().$el).appendTo('#test-area');
         w.activate(this.pubsub.beehive);
         this.pubsub.request.returns(mockResponse(3)); // 3 docs
         this.pubsub.publish(this.pubsub.CUSTOM_EVENT, 'latest-abstract-data', {
           bibcode: 'foo',
-          property: ['ASSOCIATED']
+          property: ['ASSOCIATED'],
         });
-        expect($el.find('button').length).to.eql(0);
+        expect($el.find('#associated_works_btn').length).to.eql(0);
         done();
       });
-      it('if items count greater than max do show button', function (done) {
+      it('if items count greater than max do show button', function(done) {
         const w = new Widget();
         const $el = $(w.view.render().$el).appendTo('#test-area');
         w.activate(this.pubsub.beehive);
         this.pubsub.request.returns(mockResponse(10)); // 10 docs
         this.pubsub.publish(this.pubsub.CUSTOM_EVENT, 'latest-abstract-data', {
           bibcode: 'foo',
-          property: ['ASSOCIATED']
+          property: ['ASSOCIATED'],
         });
-        expect($el.find('button').length).to.eql(1);
+        expect($el.find('#associated_works_btn').length).to.eql(1);
         done();
       });
-      it('if has more items than max, make sure to show full count at top', function (done) {
+      it('if has more items than max, make sure to show full count at top', function(done) {
         const w = new Widget();
         const $el = $(w.view.render().$el).appendTo('#test-area');
         w.activate(this.pubsub.beehive);
         this.pubsub.request.returns(mockResponse(10)); // 10 docs
         this.pubsub.publish(this.pubsub.CUSTOM_EVENT, 'latest-abstract-data', {
           bibcode: 'foo',
-          property: ['ASSOCIATED']
+          property: ['ASSOCIATED'],
         });
         expect(/\((.*)\)/.exec($el.text())[1]).to.eql('10');
         done();
       });
-      it('if button shown, only show the first (max) records', function (done) {
+      it('if button is "show all", only show the first (max) records', function(done) {
         const w = new Widget();
         const $el = $(w.view.render().$el).appendTo('#test-area');
         w.activate(this.pubsub.beehive);
         this.pubsub.request.returns(mockResponse(10)); // 10 docs
         this.pubsub.publish(this.pubsub.CUSTOM_EVENT, 'latest-abstract-data', {
           bibcode: 'foo',
-          property: ['ASSOCIATED']
+          property: ['ASSOCIATED'],
         });
-        expect($el.find('ul').length).to.eql(1);
-        expect($el.find('li').length).to.eql(4);
-        expect($el.find('button').length).to.eql(1);
+        expect($el.find('#associated_works').length).to.eql(1);
+        expect($el.find('.associated_work').length).to.eql(4);
+        expect($el.find('#associated_works_btn').prop('value')).to.eql(
+          'Show All'
+        );
         done();
       });
-      it('if button is clicked, clear button and show all records', function (done) {
+      it('if "show all" button is clicked, button is toggled and show all records', function(done) {
         const w = new Widget();
         const $el = $(w.view.render().$el).appendTo('#test-area');
         w.activate(this.pubsub.beehive);
         this.pubsub.request.returns(mockResponse(10)); // 10 docs
         this.pubsub.publish(this.pubsub.CUSTOM_EVENT, 'latest-abstract-data', {
           bibcode: 'foo',
-          property: ['ASSOCIATED']
+          property: ['ASSOCIATED'],
         });
-        $('button', $el).click();
+        $('#associated_works_btn', $el).click();
         expect($el.find('.fa-spinner').length).to.eql(0);
-        expect($el.find('ul').length).to.eql(1);
-        expect($el.find('li').length).to.eql(10);
-        expect($el.find('button').length).to.eql(0);
+        expect($el.find('#associated_works').length).to.eql(1);
+        expect($el.find('.associated_work').length).to.eql(10);
+        expect($el.find('#associated_works_btn').prop('value')).to.eql(
+          'Show Less'
+        );
+        $('#associated_works_btn', $el).click();
+        expect($el.find('.fa-spinner').length).to.eql(0);
+        expect($el.find('#associated_works').length).to.eql(1);
+        expect($el.find('.associated_work').length).to.eql(4);
+        expect($el.find('#associated_works_btn').prop('value')).to.eql(
+          'Show All'
+        );
         done();
       });
     });


### PR DESCRIPTION
* Combine the two components' UI into one container
* Use 'toggle' to show and hide long list of related materials
* Limit the height of the container, and if content is too long use scroll bar

### Normal view
![Screen Shot 2022-01-21 at 11 30 03 AM](https://user-images.githubusercontent.com/636361/150564038-b6e1fe40-3598-406f-a731-037f3e67a4b3.png)
### Long list of related materials
![Screen Shot 2022-01-21 at 11 28 00 AM](https://user-images.githubusercontent.com/636361/150563638-efea00e6-0852-4d17-9659-cd3c34d85bf7.png)
### On small screen
![Screen Shot 2022-01-21 at 5 00 02 PM](https://user-images.githubusercontent.com/636361/150605830-133e1cf4-27a3-41d0-b37f-5895cdc1351b.png)

