### PR TITLE
Use default query for empty classic form

### DIFF
--- a/src/js/widgets/classic_form/widget.js
+++ b/src/js/widgets/classic_form/widget.js
@@ -678,6 +678,11 @@ define([
         q: queryDict.q.join(' '),
       });
 
+      // if q is empty, set it to default
+      if (newQuery.q === '') {
+        newQuery.q = '*:*';
+      }
+
       newQuery = new ApiQuery(newQuery);
       var ps = this.getPubSub();
       var options = {


### PR DESCRIPTION
When submitting empty classic form, there was an error thrown and the form would not actually submit.  This just allows the default query to be submitted.