### PR TITLE
Fix transition error

### DIFF
--- a/src/js/apps/discovery/navigator.js
+++ b/src/js/apps/discovery/navigator.js
@@ -438,8 +438,6 @@ define([
                     }
                     defer.resolve();
                   });
-
-                app.getWidget('Library');
               });
           });
 

--- a/src/js/components/application.js
+++ b/src/js/components/application.js
@@ -816,7 +816,7 @@ define([
       }
       var thing = placeholder.get(name);
 
-      if (thing === null) {
+      if (typeof thing === 'undefined' || thing === null) {
         defer.reject(name + ' does not exist');
       } else if (thing && thing.lazyLoad) {
         // load it


### PR DESCRIPTION
After previous update where equals operator was changed from `==` to `===`, an unintended bug was introduced.

This updates the condition to remove this, and removes the offending getWidget call.