### PR TITLE
SCIX-490 - Fix ORCiD Bulk Claim Issue

### DIFF
--- a/src/js/modules/orcid/extension.js
+++ b/src/js/modules/orcid/extension.js
@@ -52,8 +52,6 @@ define([
           }
         });
 
-        console.group('Orcid Action');
-        console.log(`Running action: ${action} on ${models.length} models`);
         // go through each model and grab the view for triggering
         _.forEach(
           models,
@@ -65,14 +63,12 @@ define([
               var view = this.view.children.findByModel(m);
 
               if (view) {
-                console.log('Found view for model, firing event on view', m);
                 view.trigger('OrcidAction', {
                   action: action,
                   view: view,
                   model: m,
                 });
               } else {
-                console.warn('Could not find view for model, firing event directly', m);
                 WidgetClass.prototype.onAllInternalEvents.call(this, 'childview:OrcidAction', null, {
                   action: action,
                   model: m,
@@ -81,7 +77,6 @@ define([
             }
           }, this)
         );
-        console.groupEnd('Orcid Action');
       }, this);
 
       switch (event) {

--- a/src/js/modules/orcid/extension.js
+++ b/src/js/modules/orcid/extension.js
@@ -43,10 +43,17 @@ define([
        * Trigger the action on each of the views
        */
       var orcidAction = _.bind(function(action, bibcodes) {
-        var models = _.filter(this.collection.models, function(m) {
-          return _.contains(bibcodes, m.get('bibcode'));
+        var models = [];
+
+        bibcodes.forEach(( bibcode ) => {
+          var model = this.hiddenCollection.find((m) => m.get('bibcode') === bibcode);
+          if (model) {
+            models.push(model);
+          }
         });
 
+        console.group('Orcid Action');
+        console.log(`Running action: ${action} on ${models.length} models`);
         // go through each model and grab the view for triggering
         _.forEach(
           models,
@@ -58,15 +65,23 @@ define([
               var view = this.view.children.findByModel(m);
 
               if (view) {
+                console.log('Found view for model, firing event on view', m);
                 view.trigger('OrcidAction', {
                   action: action,
                   view: view,
+                  model: m,
+                });
+              } else {
+                console.warn('Could not find view for model, firing event directly', m);
+                WidgetClass.prototype.onAllInternalEvents.call(this, 'childview:OrcidAction', null, {
+                  action: action,
                   model: m,
                 });
               }
             }
           }, this)
         );
+        console.groupEnd('Orcid Action');
       }, this);
 
       switch (event) {


### PR DESCRIPTION
There were two issues with how this bulk claim/delete calls were being made.

1. The collection from which it was getting the models to run the claims/deletes on were only the currently shown ones (i.e. active views).
  - I changed this so that it now considers all known collections (i.e. hiddenCollection)

2. It makes it's calls by sending an event through the active view and causing it to trigger an action.  This allows the UI to properly update to represent the current pending status.  However, if an active view is not found it was skipped.
  - I changed this to call the internal request method on all skipped view updates so it won't miss ones that were selected.

In the future this could be refactored further if we wish to be less coupled to the UI components.