### PR TITLE
Remove 'noreferrer' from most links

### DIFF
--- a/src/js/apps/discovery/main.js
+++ b/src/js/apps/discovery/main.js
@@ -195,10 +195,10 @@ define(['config/discovery.config', 'module'], function(config, module) {
             const msg = `
               <p>
                 You are using a proxied version of ADS, we recommend you switch to the regular non-proxied URL:
-                <a href="${url}${location.pathname}" rel="noopener noreferrer">${url}</a></p>
+                <a href="${url}${location.pathname}" rel="noopener">${url}</a></p>
               <p>
                 Configure authenticated access to publisher content via the Library Link Server in your account
-                <a href="${url}/user/settings/librarylink" rel="noopener noreferrer">preferences</a>.
+                <a href="${url}/user/settings/librarylink" rel="noopener">preferences</a>.
               </p>
             `;
 

--- a/src/js/widgets/abstract/templates/abstract_template.html
+++ b/src/js/widgets/abstract/templates/abstract_template.html
@@ -208,7 +208,7 @@ hideCloseButton=true widgetLoadingSize="big"}} {{else if error}}
         data-target="DOI"
         href="{{href}}"
         target="_blank"
-        rel="noreferrer noopener"
+        rel="noopener"
       >{{doi}}</a
       >
       <i class="fa fa-external-link" aria-hidden="true"></i>
@@ -223,7 +223,7 @@ hideCloseButton=true widgetLoadingSize="big"}} {{else if error}}
         data-target="arXiv"
         href="{{arxiv.href}}"
         target="_blank"
-        rel="noreferrer noopener"
+        rel="noopener"
       >{{arxiv.id}}</a
       >
       <i class="fa fa-external-link" aria-hidden="true"></i>

