### PR TITLE
SCIX-856 fix(search): increase hl.maxAnalyzedChars to 1M

### DIFF
--- a/src/js/widgets/list_of_things/widget.js
+++ b/src/js/widgets/list_of_things/widget.js
@@ -611,7 +611,7 @@ define([
       q.set({
         hl: 'true',
         'hl.fl': 'title,abstract,body,ack,*',
-        'hl.maxAnalyzedChars': '150000',
+        'hl.maxAnalyzedChars': '1000000',
         'hl.requireFieldMatch': 'true',
         'hl.usePhraseHighlighter': 'true',
         start: start,


### PR DESCRIPTION
Highlight analyzer limit was hardcoded at 150k, causing highlights to be silently truncated on longer documents.

- Increase hl.maxAnalyzedChars from 150000 to 1000000