### PR TITLE
add process env var back in

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -225,6 +225,9 @@
       crossorigin="anonymous"
     ></script>
     <script>
+      // Set the environment variable
+      window.process = { env: { NODE_ENV: window.ENV ?? 'production' } };
+
       window.getSentry = (cb, errCb) => {
         if (typeof errCb === 'function') {
           errCb.call(null, new Error('Failed to get Sentry'));


### PR DESCRIPTION
This was removed as part of the sentry change earlier and broke the feedback forms