### PR TITLE
SCIX-494 Fix module timeout issue

### DIFF
--- a/grunt/optimize-build.js
+++ b/grunt/optimize-build.js
@@ -209,7 +209,7 @@ module.exports = function(grunt) {
       const rjs = require('requirejs');
       const fullConfig = {};
       const options = this.options({
-        waitSeconds: 7,
+        waitSeconds: 30,
         logLevel: 4,
         baseUrl: 'dist',
         optimize: 'none',

--- a/src/config/discovery.config.js
+++ b/src/config/discovery.config.js
@@ -10,7 +10,7 @@ require.config({
   })(),
 
   // this will be overridden in the compiled file
-  waitSeconds: 7,
+  waitSeconds: 30,
 
   // Configuration we want to make available to modules of ths application
   // see: http://requirejs.org/docs/api.html#config-moduleconfig

--- a/src/index.html
+++ b/src/index.html
@@ -214,6 +214,7 @@
       // Session Replay
       replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
       replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
+      debug: false
     });
   });
 </script>

--- a/src/libs/require.js
+++ b/src/libs/require.js
@@ -203,7 +203,7 @@ var requirejs, require, define;
                 //Defaults. Do not set a default for map
                 //config to speed up normalize(), which
                 //will run faster if there is no default.
-                waitSeconds: 7,
+                waitSeconds: 30,
                 baseUrl: './',
                 paths: {},
                 bundles: {},


### PR DESCRIPTION
Even though the configured bundles have a timeout set of 30 seconds, and the shim sets it to `0` the initial modules are subject to a `7` second timeout (default).

This resets all of the timeouts, including the default to be 30 seconds. This should allow even slow connections to wait for pending requests.

