### PR TITLE
Fix the public library getting into my libraries collection bug

### DIFF
--- a/src/js/apps/discovery/navigator.js
+++ b/src/js/apps/discovery/navigator.js
@@ -417,7 +417,7 @@ define([
           .then(function() {
             app
               .getObject('LibraryController')
-              .getLibraryMetadata(data.id)
+              .getLibraryMetadata(data.id, !data.publicView)
               .done(function(metadata) {
                 data.editRecords =
                   _.contains(

--- a/src/js/components/library_controller.js
+++ b/src/js/components/library_controller.js
@@ -245,11 +245,11 @@ define([
      * about the lib with that id
      * */
 
-    getLibraryMetadata: function(id) {
+    getLibraryMetadata: function(id, merge = true) {
       // check to see if the id is even in the collection,
       // if not return fetchLibraryMetadata;
       if (id && !this.collection.get(id)) {
-        return this.fetchLibraryMetadata(id);
+        return this.fetchLibraryMetadata(id, merge);
       }
       var deferred = $.Deferred();
       var that = this;
@@ -278,7 +278,7 @@ define([
      * in case the new data hasn't been added to the collection yet
      * */
 
-    fetchLibraryMetadata: function(id) {
+    fetchLibraryMetadata: function(id, merge = true) {
       var that = this;
       if (!id) throw new Error('need to provide a library id');
       var deferred = $.Deferred();
@@ -287,7 +287,9 @@ define([
         .done(function(data) {
           deferred.resolve(data.metadata);
           // set into collection
-          that.collection.add(data.metadata, { merge: true });
+          if (merge) {
+            that.collection.add(data.metadata, { merge: true });
+          }
         })
         .fail(function(xhr) {
           deferred.reject(xhr);

--- a/src/js/widgets/library_individual/widget.js
+++ b/src/js/widgets/library_individual/widget.js
@@ -85,7 +85,7 @@ define([
 
       this.getBeeHive()
         .getObject('LibraryController')
-        .getLibraryMetadata(this.model.get('id'))
+        .getLibraryMetadata(this.model.get('id'), !this.model.get('publicView'))
         .done(done);
     },
 


### PR DESCRIPTION
`fetchLibraryMetadata(id)` merges that library into your library collection. Which is what happens when you open a public library, but not what we want to do. So my fix was to only merge if it's not from viewing a public library.