### PR TITLE
Fix plot transition from stacked to grouped y-axis bug

### DIFF
--- a/src/js/widgets/metrics/widget.js
+++ b/src/js/widgets/metrics/widget.js
@@ -345,8 +345,6 @@ define([
       }
 
       function transitionGrouped() {
-        y.domain([0, yGroupMax]);
-
         rect
           .transition()
           .duration(500)


### PR DESCRIPTION
Remove adjusting grouped domain (it doesn't reflect on the graph).
This makes the bars value correct.
## Stacked
![Screen Shot 2022-02-22 at 1 50 02 PM](https://user-images.githubusercontent.com/636361/155199883-6fd9d278-5fa0-4c43-a782-44e6b8a8ecec.png)
## Transition to grouped (before the fix)
![Screen Shot 2022-02-22 at 1 50 57 PM](https://user-images.githubusercontent.com/636361/155199914-12f8d7df-9be8-400d-81ac-2f28fcdffdae.png)
## Transition to grouped (fixed)
![Screen Shot 2022-02-22 at 1 50 16 PM](https://user-images.githubusercontent.com/636361/155199905-f45c21e2-e78f-4e6e-9797-90aa8922bb61.png)

