### PR TITLE
Link to scix landing page with default to astrophysics

### DIFF
--- a/src/js/adstoscix.js
+++ b/src/js/adstoscix.js
@@ -82,6 +82,15 @@ const css = `
     const currentUrl = window.location.href;
     let correspondingUrl = currentUrl.replace(window.location.host, 'scixplorer.org');
     const pathname = window.location.pathname;
+
+    // landing page, default to astrophysics discipline
+    if (pathname === '/') {
+      const index = correspondingUrl.lastIndexOf('/');
+      correspondingUrl = correspondingUrl.slice(0, index) + '/astrophysics';
+      window.open(correspondingUrl, '_blank');
+      return;
+    }
+
     let newpath = window.location.pathname;
     if (pathname.match(/\/export-([a-zA-Z]+)$/)) {
       // this check must come before /search/

--- a/src/js/widgets/navbar/template/navbar.html
+++ b/src/js/widgets/navbar/template/navbar.html
@@ -21,7 +21,7 @@
                   <ul class="dropdown-menu" role="menu">
                     <li class="no-hover-style" style="padding:15px 10px;">SciX is the evolution of ADS, bringing its powerful capabilities into new domains. SciX will become the sole interface in late 2026.</li>
                     <li>
-                      <a href="https://scixplorer.org" target="_blank" rel="noopener">
+                      <a href="https://scixplorer.org/astrophysics" target="_blank" rel="noopener">
                         <i class="fa fa-globe" aria-hidden="true"></i> Visit SciX
                       </a>
                     </li>


### PR DESCRIPTION
Update links to SciX landing page with '/astrophysics'. This way when redirecting to SciX and the astrophysics specific tour for starts, the classic and paper forms tabs are visible. 