### PR TITLE
fix missing related materials section

### DIFF
--- a/src/js/widgets/abstract/widget.js
+++ b/src/js/widgets/abstract/widget.js
@@ -325,7 +325,7 @@ define([
       this._docs = {};
       this.maxAuthors = MAX_AUTHORS;
       this.isFetchingAff = false;
-      this.listenTo(this.model, 'change:abstract', this._onAbstractLoaded);
+      this.listenTo(this.model, 'change:bibcode', this._onAbstractLoaded);
     },
 
     activate: function(beehive) {


### PR DESCRIPTION
Related material query not fired when article has no abstract, fixed it to listen to bibcode change.
![Screenshot 2024-08-16 at 11 27 38 AM](https://github.com/user-attachments/assets/87c886c3-f731-4722-b04a-62cf86b163c2)
