### PR TITLE
add book_author to abstract pages

### DIFF
--- a/src/js/widgets/abstract/templates/abstract_template.html
+++ b/src/js/widgets/abstract/templates/abstract_template.html
@@ -64,20 +64,20 @@ hideCloseButton=true widgetLoadingSize="big"}} {{else if error}}
             {{/compare}}
           {{/compare}}
         {{/compare}}
-      </span>    
+      </span>
       <span class="affiliation hide"> (<i>{{this.[1]}}</i>)</span>{{#if @last}}{{else}};{{/if}}
     </li>
-    {{/each}} 
-    
+    {{/each}}
+
     {{#if hasMoreAuthors}}
     <li class="author">
-      ; 
+      ;
       <span class="extra-dots">
         <a data-target="more-authors" title="Show all authors">...</a>
       </span>
     </li>
-    {{/if}} 
-    
+    {{/if}}
+
     {{#each authorAffExtra}}
     <li class="author extra hide">
       <a href="#search/q=author:{{this.[5]}}&sort=date%20desc,%20bibcode%20desc">
@@ -104,11 +104,11 @@ hideCloseButton=true widgetLoadingSize="big"}} {{else if error}}
             {{/compare}}
           {{/compare}}
         {{/compare}}
-      </span> 
+      </span>
       <span class="affiliation hide"> (<i>{{this.[1]}}</i>)</span>{{#if @last}}{{else}};{{/if}}
     </li>
     {{/each}}
-    
+
   </ul>
 </div>
 {{/if}}
@@ -129,7 +129,16 @@ hideCloseButton=true widgetLoadingSize="big"}} {{else if error}}
   <dd>
     <div id="article-publication">{{{pub_raw}}}</div>
   </dd>
-  {{/if}} {{#if formattedDate}}
+  {{/if}}
+  {{#if book_author}}
+  <dt>
+    Book Author{{#compare book_author.length 1 operator='>'}}(s){{/compare}}:
+  </dt>
+  <dd>
+    {{#each book_author}}<a href="{{href}}">{{name}}</a>{{delim}}{{/each}}
+  </dd>
+  {{/if}}
+  {{#if formattedDate}}
   <dt>Pub Date:</dt>
   <dd>{{formattedDate}}</dd>
   {{/if}} {{#if doi}}
@@ -152,11 +161,11 @@ hideCloseButton=true widgetLoadingSize="big"}} {{else if error}}
 
   <dt>Bibcode:</dt>
   <dd>
-    <button 
-    class="btn btn-link copy-btn" 
-    style="padding: 0px" 
-    id="abs-bibcode-copy" 
-    data-clipboard-text="{{bibcode}}" 
+    <button
+    class="btn btn-link copy-btn"
+    style="padding: 0px"
+    id="abs-bibcode-copy"
+    data-clipboard-text="{{bibcode}}"
     aria-label="copy bibcode">
       {{ bibcode }}
       <i

--- a/src/js/widgets/abstract/widget.js
+++ b/src/js/widgets/abstract/widget.js
@@ -158,6 +158,19 @@ define([
         doc.pubnote = _.unescape(doc.pubnote);
       }
 
+      // handle book_author field
+      if (
+        doc.book_author &&
+        Array.isArray(doc.book_author) &&
+        doc.book_author.length > 0
+      ) {
+        doc.book_author = doc.book_author.map((name, i) => ({
+          name,
+          href: `#search?q=book_author:"${name}"&sort=date%20desc,%20bibcode%20desc`,
+          delim: i < doc.book_author.length - 1 ? '; ' : '',
+        }));
+      }
+
       const ids = Array.isArray(doc.identifier)
         ? doc.identifier
         : doc.original_identifier;
@@ -346,7 +359,7 @@ define([
 
     defaultQueryArguments: {
       fl:
-        'identifier,[citations],abstract,author,orcid_pub,orcid_user,orcid_other,bibcode,citation_count,comment,doi,id,keyword,page,property,pub,pub_raw,pubdate,pubnote,read_count,title,volume',
+        'identifier,[citations],abstract,author,book_author,orcid_pub,orcid_user,orcid_other,bibcode,citation_count,comment,doi,id,keyword,page,property,pub,pub_raw,pubdate,pubnote,read_count,title,volume',
       rows: 1,
     },
 


### PR DESCRIPTION
Adds book author as a field on abstract pages
Field comes in as a list of author names, I assumed we wanted them to link to a `book_author:xxx` search.

<img width="624" alt="image" src="https://user-images.githubusercontent.com/6970899/153686846-727d0e11-390e-4866-b357-c90532eb8e5c.png">

Resolves: #2219