### PR TITLE
SCIX-877 feat(meta_tags): gate Google Scholar tags by doctype, add JSON-LD

### DIFF
--- a/src/js/components/navigator.js
+++ b/src/js/components/navigator.js
@@ -271,7 +271,7 @@ define([
 
         // clear any metadata added to head on the previous page
         $('head')
-        .find('meta[data-highwire]')
+        .find('meta[data-highwire], script[data-ads-jsonld]')
         .remove();
         this._updateDocumentTitle(transition.title);
         defer.resolve();

--- a/src/js/widgets/meta_tags/jsonld.js
+++ b/src/js/widgets/meta_tags/jsonld.js
@@ -1,0 +1,127 @@
+/**
+ * Build a Schema.org ScholarlyArticle JSON-LD object for an ADS record.
+ * This is a lean implementation emitted for all doctypes; it uses only
+ * fields already fetched on the abstract page (identifier/UAT/encoding
+ * enrichment is deferred to a follow-up).
+ *
+ * Must be called with the raw record, before the meta_tags widget reshapes
+ * `author` and flattens `doi`.
+ */
+define(['underscore'], function(_) {
+  function firstString(v) {
+    if (_.isArray(v)) {
+      return v.length ? String(v[0]) : '';
+    }
+    return v == null ? '' : String(v);
+  }
+
+  function stripHtml(s) {
+    return String(s == null ? '' : s)
+      .replace(/<[^>]*>/g, '')
+      .trim();
+  }
+
+  function toArray(v) {
+    if (_.isArray(v)) {
+      return v;
+    }
+    return v == null ? [] : [v];
+  }
+
+  // Pass through ADS pubdate-like strings (YYYY, YYYY-MM, YYYY-MM-DD, and
+  // "-00" placeholder forms); reject anything without a 4-digit year.
+  function normalizePubdate(d) {
+    const raw = (d == null ? '' : String(d)).trim();
+    return /^\d{4}/.test(raw) ? raw : undefined;
+  }
+
+  // Remove undefined/null, empty strings, and empty arrays; keep booleans.
+  function prune(obj) {
+    const out = {};
+    _.each(obj, function(v, k) {
+      if (v === undefined || v === null) {
+        return;
+      }
+      if (typeof v === 'string' && v.trim() === '') {
+        return;
+      }
+      if (_.isArray(v) && v.length === 0) {
+        return;
+      }
+      out[k] = v;
+    });
+    return out;
+  }
+
+  // Accept either a raw author string or an already-reshaped { name, aff }
+  // object (the meta_tags widget rewrites `author` in place before render).
+  function authorName(entry) {
+    if (entry == null) {
+      return '';
+    }
+    if (typeof entry === 'object') {
+      return String(entry.name == null ? '' : entry.name).trim();
+    }
+    return String(entry).trim();
+  }
+
+  function buildAuthors(doc) {
+    return _.map(toArray(doc.author), function(entry) {
+      return { '@type': 'Person', name: authorName(entry) };
+    });
+  }
+
+  function buildKeywords(doc) {
+    return _.filter(
+      _.map(toArray(doc.keyword), function(k) {
+        return String(k == null ? '' : k).trim();
+      }),
+      function(k) {
+        return k.length > 0;
+      }
+    );
+  }
+
+  function buildIsPartOf(doc) {
+    const pub = (doc.pub == null ? '' : String(doc.pub)).trim();
+    if (!pub) {
+      return undefined;
+    }
+    const periodical = { '@type': 'Periodical', name: pub };
+    const volume = (doc.volume == null ? '' : String(doc.volume)).trim();
+    if (!volume) {
+      return periodical;
+    }
+    return {
+      '@type': 'PublicationVolume',
+      volumeNumber: volume,
+      isPartOf: periodical,
+    };
+  }
+
+  function buildJsonLd(doc, canonicalUrl) {
+    doc = doc || {};
+    const title = stripHtml(firstString(doc.title));
+    const name = title || firstString(doc.bibcode) || 'Untitled';
+    const abstract = stripHtml(firstString(doc.abstract));
+    const url = canonicalUrl || undefined;
+
+    return prune({
+      '@context': 'https://schema.org',
+      '@type': 'ScholarlyArticle',
+      '@id': url,
+      url: url,
+      name: name,
+      headline: name,
+      abstract: abstract || undefined,
+      inLanguage: 'en',
+      isAccessibleForFree: true,
+      datePublished: normalizePubdate(doc.pubdate),
+      author: buildAuthors(doc),
+      keywords: buildKeywords(doc),
+      isPartOf: buildIsPartOf(doc),
+    });
+  }
+
+  return { buildJsonLd: buildJsonLd };
+});

--- a/src/js/widgets/meta_tags/jsonld.js
+++ b/src/js/widgets/meta_tags/jsonld.js
@@ -28,11 +28,13 @@ define(['underscore'], function(_) {
     return v == null ? [] : [v];
   }
 
-  // Pass through ADS pubdate-like strings (YYYY, YYYY-MM, YYYY-MM-DD, and
-  // "-00" placeholder forms); reject anything without a 4-digit year.
+  // Normalize ADS pubdate-like strings to valid ISO 8601. ADS uses "-00"
+  // placeholders for unknown month/day (e.g. "2017-06-00", "2017-00-00");
+  // day/month 00 is not a valid ISO date, so strip the placeholder segments
+  // down to YYYY-MM or YYYY. Reject anything that isn't a clean YYYY[-MM[-DD]].
   function normalizePubdate(d) {
-    const raw = (d == null ? '' : String(d)).trim();
-    return /^\d{4}/.test(raw) ? raw : undefined;
+    const raw = (d == null ? '' : String(d)).trim().replace(/(-00)+$/, '');
+    return /^\d{4}(-\d{2}){0,2}$/.test(raw) ? raw : undefined;
   }
 
   // Remove undefined/null, empty strings, and empty arrays; keep booleans.
@@ -115,7 +117,11 @@ define(['underscore'], function(_) {
       headline: name,
       abstract: abstract || undefined,
       inLanguage: 'en',
-      isAccessibleForFree: true,
+      // Only claim free access when the record is flagged open access;
+      // asserting it for paywalled content is a false structured-data signal.
+      isAccessibleForFree: _.contains(toArray(doc.property), 'OPENACCESS')
+        ? true
+        : undefined,
       datePublished: normalizePubdate(doc.pubdate),
       author: buildAuthors(doc),
       keywords: buildKeywords(doc),

--- a/src/js/widgets/meta_tags/scholar_doctypes.js
+++ b/src/js/widgets/meta_tags/scholar_doctypes.js
@@ -1,0 +1,39 @@
+/**
+ * Doctypes permitted to emit Google Scholar-compatible (Highwire
+ * citation_*) meta tags on the abstract page. Only these doctypes display
+ * the tags; any other or unknown doctype omits them. Schema.org JSON-LD is
+ * emitted for all records regardless and is not gated by this list.
+ */
+define([], function() {
+  const GOOGLE_SCHOLAR_DOCTYPES = [
+    'article',
+    'eprint',
+    'phdthesis',
+    'circular',
+    'inbook',
+    'erratum',
+    'book',
+    'mastersthesis',
+    'inproceedings',
+    'abstract',
+    'techreport',
+    'bookreview',
+    'proceedings',
+    'editorial',
+    'newsletter',
+    'obituary',
+  ];
+
+  // Case-insensitive to tolerate inconsistent casing in upstream data.
+  function showsGoogleScholarTags(doctype) {
+    if (!doctype || typeof doctype !== 'string') {
+      return false;
+    }
+    return GOOGLE_SCHOLAR_DOCTYPES.indexOf(doctype.toLowerCase()) !== -1;
+  }
+
+  return {
+    GOOGLE_SCHOLAR_DOCTYPES: GOOGLE_SCHOLAR_DOCTYPES,
+    showsGoogleScholarTags: showsGoogleScholarTags,
+  };
+});

--- a/src/js/widgets/meta_tags/template/metatags.html
+++ b/src/js/widgets/meta_tags/template/metatags.html
@@ -1,13 +1,17 @@
 <meta name="og:type" content="article" data-highwire="true">
 <meta name="twitter:card" content="summary" data-highwire="true">
 
+{{#if showScholarTags}}
 <meta name="citation_title" content="{{title}}" data-highwire="true">
+{{/if}}
 <meta name="og:title" content="{{title}}" data-highwire="true">
 <meta name="twitter:title" content="{{title}}" data-highwire="true">
 
 <meta name="og:url" content="{{url}}" data-highwire="true">
 <meta name="twitter:url" content="{{url}}" data-highwire="true">
+{{#if showScholarTags}}
 <meta name="citation_abstract_html_url" content="{{url}}" data-highwire="true">
+{{/if}}
 
 <meta name="og:image" content="https://ui.adsabs.harvard.edu/styles/img/transparent_logo.svg" data-highwire="true">
 <meta name="twitter:image" content="https://ui.adsabs.harvard.edu/styles/img/transparent_logo.svg" data-highwire="true">
@@ -16,6 +20,7 @@
 <meta name="og:description" content="{{abstract}}" data-highwire="true">
 <meta name="twitter:description" content="{{abstract}}" data-highwire="true">
 {{/if}}
+{{#if showScholarTags}}
 {{#each author}}
 <meta name="citation_author" content="{{this.name}}" data-highwire="true">
 <meta xmlns="http://www.w3.org/1999/xhtml" name="citation_author_institution" content="{{this.aff}}" data-highwire="true">
@@ -46,4 +51,5 @@
 {{/each}}
 {{#if pdfUrl}}
 <meta name="citation_pdf_url" content="{{pdfUrl}}" data-highwire="true">
+{{/if}}
 {{/if}}

--- a/src/js/widgets/meta_tags/widget.js
+++ b/src/js/widgets/meta_tags/widget.js
@@ -5,7 +5,18 @@ define([
   'js/widgets/base/base_widget',
   'hbs!js/widgets/meta_tags/template/metatags',
   'js/mixins/link_generator_mixin',
-], function($, Backbone, _, BaseWidget, metatagsTemplate, LinkGenerator) {
+  'js/widgets/meta_tags/jsonld',
+  'js/widgets/meta_tags/scholar_doctypes',
+], function(
+  $,
+  Backbone,
+  _,
+  BaseWidget,
+  metatagsTemplate,
+  LinkGenerator,
+  JsonLd,
+  ScholarDoctypes
+) {
   var View = Backbone.View.extend({
     destroy: function() {
       this.remove();
@@ -78,6 +89,12 @@ define([
     updateMetaTags: function(data) {
       data.url = Backbone.history.location.href;
 
+      // Build JSON-LD from the raw record before the mutations below reshape
+      // `author` and flatten `doi`. Emitted for all doctypes; the citation_*
+      // tags are gated by the doctype whitelist.
+      const jsonld = JsonLd.buildJsonLd(data, data.url);
+      data.showScholarTags = ScholarDoctypes.showsGoogleScholarTags(data.doctype);
+
       var sources = {};
       try {
         sources = this.parseResourcesData(data);
@@ -123,6 +140,19 @@ define([
         });
       });
 
+      // Replace any prior JSON-LD node so repeated invocations (search
+      // results + abstract display) leave exactly one block, reflecting the
+      // most recently displayed record.
+      $('head')
+        .find('script[type="application/ld+json"][data-ads-jsonld]')
+        .remove();
+      $('head').append(
+        $('<script>', {
+          type: 'application/ld+json',
+          'data-ads-jsonld': 'true',
+        }).text(JSON.stringify(jsonld))
+      );
+
       // fire off dom events
       this.emitDOMEvents();
     },
@@ -141,7 +171,7 @@ define([
     },
     defaultQueryArguments: {
       fl:
-        'links_data,[citations],keyword,property,first_author,year,issn,isbn,title,aff,abstract,bibcode,pub,pub_raw,volume,author,issue,pubdate,doi,page,esources,data',
+        'links_data,[citations],keyword,property,first_author,year,issn,isbn,title,aff,abstract,bibcode,pub,pub_raw,volume,author,issue,pubdate,doi,page,esources,data,doctype',
       rows: 1,
     },
   });

--- a/src/js/widgets/meta_tags/widget.js
+++ b/src/js/widgets/meta_tags/widget.js
@@ -128,17 +128,13 @@ define([
         });
       }
 
-      // Update the <head> with the meta tags
-      $('head').append(function() {
-        return $(metatagsTemplate(data)).filter(function() {
-          var name = $(this).attr('name');
-          if (name) {
-            // check to see if the tag already exists
-            return !$('head>meta[name="' + name + '"]').length;
-          }
-          return true;
-        });
-      });
+      // Clear the widget's prior tags before rendering so the current record
+      // is authoritative. The old append-if-absent logic could leave stale
+      // citation_* tags in <head> when a later record omits them.
+      $('head')
+        .find('meta[data-highwire="true"]')
+        .remove();
+      $('head').append(metatagsTemplate(data));
 
       // Replace any prior JSON-LD node so repeated invocations (search
       // results + abstract display) leave exactly one block, reflecting the

--- a/test/mocha/js/widgets/meta_tags_widget.spec.js
+++ b/test/mocha/js/widgets/meta_tags_widget.spec.js
@@ -404,5 +404,34 @@ define([
       const jsonld = getJsonLd();
       expect(jsonld.author[0]).to.eql({ '@type': 'Person', name: 'Doe, J.' });
     });
+
+    it('strips ADS "-00" placeholders to a valid ISO datePublished', function() {
+      widget.updateMetaTags(makeDoc('article')); // pubdate: '2017-06-00'
+      expect(getJsonLd().datePublished).to.equal('2017-06');
+
+      $('head')
+        .find('script[data-ads-jsonld]')
+        .remove();
+      widget.updateMetaTags({ ...makeDoc('article'), pubdate: '2017-00-00' });
+      expect(getJsonLd().datePublished).to.equal('2017');
+    });
+
+    it('omits datePublished when pubdate has no usable year', function() {
+      widget.updateMetaTags({ ...makeDoc('article'), pubdate: 'n/a' });
+      expect(getJsonLd().datePublished).to.equal(undefined);
+    });
+
+    it('omits isAccessibleForFree unless the record is open access', function() {
+      widget.updateMetaTags(makeDoc('article')); // no property field
+      expect(getJsonLd().isAccessibleForFree).to.equal(undefined);
+    });
+
+    it('sets isAccessibleForFree for open-access records', function() {
+      widget.updateMetaTags({
+        ...makeDoc('article'),
+        property: ['REFEREED', 'OPENACCESS'],
+      });
+      expect(getJsonLd().isAccessibleForFree).to.equal(true);
+    });
   });
 });

--- a/test/mocha/js/widgets/meta_tags_widget.spec.js
+++ b/test/mocha/js/widgets/meta_tags_widget.spec.js
@@ -31,6 +31,7 @@ define([
       '{"access": "", "instances": "", "title": "IRSA References (2MASS)", "type": "data", "url": "https://irsa.ipac.caltech.edu/bibdata/2017/H/2017MNRAS.467.4015H.html"}',
     ],
     year: '2017',
+    doctype: 'article',
     property: [
       'DATA',
       'ESOURCE',
@@ -260,7 +261,36 @@ define([
 
     afterEach(function() {
       sandbox.restore();
+      // Keep <head> clean so tags from one test don't leak into the next.
+      $('head')
+        .find('meta[data-highwire="true"]')
+        .remove();
+      $('head')
+        .find('script[data-ads-jsonld]')
+        .remove();
     });
+
+    const makeDoc = function(doctype) {
+      return {
+        bibcode: '2017MNRAS.467.4015H',
+        title: ['Some title'],
+        abstract: 'Some abstract',
+        author: ['Doe, J.'],
+        aff: ['Inst X'],
+        pub: 'Journal X',
+        pub_raw: 'Journal X, Volume 1',
+        volume: '1',
+        pubdate: '2017-06-00',
+        doi: ['10.1/x'],
+        keyword: ['kw1'],
+        doctype: doctype,
+      };
+    };
+
+    const getJsonLd = function() {
+      const node = $('head').find('script[data-ads-jsonld]');
+      return node.length ? JSON.parse(node.first().text()) : null;
+    };
 
     it('extends from BaseWidget', function() {
       expect(widget).to.be.instanceOf(BaseWidget);
@@ -316,6 +346,63 @@ define([
         expect(tags[i]).to.equal(metas[i]);
       }
       expect(zoteroSpy.called).to.be.true;
+    });
+
+    it('renders citation_ tags for a whitelisted doctype', function() {
+      widget.updateMetaTags(makeDoc('article'));
+
+      const citationTags = $('head').find('meta[name^="citation_"]');
+      expect(citationTags.length).to.be.above(0);
+    });
+
+    it('omits citation_ tags for a removed doctype', function() {
+      widget.updateMetaTags(makeDoc('dataset'));
+
+      const citationTags = $('head').find('meta[name^="citation_"]');
+      expect(citationTags.length).to.equal(0);
+      // OpenGraph/Twitter tags remain for all doctypes.
+      expect($('head').find('meta[name="og:title"]').length).to.be.above(0);
+      expect($('head').find('meta[name="twitter:title"]').length).to.be.above(0);
+    });
+
+    it('omits citation_ tags for an unlisted doctype', function() {
+      widget.updateMetaTags(makeDoc('intechreport'));
+
+      expect($('head').find('meta[name^="citation_"]').length).to.equal(0);
+    });
+
+    it('emits Schema.org JSON-LD for all doctypes, including removed ones', function() {
+      widget.updateMetaTags(makeDoc('dataset'));
+
+      const jsonld = getJsonLd();
+      expect(jsonld).to.not.equal(null);
+      expect(jsonld['@type']).to.equal('ScholarlyArticle');
+      expect(jsonld['@context']).to.equal('https://schema.org');
+    });
+
+    it('leaves exactly one JSON-LD node after repeated invocations', function() {
+      widget.updateMetaTags(makeDoc('article'));
+      widget.updateMetaTags(makeDoc('article'));
+      widget.updateMetaTags(makeDoc('dataset'));
+
+      expect($('head').find('script[data-ads-jsonld]').length).to.equal(1);
+    });
+
+    it('builds JSON-LD from the raw record before author/doi mutation', function() {
+      widget.updateMetaTags(makeDoc('article'));
+
+      const jsonld = getJsonLd();
+      expect(jsonld.author).to.be.an('array');
+      expect(jsonld.author[0]).to.eql({ '@type': 'Person', name: 'Doe, J.' });
+    });
+
+    it('keeps JSON-LD authors correct when the same record is processed twice', function() {
+      const doc = makeDoc('article');
+      widget.updateMetaTags(doc); // reshapes doc.author into { name, aff }
+      widget.updateMetaTags(doc); // re-process the now-mutated object
+
+      const jsonld = getJsonLd();
+      expect(jsonld.author[0]).to.eql({ '@type': 'Person', name: 'Doe, J.' });
     });
   });
 });


### PR DESCRIPTION
Google Scholar-compatible citation_* meta tags were emitted on every abstract page regardless of doctype. Per SCIX-877 only a defined set of doctypes should expose them; non-scholarly doctypes (proposal, dataset, software, misc, pressrelease, catalog, talk, service, instrument) should not. BBB also lacked any Schema.org structured data.

- Added a doctype whitelist and showsGoogleScholarTags predicate (scholar_doctypes.js), matched case-insensitively
- Gated the citation_* tags in the meta_tags template behind showScholarTags
- Added a lean Schema.org ScholarlyArticle JSON-LD builder (jsonld.js), emitted for all records, injected as a single idempotent script[data-ads-jsonld] node in the head
- Built JSON-LD from the raw record before the widget reshapes author and flattens doi, and hardened author handling for reprocessed records
- Added doctype to the default fl so it is available for gating
- Added mocha coverage for gating and JSON-LD emission