--- a/src/js/widgets/associated/components/app.jsx.js
+++ b/src/js/widgets/associated/components/app.jsx.js
@@ -33,7 +33,7 @@ define(['underscore', 'react', 'prop-types'], function(_, React, PropTypes) {
             <a
               href={item.url}
               target="_blank"
-              rel="noreferrer noopener"
+              rel="noopener"
               onClick={() => onClick(item)}
             >
               {item.name}{' '}

--- a/src/js/widgets/dropdown-menu/templates/dropdown-item.html
+++ b/src/js/widgets/dropdown-menu/templates/dropdown-item.html
@@ -3,7 +3,7 @@
 <li role="presentation" class="dropdown-header no-hover-style">
   {{section}}
   {{#if icon}}
-    <a href="{{icon.href}}" class="pull-right dropdown-helper-icon" target="_blank" rel="noreferrer noopener" title="{{icon.description}}"><i class="{{icon.class}}"></i></a>
+    <a href="{{icon.href}}" class="pull-right dropdown-helper-icon" target="_blank" rel="noopener" title="{{icon.description}}"><i class="{{icon.class}}"></i></a>
   {{/if}}
 </li>
 {{else}}

--- a/src/js/widgets/export/components/Setup.jsx.js
+++ b/src/js/widgets/export/components/Setup.jsx.js
@@ -66,7 +66,7 @@ define(['react', 'prop-types'], function(React, ReactPropTypes) {
                     <a
                       title="Get Help With ADS Custom Format Syntax"
                       target="_blank"
-                      rel="noreferrer noopener"
+                      rel="noopener"
                       href="/help/actions/export"
                     >
                       <i
@@ -112,7 +112,7 @@ define(['react', 'prop-types'], function(React, ReactPropTypes) {
                     <a
                       title="Get Help With ADS Custom Format Syntax"
                       target="_blank"
-                      rel="noreferrer noopener"
+                      rel="noopener"
                       href="/help/actions/export"
                     >
                       <i

--- a/src/js/widgets/export/templates/classic_submit_form.html
+++ b/src/js/widgets/export/templates/classic_submit_form.html
@@ -1,4 +1,4 @@
-<form action="http://adsabs.harvard.edu/cgi-bin/nph-abs_connect" target="_blank" rel="noreferrer noopener" method="post" class="hidden">
+<form action="http://adsabs.harvard.edu/cgi-bin/nph-abs_connect" target="_blank" rel="noopener" method="post" class="hidden">
     <input type="hidden" name="nr_to_return" value="{{exportLimit}}"/>
     {{#each bibcode}}
     <input type="hidden" name="bibcode" value="{{this}}"/>

--- a/src/js/widgets/footer/footer.html
+++ b/src/js/widgets/footer/footer.html
@@ -14,17 +14,17 @@
       </div>
       <div class="__footer_brand_logos">
         <div class="logo1">
-          <a href="http://www.si.edu" target="_blank" rel="noreferrer noopener">
+          <a href="http://www.si.edu" target="_blank" rel="noopener">
             <img id="smithsonian-logo" src="/styles/img/smithsonian-logo.svg" alt="Smithsonian logo" />
           </a>
         </div>
         <div class="logo2">
-          <a href="https://www.cfa.harvard.edu/" target="_blank" rel="noreferrer noopener">
+          <a href="https://www.cfa.harvard.edu/" target="_blank" rel="noopener">
             <img src="/styles/img/cfa.png" alt="Harvard Center for Astrophysics logo" id="cfa-logo" />
           </a>
         </div>
         <div class="logo3">
-          <a href="http://www.nasa.gov" target="_blank" rel="noreferrer noopener">
+          <a href="http://www.nasa.gov" target="_blank" rel="noopener">
             <img src="/styles/img/nasa-partner.svg" alt="NASA logo" id="nasa-logo" />
           </a>
         </div>
@@ -41,27 +41,27 @@
       </div>
       <ul class="__footer_links">
         <li>
-          <a href="/about/" target="_blank" rel="noreferrer noopener">
+          <a href="/about/" target="_blank" rel="noopener">
             <i class="fa fa-question-circle" aria-hidden="true"></i> About ADS
           </a>
         </li>
         <li>
-          <a href="/help/" target="_blank" rel="noreferrer noopener">
+          <a href="/help/" target="_blank" rel="noopener">
             <i class="fa fa-info-circle" aria-hidden="true"></i> ADS Help
           </a>
         </li>
         <li>
-          <a href="/help/whats_new/" target="_blank" rel="noreferrer noopener">
+          <a href="/help/whats_new/" target="_blank" rel="noopener">
             <i class="fa fa-bullhorn" aria-hidden="true"></i> What's New
           </a>
         </li>
         <li>
-          <a href="/about/careers/" target="_blank" rel="noreferrer noopener">
+          <a href="/about/careers/" target="_blank" rel="noopener">
             <i class="fa fa-group" aria-hidden="true"></i> Careers@ADS
           </a>
         </li>
         <li>
-          <a href="/help/accessibility/" target="_blank" rel="noreferrer noopener">
+          <a href="/help/accessibility/" target="_blank" rel="noopener">
             <i class="fa fa-universal-access" aria-hidden="true"></i>
             Web Accessibility Policy
           </a>
@@ -74,12 +74,12 @@
       </div>
       <ul class="__footer_links">
         <li>
-          <a href="https://twitter.com/adsabs" target="_blank" rel="noreferrer noopener">
+          <a href="https://twitter.com/adsabs" target="_blank" rel="noopener">
             <i class="fa fa-twitter" aria-hidden="true"></i> @adsabs
           </a>
         </li>
         <li>
-          <a href="/blog/" target="_blank" rel="noreferrer noopener">
+          <a href="/blog/" target="_blank" rel="noopener">
             <i class="fa fa-newspaper-o" aria-hidden="true"></i> ADS Blog
           </a>
         </li>
@@ -94,19 +94,19 @@
           <a href="/core">Switch to basic HTML</a>
         </li>
         <li>
-          <a href="/help/privacy/" target="_blank" rel="noreferrer noopener">Privacy Policy</a>
+          <a href="/help/privacy/" target="_blank" rel="noopener">Privacy Policy</a>
         </li>
         <li>
-          <a href="/help/terms" target="_blank" rel="noreferrer noopener">Terms of Use</a>
+          <a href="/help/terms" target="_blank" rel="noopener">Terms of Use</a>
         </li>
         <li>
-          <a href="https://www.cfa.harvard.edu/sao" target="_blank" rel="noreferrer noopener">Smithsonian Astrophysical Observatory</a>
+          <a href="https://www.cfa.harvard.edu/sao" target="_blank" rel="noopener">Smithsonian Astrophysical Observatory</a>
         </li>
         <li>
-          <a href="https://www.si.edu" target="_blank" rel="noreferrer noopener">Smithsonian Institution</a>
+          <a href="https://www.si.edu" target="_blank" rel="noopener">Smithsonian Institution</a>
         </li>
         <li>
-          <a href="https://www.nasa.gov" target="_blank" rel="noreferrer noopener">NASA</a>
+          <a href="https://www.nasa.gov" target="_blank" rel="noopener">NASA</a>
         </li>
       </ul>
     </div>

--- a/src/js/widgets/graphics/templates/grid.html
+++ b/src/js/widgets/graphics/templates/grid.html
@@ -11,7 +11,7 @@
 <div class="s-grid-container">
     <p><i>{{{linkSentence}}}</i></p>
     {{#each graphics}}
-  <a href="{{this.highres}}" target="_blank" rel="noreferrer noopener" class="graphics-external-link">
+  <a href="{{this.highres}}" target="_blank" rel="noopener" class="graphics-external-link">
         <div class="grid-cell">
             {{#if this.interactive}}
             <div class="graphics_ribbon--interactive">

--- a/src/js/widgets/library_individual/templates/make-public.html
+++ b/src/js/widgets/library_individual/templates/make-public.html
@@ -21,7 +21,7 @@
             The public address of this library is
             <a
               target="_blank"
-              rel="noreferrer noopener"
+              rel="noopener"
               href="https://ui.adsabs.harvard.edu/public-libraries/{{id}}"
               >https://ui.adsabs.harvard.edu/public-libraries/{{id}}</a
             >
@@ -68,7 +68,7 @@
             The public address of this library is
             <a
               target="_blank"
-              rel="noreferrer noopener"
+              rel="noopener"
               href="https://ui.adsabs.harvard.edu/public-libraries/{{id}}"
               >https://ui.adsabs.harvard.edu/public-libraries/{{id}}</a
             >

--- a/src/js/widgets/library_list/templates/library-container.html
+++ b/src/js/widgets/library_list/templates/library-container.html
@@ -1,6 +1,6 @@
 {{#compare numMissing 0 operator=">"}}
 <div class="alert alert-warning s-library-missing-record print-hidden">Displaying {{numFound}} out of {{numRecords}} records due to {{numMissing}} unmatched or merged record{{#compare numMissing 1 operator=">"}}s{{/compare}}
-  <a href="/help/faq/#ads-libraries" target="_blank" rel="noopener noreferrer"><i class="fa fa-question-circle alert-warning" title="See help page" style="margin: 5px"></i></a>
+  <a href="/help/faq/#ads-libraries" target="_blank" rel="noopener"><i class="fa fa-question-circle alert-warning" title="See help page" style="margin: 5px"></i></a>
 </div>
 {{/compare}}
 <div class="s-library-list">

--- a/src/js/widgets/library_list/templates/library-item-edit.html
+++ b/src/js/widgets/library_list/templates/library-item-edit.html
@@ -41,7 +41,7 @@
 
                         {{#each links.text}}
                         <li><a {{#if this.openAccess}} class="s-open-access" {{/if}} href="{{this.url}}"
-                                target="_blank" rel="noreferrer noopener" aria-label="open access link">
+                                target="_blank" rel="noopener" aria-label="open access link">
                               {{this.name}}{{#if (and ../publisher (startsWith this.rawType "PUB_")) }}&nbsp;{{this.type}}{{/if}}</a>
                         </li>
                         {{/each}}
@@ -75,7 +75,7 @@
                     <ul class="hidden list-unstyled link-details s-link-details" role="menu">
 
                         {{#each links.data}}
-                        <li><a {{#if this.openAccess}}class="s-open-access"{{/if}} href="{{this.url}}" target="_blank" rel="noreferrer noopener"
+                        <li><a {{#if this.openAccess}}class="s-open-access"{{/if}} href="{{this.url}}" target="_blank" rel="noopener"
                             >{{this.name}}</a></li>
                         {{/each}}
                     </ul>

--- a/src/js/widgets/list_of_things/templates/empty-view-template.html
+++ b/src/js/widgets/list_of_things/templates/empty-view-template.html
@@ -5,7 +5,7 @@
     Using the ADS classic query translator? view the
     <a
       href="/help/faq/#classic-search-translator"
-      rel="noreferrer noopener"
+      rel="noopener"
       target="_blank"
       >docs</a
     >.
@@ -25,7 +25,7 @@
       <a
         href="/help/search/search-syntax"
         target="_blank"
-        rel="noreferrer noopener"
+        rel="noopener"
         >Read our help pages</a
       >
     </li>

--- a/src/js/widgets/list_of_things/templates/item-template.html
+++ b/src/js/widgets/list_of_things/templates/item-template.html
@@ -63,7 +63,7 @@
                             {{#each links.text}}
                             <li>
                               <a {{#if this.openAccess}} class="s-open-access"{{/if}} href="{{this.url}}" data-ftl="{{this.name}}"
-                                target="_blank" rel="noreferrer noopener" aria-label="open access link">
+                                target="_blank" rel="noopener" aria-label="open access link">
                               {{this.name}}{{#if (and ../publisher (startsWith this.rawType "PUB_")) }}&nbsp;{{this.type}}{{/if}}
                               </a>
                             </li>
@@ -122,7 +122,7 @@
                 <ul class="hidden list-unstyled link-details s-link-details" role="menu">
 
                     {{#each links.data}}
-                    <li><a {{#if this.openAccess}} class="s-open-access"{{/if}} href="{{this.url}}" data-datalink="{{this.name}}" target="_blank" rel="noreferrer noopener"
+                    <li><a {{#if this.openAccess}} class="s-open-access"{{/if}} href="{{this.url}}" data-datalink="{{this.name}}" target="_blank" rel="noopener"
                         >{{this.name}}</a></li>
                     {{/each}}
                 </ul>

--- a/src/js/widgets/navbar/template/navbar.html
+++ b/src/js/widgets/navbar/template/navbar.html
@@ -153,12 +153,12 @@
                       <i class="fa fa-question-circle about-page-icon" aria-hidden="true"></i> About <span class="caret"></span>
                     </button>
                     <ul class="dropdown-menu" role="menu">
-                        <li> <a href="/about/" target="_blank" rel="noreferrer noopener"> <i class="fa fa-question-circle" aria-hidden="true"></i> About ADS </a></li>
-                        <li> <a href="/help/whats_new/" target="_blank" rel="noreferrer noopener"> <i class="fa fa-bullhorn" aria-hidden="true"></i> What's New </a></li>
-                        <li> <a href="/blog/" target="_blank" rel="noreferrer noopener"> <i class="fa fa-newspaper-o" aria-hidden="true"></i> ADS Blog </a></li>
-                        <li> <a href="/help/" target="_blank" rel="noreferrer noopener"> <i class="fa fa-info-circle" aria-hidden="true"></i> ADS Help Pages </a></li>
-						            <li> <a href="/help/legacy/" target="_blank" rel="noreferrer noopener"> <i class="fa fa-archive" aria-hidden="true"></i> ADS Legacy Services </a></li>
-                        <li> <a href="/about/careers/" target="_blank" rel="noreferrer noopener"> <i class="fa fa-group" aria-hidden="true"></i> Careers@ADS </a></li>
+                        <li> <a href="/about/" target="_blank" rel="noopener"> <i class="fa fa-question-circle" aria-hidden="true"></i> About ADS </a></li>
+                        <li> <a href="/help/whats_new/" target="_blank" rel="noopener"> <i class="fa fa-bullhorn" aria-hidden="true"></i> What's New </a></li>
+                        <li> <a href="/blog/" target="_blank" rel="noopener"> <i class="fa fa-newspaper-o" aria-hidden="true"></i> ADS Blog </a></li>
+                        <li> <a href="/help/" target="_blank" rel="noopener"> <i class="fa fa-info-circle" aria-hidden="true"></i> ADS Help Pages </a></li>
+						            <li> <a href="/help/legacy/" target="_blank" rel="noopener"> <i class="fa fa-archive" aria-hidden="true"></i> ADS Legacy Services </a></li>
+                        <li> <a href="/about/careers/" target="_blank" rel="noopener"> <i class="fa fa-group" aria-hidden="true"></i> Careers@ADS </a></li>
                     </ul>
                 </li>
 

--- a/src/js/widgets/network_vis/templates/author-details-template.html
+++ b/src/js/widgets/network_vis/templates/author-details-template.html
@@ -26,7 +26,7 @@
   <ul class="list-unstyled">
     {{#each papers}}
     <li>
-      <a href="#abs/{{bibcode}}" target="_blank" rel="noreferrer noopener"
+      <a href="#abs/{{bibcode}}" target="_blank" rel="noopener"
         ><b>{{title}}</b></a
       >
       {{#if citation_count}}

--- a/src/js/widgets/network_vis/templates/default-details-template.html
+++ b/src/js/widgets/network_vis/templates/default-details-template.html
@@ -12,7 +12,7 @@
 
 <br/>
 <div>
-    <a href="/help/actions/visualize#author-network" target="_blank" rel="noreferrer noopener">Learn more about the author network.</a>
+    <a href="/help/actions/visualize#author-network" target="_blank" rel="noopener">Learn more about the author network.</a>
 </div>
 
 
@@ -51,6 +51,6 @@
 
 <br/>
 <p>Click on a group to learn more about the papers within the group, as well as the papers cited by those papers.</p>
-<a href="/help/actions/visualize#paper-network" target="_blank" rel="noreferrer noopener">Learn more about the paper network.</a>
+<a href="/help/actions/visualize#paper-network" target="_blank" rel="noopener">Learn more about the paper network.</a>
 
 {{/compare}}

--- a/src/js/widgets/network_vis/templates/group-details-template.html
+++ b/src/js/widgets/network_vis/templates/group-details-template.html
@@ -24,7 +24,7 @@
         href="#abs/{{bibcode}}"
         data-bypass=""
         target="_blank"
-        rel="noreferrer noopener"
+        rel="noopener"
         ><b>{{title}}</b></a
       >
       {{#if citation_count}}

--- a/src/js/widgets/paper_search_form/form.html
+++ b/src/js/widgets/paper_search_form/form.html
@@ -8,7 +8,7 @@
           <a
             href="http://adsabs.harvard.edu/abs_doc/journal_abbr.html"
             target="_blank"
-            rel="noreferrer noopener"
+            rel="noopener"
             >A full list is available here.</a
           >
           The input field below will autocomplete on the 1,000 most popular

--- a/src/js/widgets/preferences/templates/export.html
+++ b/src/js/widgets/preferences/templates/export.html
@@ -49,7 +49,7 @@
                   Edit your saved custom formats
                 </p>
                 <p>
-                  Check out our <a href="/help/actions/export" rel="noreferrer noopener" target="_blank">docs</a> for more information.
+                  Check out our <a href="/help/actions/export" rel="noopener" target="_blank">docs</a> for more information.
                 </p>
               </div>
             </div>
@@ -132,7 +132,7 @@
             <div class="collapse" id="collapsebibtexKeyFormat">
               <div class="card card-body">
                 <p>
-                  Select the default key format when exporting in BibTeX (<a href="/help/actions/export" rel="noreferrer noopener" target="_blank">Learn More <i
+                  Select the default key format when exporting in BibTeX (<a href="/help/actions/export" rel="noopener" target="_blank">Learn More <i
                       class="fa fa-external-link" aria-hidden="true"></i></a>)
                   <table class="table">
                     <caption>
@@ -281,7 +281,7 @@
             <div class="collapse" id="collapsebibtexABSKeyFormat">
               <div class="card card-body">
                 <p>
-                  Select the default key format when exporting in BibTeX ABS (<a href="/help/actions/export" rel="noreferrer noopener" target="_blank">Learn More <i
+                  Select the default key format when exporting in BibTeX ABS (<a href="/help/actions/export" rel="noopener" target="_blank">Learn More <i
                       class="fa fa-external-link" aria-hidden="true"></i></a>)
                   <table class="table">
                     <caption>

--- a/src/js/widgets/preferences/templates/openurl.html
+++ b/src/js/widgets/preferences/templates/openurl.html
@@ -95,7 +95,7 @@
             <p>
               If you find your institution in the above list, please select it so that we
               can generate the appropriate links for you. For more information,
-              please visit our <a rel="noreferrer noopener" target="_blank" href="/help/userpreferences/library-servers">Help Docs.</a>
+              please visit our <a rel="noopener" target="_blank" href="/help/userpreferences/library-servers">Help Docs.</a>
             </p>
           </div>
           <div class="col-md-4"></div>

--- a/src/js/widgets/resources/components/app.jsx.js
+++ b/src/js/widgets/resources/components/app.jsx.js
@@ -28,7 +28,7 @@ define(['underscore', 'react', 'prop-types'], function(_, React, PropTypes) {
                 <a
                   href={g.url}
                   target="_blank"
-                  rel="noreferrer noopener"
+                  rel="noopener"
                   onClick={() => onClick('ftl', g)}
                   title={`${g.description} ${
                     g.open
@@ -87,7 +87,7 @@ define(['underscore', 'react', 'prop-types'], function(_, React, PropTypes) {
             key={item.name}
             href={item.url}
             target="_blank"
-            rel="noreferrer noopener"
+            rel="noopener"
             onClick={() => onClick('data', item)}
             title={item.description}
             className="resources__content__link"

--- a/src/js/widgets/wordcloud/templates/wordcloud-template.html
+++ b/src/js/widgets/wordcloud/templates/wordcloud-template.html
@@ -17,7 +17,7 @@
         This visualization shows you unique and frequent words from
         a set of the top 100 search results.
         <br/>
-        <b><a href="/help/actions/visualize#word-cloud" target="_blank" rel="noreferrer noopener">
+        <b><a href="/help/actions/visualize#word-cloud" target="_blank" rel="noopener">
             Learn more about the concept cloud</a></b>
         <br/>
         <br/>
@@ -57,5 +57,5 @@
     </div>
     {{/if}}
 </div>
-<a id="download-link" class="hidden"></a> 
+<a id="download-link" class="hidden"></a>
 </div>

--- a/src/js/wraps/discovery_mediator.js
+++ b/src/js/wraps/discovery_mediator.js
@@ -261,7 +261,7 @@ define([
                 msg:
                   (msg || 'There is something wrong with the query:') +
                   '<b><a href="#">&nbsp;&nbsp;Try looking at the search examples on the home page</a></b> ' +
-                  ' or <b><a href="/help/search/search-syntax" target="_blank" rel="noreferrer noopener">reading our help page</a>.</b>',
+                  ' or <b><a href="/help/search/search-syntax" target="_blank" rel="noopener">reading our help page</a>.</b>',
                 events: {
                   'click a#query-assistant': 'query-assistant',
                 },

--- a/src/js/wraps/libraries_page_manager/libraries-nav.html
+++ b/src/js/wraps/libraries_page_manager/libraries-nav.html
@@ -14,7 +14,7 @@
     <a
       href="/help/libraries/creating-libraries"
       target="_blank"
-      rel="noreferrer noopener"
+      rel="noopener"
     >
       <i class="fa fa-info-circle" aria-hidden="true"></i>&nbsp;&nbsp;Library
       Help

--- a/src/js/wraps/templates/paper-network-data.html
+++ b/src/js/wraps/templates/paper-network-data.html
@@ -43,7 +43,7 @@
             href="#abs/{{this.node_name}}"
             data-bypass
             target="_blank"
-            rel="noreferrer noopener"
+            rel="noopener"
             ><b>{{this.title}}</b></a
           >; <i>{{this.first_author}}</i>
           ({{this.citation_count}} citations)
@@ -73,7 +73,7 @@
             href="#abs/{{this.bibcode}}"
             data-bypass
             target="_blank"
-            rel="noreferrer noopener"
+            rel="noopener"
             >{{this.bibcode}}</a
           >
           (cited by {{this.percent}}% of papers in this group)


### PR DESCRIPTION
* This is so that the browser doesn't strip the referrer header from request