### PR TITLE
feat(api): Setup API Proxy config for development

### DIFF
--- a/nginx/compose.yml
+++ b/nginx/compose.yml
@@ -15,5 +15,8 @@ services:
     environment:
       ENVIRONMENT: "${ENV:-production}"
       NGINX_ENTRYPOINT_QUIET_LOGS: 1
+      DEV_API_URL: "https://devapi.adsabs.harvard.edu/v1"
+      QA_API_URL: "https://qa.adsabs.harvard.edu/v1"
+      PROD_API_URL: "https://api.adsabs.harvard.edu/v1"
     healthcheck:
       test: 'curl --fail http://localhost:8000/ready || exit 1'

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,60 +1,150 @@
 server {
-    listen 80;
-    server_name localhost;
+  listen 80;
+  server_name localhost;
 
-    # Root location with CORS and ENV variable for scripts
-    location / {
-        add_header 'Access-Control-Allow-Origin' "http://localhost:8000" always;
-        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-        add_header 'Access-Control-Allow-Headers' 'Content-Type';
+  root /app/production;
+  index index.html;
 
-        root /app/production;
-        index index.html;
+  # -------- SPA catch-all (everything that's NOT /api-*) --------
+  location / {
+    # Serve file if it exists, otherwise hand back the SPA
+    try_files $uri $uri/ /index.html;
 
-        # Inject environment variable as a script tag in the HTML
-        sub_filter '</head>' '<script>window.ENV="${ENVIRONMENT}";</script></head>';
-        sub_filter_once on;
+    # CORS (dev)
+    add_header 'Access-Control-Allow-Origin' "http://localhost:8000" always;
+    add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+    add_header 'Access-Control-Allow-Headers' 'Content-Type';
 
-        include /etc/nginx/mime.types;
-        expires 6M;
+    # Inject ENV only into HTML responses
+    sub_filter '</head>' '<script>window.ENV="${ENVIRONMENT}";</script></head>';
+    sub_filter_once on;
 
-        # Prevent caching of specific files
-        location ^~ /discovery.config {
-            expires 0;
-            add_header Cache-Control "public";
-        }
+    # (Optional) long cache for static assets the SPA links to
+    # You can keep global caching via headers on the files themselves if preferred
+  }
 
-        location ^~ /index {
-            expires 0;
-            add_header Cache-Control "public";
-        }
+  # Static asset hard cache (optional but recommended)
+  location ~* \.(?:js|css|png|jpg|jpeg|gif|svg|ico|woff2?)$ {
+    try_files $uri =404;
+    access_log off;
+    expires 6M;
+    add_header Cache-Control "public, max-age=15552000, immutable";
+  }
+
+  # Files we don’t want cached
+  location = /discovery.config { expires 0; add_header Cache-Control "public"; }
+  location = /index         { expires 0; add_header Cache-Control "public"; }
+  location = /index.html    { expires 0; add_header Cache-Control "no-store, must-revalidate"; }
+
+  # Health checks
+  location = /ready { access_log off; return 200 '{"ready": true}'; }
+  location = /alive { access_log off; return 200 '{"alive": true}'; }
+
+  # ---------- API PROXIES ----------
+
+  # DEV: /api-dev/* -> $DEV_API_URL/*
+  location ^~ /api-dev/ {
+    if ($request_method = OPTIONS) {
+      add_header 'Access-Control-Allow-Origin'      $cors_allow_origin always;
+      add_header 'Access-Control-Allow-Credentials' $cors_allow_credentials always;
+      add_header 'Access-Control-Allow-Methods'     'GET,POST,PUT,PATCH,DELETE,OPTIONS' always;
+      add_header 'Access-Control-Allow-Headers'     'Authorization,Content-Type,X-Requested-With' always;
+      add_header 'Access-Control-Max-Age'           86400 always;
+      return 204;
     }
+    add_header 'Access-Control-Allow-Origin'      $cors_allow_origin always;
+    add_header 'Access-Control-Allow-Credentials' $cors_allow_credentials always;
 
-    # Additional paths with CORS headers
-    location ~ ^/(search|abs|user|index|feedback|execute-query|public-libraries|classic-form|paper-form)/ {
-        root /app/production;
-        index index.html;
-        include /etc/nginx/mime.types;
-        try_files $uri /index.html;
+    rewrite ^/api-dev(?<rest>/.*)$ $rest break;
 
-        add_header 'Access-Control-Allow-Origin' "http://localhost:8000" always;
-        add_header 'Access-Control-Allow-Credentials' 'true' always;
-        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
-        add_header 'Access-Control-Allow-Headers' 'Content-Type';
+    set $full_upstream_url "$DEV_API_URL$rest$is_args$args";
+    access_log /var/log/nginx/access.log proxylog;
 
-        # Inject environment variable as a script tag in the HTML
-        sub_filter '</head>' '<script>window.ENV="${ENVIRONMENT}";</script></head>';
-        sub_filter_once on;
+    proxy_pass $DEV_API_URL$rest$is_args$args;
+    proxy_http_version 1.1;
+    proxy_set_header Host              $proxy_host;   # keep SNI/Host aligned with upstream
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    proxy_connect_timeout 10s;
+    proxy_send_timeout    60s;
+    proxy_read_timeout    60s;
+
+    proxy_hide_header Access-Control-Allow-Origin;
+    proxy_hide_header Access-Control-Allow-Credentials;
+    proxy_hide_header Access-Control-Allow-Headers;
+    proxy_hide_header Access-Control-Allow-Methods;
+  }
+
+  # QA: /api-qa/* -> $QA_API_URL/*
+  location ^~ /api-qa/ {
+    if ($request_method = OPTIONS) {
+      add_header 'Access-Control-Allow-Origin'      $cors_allow_origin always;
+      add_header 'Access-Control-Allow-Credentials' $cors_allow_credentials always;
+      add_header 'Access-Control-Allow-Methods'     'GET,POST,PUT,PATCH,DELETE,OPTIONS' always;
+      add_header 'Access-Control-Allow-Headers'     'Authorization,Content-Type,X-Requested-With' always;
+      add_header 'Access-Control-Max-Age'           86400 always;
+      return 204;
     }
+    add_header 'Access-Control-Allow-Origin'      $cors_allow_origin always;
+    add_header 'Access-Control-Allow-Credentials' $cors_allow_credentials always;
 
-    # Health check endpoints
-    location /ready {
-        access_log off;
-        return 200 "{\"ready\": true}";
-    }
+    rewrite ^/api-qa(?<rest>/.*)$ $rest break;
 
-    location /alive {
-        access_log off;
-        return 200 "{\"alive\": true}";
+    set $full_upstream_url "$QA_API_URL$rest$is_args$args";
+    access_log /var/log/nginx/access.log proxylog;
+
+    proxy_pass $QA_API_URL$rest$is_args$args;
+    proxy_http_version 1.1;
+    proxy_set_header Host              $proxy_host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    proxy_connect_timeout 10s;
+    proxy_send_timeout    60s;
+    proxy_read_timeout    60s;
+
+    proxy_hide_header Access-Control-Allow-Origin;
+    proxy_hide_header Access-Control-Allow-Credentials;
+    proxy_hide_header Access-Control-Allow-Headers;
+    proxy_hide_header Access-Control-Allow-Methods;
+  }
+
+  # PROD: /api/* -> $PROD_API_URL/*
+  location ^~ /api-prod/ {
+    if ($request_method = OPTIONS) {
+      add_header 'Access-Control-Allow-Origin'      $cors_allow_origin always;
+      add_header 'Access-Control-Allow-Credentials' $cors_allow_credentials always;
+      add_header 'Access-Control-Allow-Methods'     'GET,POST,PUT,PATCH,DELETE,OPTIONS' always;
+      add_header 'Access-Control-Allow-Headers'     'Authorization,Content-Type,X-Requested-With' always;
+      add_header 'Access-Control-Max-Age'           86400 always;
+      return 204;
     }
+    add_header 'Access-Control-Allow-Origin'      $cors_allow_origin always;
+    add_header 'Access-Control-Allow-Credentials' $cors_allow_credentials always;
+
+    rewrite ^/api-prod(?<rest>/.*)$ $rest break;
+
+    set $full_upstream_url "$PROD_API_URL$rest$is_args$args";
+    access_log /var/log/nginx/access.log proxylog;
+
+    proxy_pass $PROD_API_URL$rest$is_args$args;
+    proxy_http_version 1.1;
+    proxy_set_header Host              $proxy_host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    proxy_connect_timeout 10s;
+    proxy_send_timeout    60s;
+    proxy_read_timeout    60s;
+
+    proxy_hide_header Access-Control-Allow-Origin;
+    proxy_hide_header Access-Control-Allow-Credentials;
+    proxy_hide_header Access-Control-Allow-Headers;
+    proxy_hide_header Access-Control-Allow-Methods;
+  }
+  # ---------- /API PROXIES ----------
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -3,6 +3,9 @@ worker_processes auto;
 worker_rlimit_nofile 10000;
 user nobody nogroup;
 pid /tmp/nginx.pid;
+env DEV_API_URL;
+env QA_API_URL;
+env PROD_API_URL;
 
 events {
     worker_connections 2048;
@@ -11,6 +14,8 @@ events {
 }
 
 http {
+  include /etc/nginx/mime.types;
+
   ##
   # Gzip Settings
   ##
@@ -22,11 +27,35 @@ http {
   gzip_buffers 16 8k;
   gzip_http_version 1.1;
   gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
-  gzip_min_length 500;
 
-  log_format main '{"remote_addr": "$remote_addr","X-Original-Forwarded-For": "$proxy_add_x_forwarded_for","X-Forwarded-For": "$remote_user","time_local": "$time_local","request": "$request","status": "$status","body_bytes_sent": "$body_bytes_sent","http_referer": "$http_referer","http_user_agent": "$http_user_agent","request_length": "$request_length","Authorization": "$http_Authorization","url-path": "$document_uri","query-string": "$query_string","X-Original-Uri": "$request_uri" ,"http_cookie": "$http_cookie","X-Amzn-Trace-Id": "$http_x_amzn_trace_id"}';
-  access_log /var/log/nginx/access.log main;
-  error_log /var/log/nginx/error.log;
+   # DNS + SNI for variable proxy_pass
+   resolver 1.1.1.1 9.9.9.9 valid=300s ipv6=off;
+   proxy_ssl_server_name on;
 
-  include conf.d/default.conf;
+   # CORS maps
+   map $http_origin $cors_allow_origin {
+     default "";
+     ~^https?://localhost(:\d+)?$ $http_origin;
+   }
+   map $cors_allow_origin $cors_allow_credentials {
+     default "true";
+     "" "false";
+   }
+
+   # Declare logging variable
+   map "" $full_upstream_url { default ""; }
+
+   # JSON-safe log formats
+   log_format main '{\"remote_addr\":\"$remote_addr\",\"time_local\":\"$time_local\",'
+                   '\"request\":\"$request\",\"status\":\"$status\",\"body_bytes_sent\":\"$body_bytes_sent\",'
+                   '\"http_referer\":\"$http_referer\",\"http_user_agent\":\"$http_user_agent\"}';
+
+   log_format proxylog '{\"remote_addr\":\"$remote_addr\",\"time_local\":\"$time_local\",'
+                       '\"request\":\"$request\",\"status\":\"$status\",\"body_bytes_sent\":\"$body_bytes_sent\",'
+                       '\"http_referer\":\"$http_referer\",\"http_user_agent\":\"$http_user_agent\",'
+                       '\"upstream\":\"$full_upstream_url\"}';
+
+   access_log /var/log/nginx/access.log main;
+   error_log  /var/log/nginx/error.log;
+   include conf.d/default.conf;
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "release": "grunt release",
     "release:sourcemaps": "grunt release && npm run sentry:sourcemaps",
     "start": "docker compose --project-directory nginx up --build",
-    "dev": "APP_DIR=../src ENV=development docker compose --project-directory nginx up --build",
+    "dev": "APP_DIR=../src ENV=development docker compose --project-directory nginx up --build --force-recreate",
     "test": "grunt --stack test",
     "test:prod": "grunt --stack test:prod",
     "test:debug": "grunt --stack test:debug",

--- a/src/config/discovery.vars.js.default
+++ b/src/config/discovery.vars.js.default
@@ -1,106 +1,56 @@
 define([], function() {
-  "use strict";
-  var config = {
-
-    /**
-     * When present, the version is sent with every ajax request
-     * to the api.
-     */
+  return {
+    /** Version header sent with every API request */
     clientVersion: '',
 
-    /**
-     * The url to the API services, if you develop locally,
-     * (and have created tunnel to the API) you can set this
-     * to //localhost:5000/v1 - but since our API allows for
-     * limited number of cross-site requests (from origin
-     * of 'http://localhost:8000' you can also use the production
-     * API of //api.adsabs.harvard.edu/v1/
-     */
-    apiRoot: '//api.adsabs.harvard.edu/v1/',
+    /** Base path for API (proxied by Nginx) [api-dev, api-qa, api-prod] */
+    apiRoot: '/api-dev/',
+    // apiRoot: '/api-qa/',
+    // apiRoot: '/api-prod/',
 
-    /**
-     * The url for orcid proxy, which adds the application token and
-     * secret on the server side
-     */
+    /** Server-side ORCID proxy path */
     orcidProxy: '/oauth/',
 
-    /**
-     * to let bumblebee discover oauth access_token at boot time
-     * and load dynamic configuration (which will be merged with
-     * the default config)
-     * this can be absolute url; or url relative to the api path
-     */
+    /** Extra config/bootstrap endpoints (relative to apiRoot) */
     bootstrapUrls: ['/accounts/bootstrap'],
 
-    /**
-     *  pushState: when true, urls are without hashtag '#'
-     *  root is the url, under which your application is
-     *  deployed, eg. /foo/bar if the main page lives at
-     *  http://somewhere.org/foo/bar/index.html
-     */
-    routerConf: {
-      pushState: false,
-      root: '/',
-    },
+    /** Router settings (SPA root + hash/history mode) */
+    routerConf: { pushState: false, root: '/' },
 
-    /**
-     * When set to true, window.app will contain reference to
-     * to the application object
-     */
+    /** Expose app instance on window for debugging */
     debugExportBBB: false,
 
-    /**
-     * To get debugging output in console
-     */
+    /** Console debug output toggle */
     debug: false,
 
-    /**
-     * When a component has method 'activateCache' - we'll call it;
-     * this is e.g. useful for Query Mediator which controls traffic
-     * between widgets and API (and doesn't bother issuing another
-     * request when the query can be served from the application cache)
-     */
+    /** Enable in-app caching between widgets/API */
     useCache: false,
 
+    /** Google Analytics tracking ID */
+    googleTrackingCode: 'UA-XXXXXXXX-X',
 
-    /**
-     * Google analytics tracking info, your main config should have
-     * info how to load 'analytics_config', see config.map section
-     *
-     * For testing, the following will work from localhost (your GA
-     * instance must be configured to accept domain localhost)
-     *
-     * googleTrackingCode: 'UA-37369750-7',
-     * googleTrackingOptions: {
-     *   'cookieDomain': 'none'
-     * }
-     *
-     * For more, see:
-     * https://developers.google.com/analytics/devguides/collection/analyticsjs/advanced
-     */
-     googleTrackingCode: 'UA-XXXXXXXX-X',
-     googleTrackingOptions: 'auto',
-     googleOptimizeCode: null,
-     googleOptimizeOptions: null,
+    /** GA config (string or object) */
+    googleTrackingOptions: 'auto',
 
+    /** Google Optimize container ID */
+    googleOptimizeCode: null,
 
-     /**
-      * If you have activated Orcid module, these settings
-      * are necessary (showing sandbox/testing values):
-     */
-       orcidClientId: 'APP-P5ANJTQRRTMA6GXZ',
-       orcidLoginEndpoint: 'http://sandbox.orcid.org/oauth/authorize',
-       orcidApiEndpoint: '//ecs-staging-elb-2044121877.us-east-1.elb.amazonaws.com/v1/orcid',
+    /** Google Optimize options */
+    googleOptimizeOptions: null,
 
+    /** ORCID OAuth client ID */
+    orcidClientId: 'APP-P5ANJTQRRTMA6GXZ',
 
+    /** ORCID login/authorize endpoint */
+    orcidLoginEndpoint: 'http://sandbox.orcid.org/oauth/authorize',
 
-     // google recaptcha
-     recaptchaKey : "6LfE6AITAAAAALdSy2qxVW4TBqy5RdmREiv-AwlJ",
+    /** ORCID API proxy base URL */
+    orcidApiEndpoint: '//ecs-staging-elb-2044121877.us-east-1.elb.amazonaws.com/v1/orcid',
 
-     //this is for bbb to know to show the hourly flag on devui.adsabs.harvard.edu,
-     hourly : false
+    /** reCAPTCHA site key */
+    recaptchaKey: '6LfE6AITAAAAALdSy2qxVW4TBqy5RdmREiv-AwlJ',
 
-  }
-
-  return config
+    /** Show hourly flag on dev UI */
+    hourly: false,
+  };
 });

--- a/src/js/apps/discovery/main.js
+++ b/src/js/apps/discovery/main.js
@@ -72,10 +72,8 @@ define(['config/discovery.config', 'module'], function(config, module) {
 
         app.onBootstrap(data);
 
-        var dynConf = app.getObject('DynamicConfig');
-        if (dynConf && dynConf.debugExportBBB) {
-          window.bbb = app;
-        }
+        // expose the app instance
+        window.__UNSAFE_BBB_APP_INSTANCE__ = app;
 
         pubsub.publish(pubsub.getCurrentPubSubKey(), pubsub.APP_BOOTSTRAPPED);
 

--- a/src/js/mixins/discovery_bootstrap.js
+++ b/src/js/mixins/discovery_bootstrap.js
@@ -45,9 +45,9 @@ define([
     });
 
     var navigate = function(ev) {
-      if (window.bbb) {
+      if (window.__UNSAFE_BBB_APP_INSTANCE__) {
         try {
-          var nav = bbb.getBeeHive().getService('Navigator');
+          var nav = window.__UNSAFE_BBB_APP_INSTANCE__.getBeeHive().getService('Navigator');
           nav.router.navigate(ev.data.url, { trigger: true, replace: false });
           return false;
         } catch (e) {

--- a/src/js/react/BumblebeeWidget.js
+++ b/src/js/react/BumblebeeWidget.js
@@ -9,7 +9,10 @@ define([
   'analytics',
 ], function(_, BaseWidget, ApiRequest, ApiQuery, analytics) {
   const getBeeHive = () => {
-    return window.bbb.getBeeHive();
+    if (window.__UNSAFE_BBB_APP_INSTANCE__ && window.__UNSAFE_BBB_APP_INSTANCE__.getBeeHive) {
+      return window.__UNSAFE_BBB_APP_INSTANCE__.getBeeHive();
+    }
+    throw new Error('Bumblebee application is not initialized');
   };
 
   const getPubSub = () => {

--- a/test/mocha/js/widgets/library_individual.spec.js
+++ b/test/mocha/js/widgets/library_individual.spec.js
@@ -662,7 +662,7 @@ define([
       minsub.beehive.addObject('LibraryController', fakeLibraryController);
       minsub.beehive.addObject('User', fakeUser);
 
-      window.bbb = {
+      window.__UNSAFE_BBB_APP_INSTANCE__ = {
         getBeeHive() {
           return minsub.beehive;
         },
@@ -768,7 +768,7 @@ define([
       expect($('#test li[data-tab=visualization-AuthorNetwork]').length).to.eql(
         0
       );
-      window.bbb = null;
+      window.__UNSAFE_BBB_APP_INSTANCE__ = null;
     });
 
     it('should allow export to the search results page', function(done) {
@@ -853,7 +853,7 @@ define([
       minsub.beehive.addObject('LibraryController', fakeLibraryController);
       minsub.beehive.addObject('User', fakeUser);
 
-      window.bbb = {
+      window.__UNSAFE_BBB_APP_INSTANCE__ = {
         getBeeHive() {
           return minsub.beehive;
         },
@@ -871,7 +871,7 @@ define([
         '1',
         { public: true },
       ]);
-      window.bbb = null;
+      window.__UNSAFE_BBB_APP_INSTANCE__ = null;
     });
   });
 });


### PR DESCRIPTION
Because of blocking of third-party cookies we have to proxy API requests.

This also fixes an issue with the exported global (used mainly by the react components)