### PR TITLE
Add QA proxy config to nginx config

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ $ npm run test
 $ npm run test:debug
 ```
 
+### Switching API Environments
+You'll need to head to `src/config/discovery.vars.js` and change the `apiRoot` and the `orcidApiEndpoint`.
+
+For example:
+```javascript
+// apiRoot: '/dev/v1', // for the dev environment
+// apiRoot: '/v1', // for the production environment
+// apiRoot: '/qa/v1', // for the QA environment
+```
+
 ### Documentation
 
 - [How to write a widget](https://github.com/adsabs/bumblebee/blob/master/docs/how-to-write-widget.md)

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -30,6 +30,91 @@ server {
         }
     }
 
+    # Proxy for QA
+    location /qa/v1 {
+        proxy_pass https://qa.adsabs.harvard.edu/v1;
+        proxy_http_version 1.1;
+        proxy_set_header Host qa.adsabs.harvard.edu;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Support CORS preflight requests
+        if ($request_method = 'OPTIONS') {
+            return 204;
+        }
+
+        # Timeouts
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 10s;
+        proxy_read_timeout 10s;
+
+        add_header 'Access-Control-Allow-Origin' "http://localhost:8000" always;
+        add_header 'Access-Control-Allow-Credentials' 'true' always;
+        add_header 'Access-Control-Allow-Methods' '*' always;
+        add_header 'Access-Control-Allow-Headers' '*';
+
+        access_log /var/log/nginx/qa_access.log proxied_log;
+        error_log /var/log/nginx/qa_error.log debug;
+    }
+
+    # Proxy for DEV
+    location /dev/v1 {
+        proxy_pass https://devapi.adsabs.harvard.edu/v1;
+        proxy_http_version 1.1;
+        proxy_set_header Host devapi.adsabs.harvard.edu;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Support CORS preflight requests
+        if ($request_method = 'OPTIONS') {
+            return 204;
+        }
+
+        # Timeouts
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 10s;
+        proxy_read_timeout 10s;
+
+        add_header 'Access-Control-Allow-Origin' "http://localhost:8000" always;
+        add_header 'Access-Control-Allow-Credentials' 'true' always;
+        add_header 'Access-Control-Allow-Methods' '*' always;
+        add_header 'Access-Control-Allow-Headers' '*';
+
+        access_log /var/log/nginx/dev_access.log proxied_log;
+        error_log /var/log/nginx/dev_error.log debug;
+    }
+
+    # Proxy for PROD
+    location /v1 {
+        proxy_pass https://api.adsabs.harvard.edu/v1;
+        proxy_http_version 1.1;
+        proxy_set_header Host api.adsabs.harvard.edu;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Support CORS preflight requests
+        if ($request_method = 'OPTIONS') {
+            return 204;
+        }
+
+        # Timeouts
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 10s;
+        proxy_read_timeout 10s;
+
+        add_header 'Access-Control-Allow-Origin' "http://localhost:8000" always;
+        add_header 'Access-Control-Allow-Credentials' 'true' always;
+        add_header 'Access-Control-Allow-Methods' '*' always;
+        add_header 'Access-Control-Allow-Headers' '*';
+
+        access_log /var/log/nginx/prod_access.log proxied_log;
+        error_log /var/log/nginx/prod_error.log debug;
+    }
+
+
     # Additional paths with CORS headers
     location ~ ^/(search|abs|user|index|feedback|execute-query|public-libraries|classic-form|paper-form)/ {
         root /app/production;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -25,6 +25,7 @@ http {
   gzip_min_length 500;
 
   log_format main '{"remote_addr": "$remote_addr","X-Original-Forwarded-For": "$proxy_add_x_forwarded_for","X-Forwarded-For": "$remote_user","time_local": "$time_local","request": "$request","status": "$status","body_bytes_sent": "$body_bytes_sent","http_referer": "$http_referer","http_user_agent": "$http_user_agent","request_length": "$request_length","Authorization": "$http_Authorization","url-path": "$document_uri","query-string": "$query_string","X-Original-Uri": "$request_uri" ,"http_cookie": "$http_cookie","X-Amzn-Trace-Id": "$http_x_amzn_trace_id"}';
+  log_format proxied_log '$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "Proxied URL: $proxy_host$request_uri"';
   access_log /var/log/nginx/access.log main;
   error_log /var/log/nginx/error.log;
 

--- a/src/config/discovery.vars.js.default
+++ b/src/config/discovery.vars.js.default
@@ -16,7 +16,7 @@ define([], function() {
      * of 'http://localhost:8000' you can also use the production
      * API of //api.adsabs.harvard.edu/v1/
      */
-    apiRoot: '//api.adsabs.harvard.edu/v1/',
+    apiRoot: '/dev/v1/',
 
     /**
      * The url for orcid proxy, which adds the application token and
@@ -90,7 +90,7 @@ define([], function() {
      */
        orcidClientId: 'APP-P5ANJTQRRTMA6GXZ',
        orcidLoginEndpoint: 'http://sandbox.orcid.org/oauth/authorize',
-       orcidApiEndpoint: '//ecs-staging-elb-2044121877.us-east-1.elb.amazonaws.com/v1/orcid',
+       orcidApiEndpoint: '/dev/v1/orcid/',
 
 
 


### PR DESCRIPTION
Adds proxy configs for the APIs into the nginx config.  
This avoids the CORs issues that crop up during development