### PR TITLE
Update item-view event, improve analytics debouncing

### DIFF
--- a/src/js/widgets/abstract/widget.js
+++ b/src/js/widgets/abstract/widget.js
@@ -325,6 +325,7 @@ define([
       this._docs = {};
       this.maxAuthors = MAX_AUTHORS;
       this.isFetchingAff = false;
+      this.listenTo(this.model, 'change:abstract', this._onAbstractLoaded);
     },
 
     activate: function(beehive) {
@@ -430,11 +431,6 @@ define([
           ps.CUSTOM_EVENT,
           'update-document-title',
           this._docs[bibcode].title
-        );
-        ps.publish(
-          ps.CUSTOM_EVENT,
-          'latest-abstract-data',
-          this._docs[bibcode]
         );
       }
       this.updateState(this.STATES.IDLE);
@@ -558,6 +554,14 @@ define([
         );
       } else {
         cb();
+      }
+    },
+
+    _onAbstractLoaded: function() {
+      const doc = this.model.toJSON();
+      const ps = this.getPubSub();
+      if (ps && doc) {
+        ps.publish(ps.CUSTOM_EVENT, 'latest-abstract-data', doc);
       }
     },
 


### PR DESCRIPTION
In terms of quality of data, the current event style wasn't super useful since it spread the collections out into separate categories.

This change makes separate events for each collection found, with the `category` field being updated.  This way in GA we can count within each collection.

Also, the way debouncing was working to help keep down the number of duplicate calls wasn't sufficient in most cases.  This is because the debounce method doesn't care about whether the calls are actually duplicate just that they are being triggered in quick succession.  So we were getting some lost events and still some duplicated.

This PR sets up a simple debouncing-cache that has short-lived cache entries that are checked against incoming events to decide whether to block or not.
