### PR TITLE
Fix ORCiD Deletion

### DIFF
--- a/src/js/modules/orcid/orcid_api.js
+++ b/src/js/modules/orcid/orcid_api.js
@@ -541,12 +541,14 @@ define([
     /**
      * Delete a single work from ORCiD
      *
-     * @param {Number} putCode - putcode of work to be deleted
+     * @param {String | Number} putCode - putcode of work to be deleted
      * @returns {jQuery.Promise} - promise for the request
      */
     deleteWork: function(putCode) {
-      if (!_.isNumber(putCode)) {
-        throw new TypeError('putcode should be a number');
+      if (!putCode) {
+        return $.Deferred()
+          .reject('No Putcode found')
+          .promise();
       }
       var $dd = $.Deferred();
       this.deleteCache.push({


### PR DESCRIPTION
Removes the type check and makes it more lax.  
Also now rejects the promise instead of throwing, so that it gets properly handled inside the promise context.  
Throwing the error here does not get handled in jQuery deferreds unlike in the native Promises.

To test: 
- login to orcid
- Claim and then delete the claim, the loading indicator will show and never go away.