### PR TITLE
Set default search collections

### DIFF
--- a/src/js/widgets/preferences/views/application.js
+++ b/src/js/widgets/preferences/views/application.js
@@ -31,6 +31,10 @@ define([
           name: 'General',
           value: false,
         },
+        {
+          name: 'Earth Science',
+          value: false,
+        },
       ],
     },
     hideSidebars: {

--- a/src/js/widgets/search_bar/search_bar_widget.js
+++ b/src/js/widgets/search_bar/search_bar_widget.js
@@ -43,6 +43,13 @@ define([
   select2,
   oldMatcher
 ) {
+
+  /**
+   * The default databases to filter by if the user has not set any in their preferences
+   * @type {string[]}
+   */
+  const DEFAULT_DATABASES = ['Astronomy', 'Physics'];
+
   var SearchBarModel = Backbone.Model.extend({
     defaults: function() {
       return {
@@ -635,8 +642,8 @@ define([
         : this.defaultDatabases;
     },
 
-    applyDefaultFilters: function(apiQuery) {
-      var dbfilters = this.defaultDatabases || [];
+    applyDefaultFilters: function (apiQuery) {
+      const dbfilters = Array.isArray(this.defaultDatabases) && this.defaultDatabases.length > 0 ? this.defaultDatabases : DEFAULT_DATABASES;
       if (dbfilters.length > 0) {
         var fqString = '{!type=aqp v=$fq_database}';
 


### PR DESCRIPTION
- Make Astronomy and Physics the default databases for new searches
- This also adds "Earth Science" to options in preferences
